### PR TITLE
[or1k-qemu] Bug Fix: Bad Link Script

### DIFF
--- a/build/or1k-pc/linker/link.ld
+++ b/build/or1k-pc/linker/link.ld
@@ -38,8 +38,8 @@ SECTIONS
 	/* Kernel code section. */
 	.bootstrap : AT(ADDR(.bootstrap))
 	{
-		*(hooks.o)
-		*(boot_code.o)
+		*hooks.o
+		*boot_code.o
 	}
 
 	. = ALIGN(8192);


### PR DESCRIPTION
Previously we were wrong referring to objects in the link script. As a
consequence, the interrupt vector of the or1k-pc target would be messed
up in some systems causing interrupts to misbehavior.