### PR TITLE
 [k1b-core] Bad Exception Stack

### DIFF
--- a/include/arch/core/k1b/asm.h
+++ b/include/arch/core/k1b/asm.h
@@ -106,12 +106,12 @@
 	 */
 	.macro _do_prologue
 
-		/* Save r0 + r1 registers. */
-		sd 0[$sp], $p0
-		;;
-
 		/* Allocate a stack frame. */
 		add $sp, $sp, -FAST_CALL_STACK_FRAME_SIZE
+		;;
+
+		/* Save r0 + r1 registers. */
+		sd 8[$sp], $p0
 		;;
 
 		/*
@@ -157,12 +157,12 @@
 		lw  $bp, STACK_FRAME_BP[$sp]
 		;;
 
-		/* Wipe out stack frame. */
-		add $sp, $sp, FAST_CALL_STACK_FRAME_SIZE
+		/* Restore r0 + r1 registers. */
+		ld $p0, 8[$sp]
 		;;
 
-		/* Restore r0 + r1 registers. */
-		ld $p0, 0[$sp]
+		/* Wipe out stack frame. */
+		add $sp, $sp, FAST_CALL_STACK_FRAME_SIZE
 		;;
 
 	.endm

--- a/include/nanvix/klib.h
+++ b/include/nanvix/klib.h
@@ -174,7 +174,7 @@
 	 * @param x Thing.
 	 */
 	#define UNUSED(x) ((void) (x))
-	
+
 	/**
 	 * @brief No operation.
 	 */
@@ -190,6 +190,27 @@
 	 * @returns Non-zero if @p x is within [a, b) and zero otherwise.
 	 */
 	#define WITHIN(x, a, b) (((x) >= (a)) && ((x) < (b)))
+
+	/**
+	 * @brief Concatenates two macros.
+	 *
+	 * @param x First macro.
+	 * @param y Second macro.
+	 */
+	#define CONCAT2(x, y) x ## y
+
+	/**
+	 * @brief Expands a macro.
+	 *
+	 * @param x First macro.
+	 * @param x Second macro.
+	 */
+	#define EXPAND2(x, y) CONCAT2(x, y)
+
+	/**
+	 * @brief Auto-name for reserved fields in a structure.
+	 */
+	#define RESERVED EXPAND2(reserved, __LINE__)
 
 /**@}*/
 

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -61,5 +61,7 @@ PUBLIC void kmain(int argc, const char *argv[])
 	test_sync();
 #endif
 
+	kprintf("[hal] halting...");
+
 	main(0, NULL);
 }


### PR DESCRIPTION
Description
----------------

Currently, when registering exception stacks at startup, we are using base addresses instead of their base ones. As consequence, the exception handler dispatcher is potentially trashing the memory, thereby leading to complete chaos. In this commit, I have fixed this problem.

Related Issues
---------------------

- [[k1b] Bad Exception Stack Configuration](https://github.com/nanvix/hal/issues/88)