### PR TITLE
[k1b-core] Exceptions Trigger Multiple Faults

### DIFF
--- a/include/arch/core/k1b/asm.h
+++ b/include/arch/core/k1b/asm.h
@@ -106,12 +106,12 @@
 	 */
 	.macro _do_prologue
 
-		/* Save r0 + r1 registers. */
-		sd 0[$sp], $p0
-		;;
-
 		/* Allocate a stack frame. */
 		add $sp, $sp, -FAST_CALL_STACK_FRAME_SIZE
+		;;
+
+		/* Save r0 + r1 registers. */
+		sd 8[$sp], $p0
 		;;
 
 		/*
@@ -157,12 +157,12 @@
 		lw  $bp, STACK_FRAME_BP[$sp]
 		;;
 
-		/* Wipe out stack frame. */
-		add $sp, $sp, FAST_CALL_STACK_FRAME_SIZE
+		/* Restore r0 + r1 registers. */
+		ld $p0, 8[$sp]
 		;;
 
-		/* Restore r0 + r1 registers. */
-		ld $p0, 0[$sp]
+		/* Wipe out stack frame. */
+		add $sp, $sp, FAST_CALL_STACK_FRAME_SIZE
 		;;
 
 	.endm

--- a/include/arch/core/k1b/context.h
+++ b/include/arch/core/k1b/context.h
@@ -36,13 +36,14 @@
 #ifndef _ASM_FILE_
 
 	#include <arch/core/k1b/core.h>
+	#include <nanvix/klib.h>
 
 #endif /* _ASM_FILE_ */
 
 	/**
 	 * @brief Execution context size (in bytes).
 	 */
-	#define K1B_CONTEXT_SIZE 308
+	#define K1B_CONTEXT_SIZE 304
 
 	/**
 	 * @name Offsets to the Context Structure
@@ -122,7 +123,7 @@
 	#define K1B_CONTEXT_LS    284 /**< Loop Start Register               */
 	#define K1B_CONTEXT_LE    288 /**< Loop Exit Register                */
 	#define K1B_CONTEXT_PS    292 /**< Processing Status Register        */
-	#define K1B_CONTEXT_SPS   300 /**< Shadow Processing Status Register */
+	#define K1B_CONTEXT_SPS   296 /**< Shadow Processing Status Register */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -151,8 +152,9 @@
 		k1b_word_t lc;                                     /**< Loop Count Register                */
 		k1b_word_t ls;                                     /**< Loop Start Register                */
 		k1b_word_t le;                                     /**< Loop Exit Register                 */
-		k1b_dword_t ps;                                    /**< Processing Status Register         */
-		k1b_dword_t sps;                                   /**< Shadow Processing Status Register  */
+		k1b_word_t ps;                                     /**< Processing Status Register         */
+		k1b_word_t sps;                                    /**< Shadow Processing Status Register  */
+		k1b_byte_t RESERVED[4];                            /**< Required padding.                  */
 	} __attribute__((packed));
 
 	/**

--- a/include/arch/core/k1b/excp.h
+++ b/include/arch/core/k1b/excp.h
@@ -39,13 +39,14 @@
 	#include <arch/core/k1b/types.h>
 
 	#include <arch/core/k1b/context.h>
+	#include <nanvix/klib.h>
 
 #endif
 
 	/**
 	 * @brief Exception information size (in bytes).
 	 */
-	#define K1B_EXCEPTION_SIZE 12
+	#define K1B_EXCEPTION_SIZE 16
 
 	/**
 	 * @name Offsets to the Exception Information structure.
@@ -110,9 +111,10 @@
 	 */
 	struct exception
 	{
-		uint32_t num; /**< Exception number.      */
-		uint32_t ea;  /**< Exception address.     */
-		uint32_t spc; /**< Saved program counter. */
+		k1b_word_t num;         /**< Exception number.      */
+		k1b_word_t ea;          /**< Exception address.     */
+		k1b_word_t spc;         /**< Saved program counter. */
+		k1b_byte_t RESERVED[4]; /**< Required padding.      */
 	} __attribute__((packed));
 
 /**@endcond*/

--- a/include/nanvix/klib.h
+++ b/include/nanvix/klib.h
@@ -174,7 +174,7 @@
 	 * @param x Thing.
 	 */
 	#define UNUSED(x) ((void) (x))
-	
+
 	/**
 	 * @brief No operation.
 	 */
@@ -190,6 +190,27 @@
 	 * @returns Non-zero if @p x is within [a, b) and zero otherwise.
 	 */
 	#define WITHIN(x, a, b) (((x) >= (a)) && ((x) < (b)))
+
+	/**
+	 * @brief Concatenates two macros.
+	 *
+	 * @param x First macro.
+	 * @param y Second macro.
+	 */
+	#define CONCAT2(x, y) x ## y
+
+	/**
+	 * @brief Expands a macro.
+	 *
+	 * @param x First macro.
+	 * @param x Second macro.
+	 */
+	#define EXPAND2(x, y) CONCAT2(x, y)
+
+	/**
+	 * @brief Auto-name for reserved fields in a structure.
+	 */
+	#define RESERVED EXPAND2(reserved, __LINE__)
 
 /**@}*/
 

--- a/src/hal/arch/core/k1b/hooks.S
+++ b/src/hal/arch/core/k1b/hooks.S
@@ -143,15 +143,15 @@ _do_excp:
 	_scoreboard_get $r2 $r3
 
 	/* Processing Status. */
-	ld  $p4 = MOS_VC_REG_PS[$r2]
+	lw  $r4 = MOS_VC_REG_PS[$r2]
 	;;
-	sd  K1B_CONTEXT_PS[$r1], $p4
+	sw  K1B_CONTEXT_PS[$r1], $r4
 	;;
 
 	/* Saved Processing Status */
-	ld  $p4 = MOS_VC_REG_SPS[$r2]
+	lw  $r4 = MOS_VC_REG_SPS[$r2]
 	;;
-	sd  K1B_CONTEXT_SPS[$r1], $p4
+	sw  K1B_CONTEXT_SPS[$r1], $r4
 	;;
 
 	/* Saved Program Counter. */

--- a/src/test/arch/k1b.S
+++ b/src/test/arch/k1b.S
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* Must come first. */
+#define _ASM_FILE_
+
+#include <arch/core/k1b/asm.h>
+
+.section .text
+

--- a/src/test/build/makefile.i386-pc
+++ b/src/test/build/makefile.i386-pc
@@ -24,7 +24,7 @@
 export LDFLAGS  += -L $(LINKERDIR)/ -T link.ld
 
 # Object Files
-OBJ = $(SRC:.c=.o)
+OBJ = $(C_SRC:.c=.o)
 
 # Builds object files for i386 PC target.
 all: $(OBJ)

--- a/src/test/build/makefile.mppa256
+++ b/src/test/build/makefile.mppa256
@@ -27,8 +27,11 @@ else
 	export LDFLAGS  += -L $(LINKERDIR)/k1bio/ -T link.ld
 endif
 
+ASM_SRC = $(wildcard arch/k1b.S)
+
 # Object Files
-OBJ = $(SRC:.c=.$(CLUSTER)-$(CLUSTER_VARIANT).o)
+OBJ = $(ASM_SRC:.S=.$(CLUSTER)-$(CLUSTER_VARIANT).o) \
+	  $(C_SRC:.c=.$(CLUSTER)-$(CLUSTER_VARIANT).o)
 
 # Builds object files for MPPA-256 target.
 mppa256: $(OBJ)
@@ -40,4 +43,8 @@ clean:
 
 # Builds a C source file.
 %.$(CLUSTER)-$(CLUSTER_VARIANT).o: %.c
+	$(CC) $(CFLAGS) $< -c -o $@
+
+# Builds an ASM Source File
+%.$(CLUSTER)-$(CLUSTER_VARIANT).o: %.S
 	$(CC) $(CFLAGS) $< -c -o $@

--- a/src/test/build/makefile.or1k-pc
+++ b/src/test/build/makefile.or1k-pc
@@ -24,7 +24,7 @@
 export LDFLAGS  += -L $(LINKERDIR)/ -T link.ld
 
 # Object Files
-OBJ = $(SRC:.c=.o)
+OBJ = $(C_SRC:.c=.o)
 
 # Builds object files for or1k PC target.
 all: $(OBJ)

--- a/src/test/exception.c
+++ b/src/test/exception.c
@@ -1,0 +1,79 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/hal/hal.h>
+#include <nanvix/const.h>
+#include <nanvix/klib.h>
+#include "test.h"
+
+/**
+ * @brief Run destructive tests?
+ */
+#define TEST_EXCEPTION_DESTRUCTIVE 0
+
+/*============================================================================*
+ * API Tests                                                                  *
+ *============================================================================*/
+
+/**
+ * @brief API Test: Trigger Exception
+ */
+PRIVATE void test_trigger_exception(void)
+{
+	char *p = (char *) 0x4badbeef; /* I like beefs. */
+
+	/* Don't run destructive tests. */
+	if (!TEST_EXCEPTION_DESTRUCTIVE)
+		return;
+
+	*p = 1;
+}
+
+/*============================================================================*
+ * Test Driver                                                                *
+ *============================================================================*/
+
+/**
+ * @brief Unit tests.
+ */
+PRIVATE struct test exception_api_tests[] = {
+	{ test_trigger_exception, "Trigger Exception" },
+	{ NULL,                   NULL                },
+};
+
+/**
+ * The test_exception() function launches testing units on the
+ * Exception Interface of the HAL.
+ *
+ * @author Pedro Henrique Penna
+ */
+PUBLIC void test_exception(void)
+{
+	for (int i = 0; exception_api_tests[i].test_fn != NULL; i++)
+	{
+		exception_api_tests[i].test_fn();
+		kprintf("[test][stress][clock] %s [passed]", exception_api_tests[i].name);
+	}
+}
+

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -54,6 +54,7 @@ PUBLIC void kmain(int argc, const char *argv[])
 	 */
 	hal_init();
 
+	test_exception();
 	test_clock();
 	test_core();
 

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -61,5 +61,7 @@ PUBLIC void kmain(int argc, const char *argv[])
 	test_sync();
 #endif
 
+	kprintf("[hal] halting...");
+
 	main(0, NULL);
 }

--- a/src/test/makefile
+++ b/src/test/makefile
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 # Source Files
-SRC = $(wildcard *.c) \
+C_SRC = $(wildcard *.c) \
       $(wildcard core/*.c)
 
 include build/makefile.$(TARGET)

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -35,12 +35,12 @@
 	};
 
 	/**
-	 * @brief Test driver for the clock interface.
+	 * @brief Test driver for the Clock Interface.
 	 */
 	EXTERN void test_clock(void);
 
-	/*
-	 * @brief Test driver for the core interface.
+	/**
+	 * @brief Test driver for the Core Interface.
 	 */
 	EXTERN void test_core(void);
 
@@ -48,5 +48,10 @@
 	 * @brief Test driver for the sync interface
 	 */
 	EXTERN void test_sync(void);
+
+	/**
+	 * @brief Test driver for the Exception Interface.
+	 */
+	EXTERN void test_exception(void);
 
 #endif /* _HAL_TEST_H_ */


### PR DESCRIPTION
Description
---------------

When an exception is raised in any core of an IO Cluster, it triggers multiple faults and causes execution flow to loop indefinitely.

An initial investigation suggests that as soon as space is allocated in the kernel stack to save the interrupted execution context and the first value is pushed, the first nestes fault is launched.

Related Issues
---------------------

- [[k1bio] Exceptions Trigger Multiple Faults](https://github.com/nanvix/hal/issues/89)