### PR TITLE
[k1b-core] Bad Interrupt Masking

### DIFF
--- a/include/arch/core/k1b/pic.h
+++ b/include/arch/core/k1b/pic.h
@@ -217,7 +217,7 @@
 	 */
 	static inline void k1b_pic_mask(int intnum)
 	{
-		mOS_it_enable_num(k1b_irqs[intnum]);
+		mOS_it_disable_num(k1b_irqs[intnum]);
 	}
 
 	/**
@@ -242,7 +242,7 @@
 	 */
 	static inline void k1b_pic_unmask(int intnum)
 	{
-		mOS_it_disable_num(k1b_irqs[intnum]);
+		mOS_it_enable_num(k1b_irqs[intnum]);
 	}
 
 	/**


### PR DESCRIPTION
Description
---------------

Previously, we were doing the opposite of what we were supposed to do
concerning interrupt masking. When we were supposed to unmask an
interrupt, we were masking it and vice-versa. In this commit, I fix this
bug.

Related Issues
--------------------

- [[k1b-core] Bad Interrupt Masking](https://github.com/nanvix/hal/issues/144)