### PR TITLE
[hal] Unmask Clock Interrupt

### DIFF
--- a/include/arch/core/or1k/pic.h
+++ b/include/arch/core/or1k/pic.h
@@ -170,7 +170,10 @@
 	 */
 	static inline void or1k_pic_unmask(int intnum)
 	{
-		or1k_mtspr(OR1K_SPR_PICMR, or1k_mfspr(OR1K_SPR_PICMR) | (1 << intnum));
+		if (intnum == OR1K_INT_CLOCK)
+			or1k_mtspr(OR1K_SPR_SR, or1k_mfspr(OR1K_SPR_SR) | OR1K_SPR_SR_TEE);
+		else
+			or1k_mtspr(OR1K_SPR_PICMR, or1k_mfspr(OR1K_SPR_PICMR) | (1 << intnum));
 	}
 
 	/**

--- a/src/test/clock.c
+++ b/src/test/clock.c
@@ -67,6 +67,7 @@ PRIVATE void test_do_clock(void)
 	KASSERT(interrupt_register(HAL_INT_CLOCK, do_clock) == 0);
 
 	interrupts_enable();
+	interrupt_unmask(HAL_INT_CLOCK);
 
 		/* Wait for enough clock interrupts. */
 		while (ticks < nticks)

--- a/src/test/clock.c
+++ b/src/test/clock.c
@@ -70,8 +70,11 @@ PRIVATE void test_do_clock(void)
 	interrupt_unmask(HAL_INT_CLOCK);
 
 		/* Wait for enough clock interrupts. */
-		while (ticks < nticks)
+		do
+		{
 			noop();
+			dcache_invalidate();
+		} while (ticks < nticks);
 
 	interrupts_disable();
 }


### PR DESCRIPTION
Description
---------------

Previously, we were assuming that all interrupt masks were cleared, so
that if we simply enabled hardware interrupts clock interrupts would
follow. However, enabling hardware interrupts and unmasking them are two
different things that we were missing to do. In this commit, I ensure
that we unmask the clock interrupt line before proceeding with tests.