### PR TITLE
[hal][lib] Buffer Size Too Small

### DIFF
--- a/include/nanvix/klib.h
+++ b/include/nanvix/klib.h
@@ -48,7 +48,7 @@
 	 *
 	 * @note Hopefully not kernel string is longer than this.
 	 */
-	#define KBUFFER_SIZE 64
+	#define KBUFFER_SIZE 128
 
 	/**
 	 * @brief Prints a string on the standard output device.


### PR DESCRIPTION
Description
---------------

Previously, we were using a very small kernel buffer size that would sometimes overflow and cause the HAL to misbehave. In this commit, I have fixed this problem by making the buffer size 2x bigger.