### PR TITLE
Bug Fix: Out of Date Run Script

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -26,7 +26,7 @@
 layout split
 target remote localhost:1234
 handle SIGSEGV nostop noprint nopass
-symbol-file bin/kernel
+symbol-file bin/test-driver
 set confirm off
 define hook-stop
 	if $_isvoid ($_exitcode) != 1

--- a/build/i386-pc/make/makefile
+++ b/build/i386-pc/make/makefile
@@ -58,7 +58,7 @@ export LIBKERNEL = libhal-$(TARGET).a
 export LIBS = $(LIBDIR)/$(LIBKERNEL)
 
 # Binaries
-export EXECBIN = test-driver-$(TARGET)
+export EXECBIN = test-driver
 
 #===============================================================================
 

--- a/build/or1k-pc/make/makefile
+++ b/build/or1k-pc/make/makefile
@@ -57,7 +57,7 @@ export LIBKERNEL = libhal-$(TARGET).a
 export LIBS = $(LIBDIR)/$(LIBKERNEL)
 
 # Binaries
-export EXECBIN = kernel
+export EXECBIN = test-driver
 
 #===============================================================================
 

--- a/src/test/build/makefile.i386-pc
+++ b/src/test/build/makefile.i386-pc
@@ -20,13 +20,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# Tweak toolchain.
+export LDFLAGS  += -L $(LINKERDIR)/ -T link.ld
+
 # Object Files
 OBJ = $(SRC:.c=.o)
 
 # Builds object files for i386 PC target.
-all:
-	# Nothing to do.
+all: $(OBJ)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJ) -o $(BINDIR)/$(EXECBIN) -Wl,--whole-archive $(LIBS)
 
 # Cleans all object files.
 clean:
 	rm -rf $(BINDIR)/$(EXECBIN) $(OBJ)
+
+# Builds a C source file.
+%.o: %.c
+	$(CC) $(CFLAGS) $< -c -o $@

--- a/src/test/build/makefile.or1k-pc
+++ b/src/test/build/makefile.or1k-pc
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# Tweak toolchain.
 export LDFLAGS  += -L $(LINKERDIR)/ -T link.ld
 
 # Object Files

--- a/tools/run/run-qemu.sh
+++ b/tools/run/run-qemu.sh
@@ -29,19 +29,19 @@ export CURDIR=`pwd`
 
 case "$TARGET" in
 	"i386-pc")
-		qemu-system-i386 -s -S \
-			--display curses   \
-			-kernel bin/kernel \
-			-m 256M            \
+		qemu-system-i386 -s -S      \
+			--display curses        \
+			-kernel bin/test-driver \
+			-m 256M                 \
 			-mem-prealloc
 		;;
 	"or1k-pc")
-		qemu-system-or1k -s -S \
-			-kernel bin/kernel \
-			-serial stdio      \
-			-display none      \
-			-m 256M            \
-			-mem-prealloc      \
+		qemu-system-or1k -s -S      \
+			-kernel bin/test-driver \
+			-serial stdio           \
+			-display none           \
+			-m 256M                 \
+			-mem-prealloc           \
 			-smp 2
 		;;
 	*)


### PR DESCRIPTION
**Description**

In this pull request I have fixed the building system for the x86-qemu and openrisc-qemu targets.

We were using out of date scripts.