### PR TITLE
[or1k-core] Bug Fix: Bad Exception Struct Padding

### DIFF
--- a/include/arch/core/or1k/excp.h
+++ b/include/arch/core/or1k/excp.h
@@ -49,7 +49,7 @@
 	/**
 	 * @brief Exception information size (in bytes).
 	 */
-	#define OR1K_EXCEPTION_SIZE 12
+	#define OR1K_EXCEPTION_SIZE 16
 
 	/**
 	 * @name Offsets to the Exception Information structure.
@@ -94,9 +94,11 @@
 	 */
 	struct exception
 	{
-		or1k_word_t num;    /**< Exception number.      */
-		or1k_word_t eear;   /**< Exception address.     */
-		or1k_word_t epcr;   /**< Saved program counter. */
+		or1k_word_t num;         /**< Exception number.      */
+		or1k_word_t eear;        /**< Exception address.     */
+		or1k_word_t epcr;        /**< Saved program counter. */
+		or1k_byte_t RESERVED[4]; /**< Required padding.      */
+
 	} __attribute__((packed));
 
 /**@endif*/

--- a/src/hal/arch/core/or1k/hooks.S
+++ b/src/hal/arch/core/or1k/hooks.S
@@ -91,7 +91,7 @@
  * Saves the current execution context.
  */
 .macro or1k_context_save dest
-	
+
 	/* Save GPRs, except SP, BP and scratch registers r3 ... r6. */
 	l.sw OR1K_CONTEXT_R0(\dest),   r0
 	l.sw OR1K_CONTEXT_R7(\dest),   r7


### PR DESCRIPTION
Description
---------------

Previously, the exception structure of the or1k core was 12-bytes long, although the Exception Interface requires this structure to be a multiple of a double word. In this commit, I fixed this problem by padding the exception structure so as it has 16 bytes.

Related Issues
--------------------

- [[or1k-core] Bad Exception Strucure Padding](https://github.com/nanvix/hal/issues/106)