### PR TITLE
[or1k-core] Bug Fix: Bad Clock Frequency

### DIFF
--- a/build/or1k-pc/linker/link.ld
+++ b/build/or1k-pc/linker/link.ld
@@ -38,8 +38,8 @@ SECTIONS
 	/* Kernel code section. */
 	.bootstrap : AT(ADDR(.bootstrap))
 	{
-		*(hooks.o)
-		*(boot_code.o)
+		*hooks.o
+		*boot_code.o
 	}
 
 	. = ALIGN(8192);

--- a/include/arch/core/or1k/clock.h
+++ b/include/arch/core/or1k/clock.h
@@ -38,7 +38,7 @@
 	/**
 	 * @brief Estimated CPU frequency (in Hz)
 	 */
-	#define OR1K_CPU_FREQUENCY 20000000
+	#define OR1K_CPU_FREQUENCY 1666666
 
 	/**
 	 * @brief Initializes the clock driver in the or1k architecture.

--- a/src/hal/arch/core/or1k/clock.c
+++ b/src/hal/arch/core/or1k/clock.c
@@ -23,6 +23,7 @@
  */
 
 #include <nanvix/const.h>
+#include <nanvix/klib.h>
 #include <arch/core/or1k/core.h>
 #include <arch/core/or1k/clock.h>
 
@@ -36,12 +37,14 @@ PUBLIC void or1k_clock_init(unsigned freq)
 	unsigned upr;  /* Unit Present Register. */
 	unsigned rate; /* Timer rate.            */
 
+	UNUSED(freq);
+
 	upr = or1k_mfspr(OR1K_SPR_UPR);
 	if ( !(upr & OR1K_SPR_UPR_TTP) )
 		while (1);
 
 	/* Clock rate. */
-	rate = (CPU_FREQUENCY)/freq;
+	rate = OR1K_CPU_FREQUENCY;
 
 	/* Ensures that the clock is disabled. */
 	or1k_mtspr(OR1K_SPR_TTCR, 0);


### PR DESCRIPTION
Previously, we were using a bad frequency for the clock. In this commit,
we fixed this problem.