### PR TITLE
[hal] Enhancements in the Hardware Interrupt Interface

### DIFF
--- a/include/arch/core/i486/8259.h
+++ b/include/arch/core/i486/8259.h
@@ -67,6 +67,11 @@
 	/**@}*/
 
 	/**
+	 * @brief Number of hardware interrupts in the i486 architecture.
+	 */
+	#define I486_NUM_HWINT 16
+
+	/**
 	 * @brief Number of interrupt levels.
 	 */
 	#define I486_NUM_INTLVL 6
@@ -113,17 +118,20 @@
 	 * @brief Masks an interrupt.
 	 *
 	 * @param intnum Number of the target interrupt.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN void i486_pic_mask(int intnum);
+	EXTERN int i486_pic_mask(int intnum);
 
 	/**
 	 * @see i486_pic_mask()
 	 *
 	 * @cond i486
 	 */
-	static inline void interrupt_mask(int intnum)
+	static inline int interrupt_mask(int intnum)
 	{
-		i486_pic_mask(intnum);
+		return (i486_pic_mask(intnum));
 	}
 	/**@endcond*/
 
@@ -131,17 +139,20 @@
 	 * @brief Unmasks an interrupt.
 	 *
 	 * @param intnum Number of the target interrupt.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN void i486_pic_unmask(int intnum);
+	EXTERN int i486_pic_unmask(int intnum);
 
 	/**
 	 * @see i486_pic_unmask()
 	 *
 	 * @cond i486
 	 */
-	static inline void interrupt_unmask(int intnum)
+	static inline int interrupt_unmask(int intnum)
 	{
-		i486_pic_unmask(intnum);
+		return (i486_pic_unmask(intnum));
 	}
 	/**@endcond*/
 

--- a/include/arch/core/i486/8259.h
+++ b/include/arch/core/i486/8259.h
@@ -50,7 +50,7 @@
 	#define PIC_CTRL_MASTER 0x20 /**< Control */
 	#define PIC_DATA_MASTER 0x21 /**< Data    */
 	/**@}*/
-	
+
 	/**
 	 * @name Slave PIC Registers
 	 */
@@ -100,7 +100,7 @@
 	#include <arch/core/i486/pmio.h>
 	#include <nanvix/const.h>
 	#include <stdint.h>
-	
+
 	/**
 	 * @brief Initializes the PIC.
 	 *
@@ -108,7 +108,7 @@
 	 * @param offset2 Vector offset for slave PIC.
 	 */
 	EXTERN void i486_pic_setup(uint8_t offset1, uint8_t offset2);
-	
+
 	/**
 	 * @brief Masks an interrupt.
 	 *

--- a/include/arch/core/i486/int.h
+++ b/include/arch/core/i486/int.h
@@ -125,8 +125,11 @@
 	 *
 	 * @param num     Number of the target hardware interrupt.
 	 * @param handler Hardware interrupt handler.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN void i486_hwint_handler_set(int num, void (*handler)(int));
+	EXTERN int i486_hwint_handler_set(int num, void (*handler)(int));
 
 /**@}*/
 
@@ -178,9 +181,9 @@
 	/**
 	 * @see i486_hwint_handler_set().
 	 */
-	static inline void interrupt_set_handler(int num, void (*handler)(int))
+	static inline int interrupt_set_handler(int num, void (*handler)(int))
 	{
-		i486_hwint_handler_set(num, handler);
+		return (i486_hwint_handler_set(num, handler));
 	}
 
 /**@endcond*/

--- a/include/arch/core/i486/int.h
+++ b/include/arch/core/i486/int.h
@@ -38,12 +38,8 @@
 /**@{*/
 
 	#include <nanvix/const.h>
+	#include <arch/core/i486/8259.h>
 	#include <arch/core/i486/context.h>
-
-	/**
-	 * @brief Number of hardware interrupts in the i486 architecture.
-	 */
-	#define I486_NUM_HWINT 16
 
 	/**
 	 * @name Hardware Interrupts for the IBM PC Target

--- a/include/arch/core/k1b/int.h
+++ b/include/arch/core/k1b/int.h
@@ -103,8 +103,11 @@
 	 *
 	 * @param num     Number of the target hardware interrupt.
 	 * @param handler Hardware interrupt handler.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
 	 */
-	extern void k1b_hwint_handler_set(int num, void (*handler)(int));
+	extern int k1b_hwint_handler_set(int num, void (*handler)(int));
 
 /**@}*/
 
@@ -157,9 +160,9 @@
 	/**
 	 * @see k1b_hwint_handler_set().
 	 */
-	static inline void interrupt_set_handler(int num, void (*handler)(int))
+	static inline int interrupt_set_handler(int num, void (*handler)(int))
 	{
-		k1b_hwint_handler_set(num, handler);
+		return (k1b_hwint_handler_set(num, handler));
 	}
 
 /**@endcond*/

--- a/include/arch/core/k1b/pic.h
+++ b/include/arch/core/k1b/pic.h
@@ -33,7 +33,12 @@
  */
 /**@{*/
 
+	/* Must come first. */
+	#define __NEED_K1B_IVT
+
+	#include <arch/core/k1b/ivt.h>
 	#include <mOS_vcore_u.h>
+	#include <errno.h>
 	#include <stdint.h>
 
 	/**
@@ -213,11 +218,20 @@
 	 * the interrupt @p intnum is hooked up in the underlying k1b
 	 * core.
 	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
+	 *
 	 * @param intnum Number of the target interrupt.
 	 */
-	static inline void k1b_pic_mask(int intnum)
+	static inline int k1b_pic_mask(int intnum)
 	{
+		/* Invalid interrupt number. */
+		if ((intnum < 0) || (intnum >= K1B_NUM_HWINT))
+			return (-EINVAL);
+
 		mOS_it_disable_num(k1b_irqs[intnum]);
+
+		return (0);
 	}
 
 	/**
@@ -225,9 +239,9 @@
 	 *
 	 * @cond k1b
 	 */
-	static inline void interrupt_mask(int intnum)
+	static inline int interrupt_mask(int intnum)
 	{
-		k1b_pic_mask(intnum);
+		return (k1b_pic_mask(intnum));
 	}
 	/**@endcond*/
 
@@ -238,11 +252,20 @@
 	 * the interrupt @p intnum is hooked up in the underlying k1b
 	 * core.
 	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
+	 *
 	 * @param intnum Number of the target interrupt.
 	 */
-	static inline void k1b_pic_unmask(int intnum)
+	static inline int k1b_pic_unmask(int intnum)
 	{
+		/* Invalid interrupt number. */
+		if ((intnum < 0) || (intnum >= K1B_NUM_HWINT))
+			return (-EINVAL);
+
 		mOS_it_enable_num(k1b_irqs[intnum]);
+
+		return (0);
 	}
 
 	/**
@@ -250,9 +273,9 @@
 	 *
 	 * @cond k1b
 	 */
-	static inline void interrupt_unmask(int intnum)
+	static inline int interrupt_unmask(int intnum)
 	{
-		k1b_pic_unmask(intnum);
+		return (k1b_pic_unmask(intnum));
 	}
 	/**@endcond*/
 

--- a/include/arch/core/or1k/int.h
+++ b/include/arch/core/or1k/int.h
@@ -46,11 +46,6 @@
 
 #endif /* _ASM_FILE_ */
 
-	/**
-	 * @brief Number of hardware interrupts in the or1k architecture.
-	 */
-	#define OR1K_NUM_HWINT 3
-
 #ifndef _ASM_FILE_
 
 	/**

--- a/include/arch/core/or1k/int.h
+++ b/include/arch/core/or1k/int.h
@@ -108,8 +108,11 @@
 	 *
 	 * @param num     Number of the target hardware interrupt.
 	 * @param handler Hardware interrupt handler.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN void or1k_hwint_handler_set(int num, void (*handler)(int));
+	EXTERN int or1k_hwint_handler_set(int num, void (*handler)(int));
 
 #endif
 
@@ -165,9 +168,9 @@
 	/**
 	 * @see or1k_hwint_handler_set()
 	 */
-	static inline void interrupt_set_handler(int num, void (*handler)(int))
+	static inline int interrupt_set_handler(int num, void (*handler)(int))
 	{
-		or1k_hwint_handler_set(num, handler);
+		return (or1k_hwint_handler_set(num, handler));
 	}
 
 #endif /* _ASM_FILE_ */

--- a/include/arch/core/or1k/pic.h
+++ b/include/arch/core/or1k/pic.h
@@ -43,9 +43,15 @@
 	#define __NEED_OR1K_REGS
 	#include <arch/core/or1k/regs.h>
 	#include <nanvix/const.h>
+	#include <errno.h>
 	#include <stdint.h>
 
 #endif /* _ASM_FILE_ */
+
+	/**
+	 * @brief Number of hardware interrupts in the or1k architecture.
+	 */
+	#define OR1K_NUM_HWINT 3
 
 	/**
 	 * @brief Number of interrupt levels.
@@ -154,26 +160,44 @@
 	 * @brief Masks an interrupt.
 	 *
 	 * @param intnum Number of the target interrupt.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
 	 */
-	static inline void or1k_pic_mask(int intnum)
+	static inline int or1k_pic_mask(int intnum)
 	{
+		/* Invalid interrupt number. */
+		if ((intnum < 0) || (intnum >= OR1K_NUM_HWINT))
+			return (-EINVAL);
+
 		if (intnum == OR1K_INT_CLOCK)
 			or1k_mtspr(OR1K_SPR_SR, or1k_mfspr(OR1K_SPR_SR) & ~OR1K_SPR_SR_TEE);
 		else
 			or1k_mtspr(OR1K_SPR_PICMR, or1k_mfspr(OR1K_SPR_PICMR) & ~(1 << intnum));
+
+		return (0);
 	}
 
 	/**
 	 * @brief Unmasks an interrupt.
 	 *
 	 * @param intnum Number of the target interrupt.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
 	 */
-	static inline void or1k_pic_unmask(int intnum)
+	static inline int or1k_pic_unmask(int intnum)
 	{
+		/* Invalid interrupt number. */
+		if ((intnum < 0) || (intnum >= OR1K_NUM_HWINT))
+			return (-EINVAL);
+
 		if (intnum == OR1K_INT_CLOCK)
 			or1k_mtspr(OR1K_SPR_SR, or1k_mfspr(OR1K_SPR_SR) | OR1K_SPR_SR_TEE);
 		else
 			or1k_mtspr(OR1K_SPR_PICMR, or1k_mfspr(OR1K_SPR_PICMR) | (1 << intnum));
+
+		return (0);
 	}
 
 	/**
@@ -233,17 +257,17 @@
 	/**
 	 * @see or1k_pic_mask()
 	 */
-	static inline void interrupt_mask(int intnum)
+	static inline int interrupt_mask(int intnum)
 	{
-		or1k_pic_mask(intnum);
+		return (or1k_pic_mask(intnum));
 	}
 
 	/**
 	 * @see or1k_pic_unmask()
 	 */
-	static inline void interrupt_unmask(int intnum)
+	static inline int interrupt_unmask(int intnum)
 	{
-		or1k_pic_unmask(intnum);
+		return (or1k_pic_unmask(intnum));
 	}
 
 #endif /* _ASM_FILE_ */

--- a/include/nanvix/hal/core/interrupt.h
+++ b/include/nanvix/hal/core/interrupt.h
@@ -158,6 +158,16 @@
 	EXTERN int interrupt_register(int num, interrupt_handler_t handler);
 
 	/**
+	 * @brief Unregisters an interrupt handler.
+	 *
+	 * @param num Number of the interrupt.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
+	 */
+	EXTERN int interrupt_unregister(int num);
+
+	/**
 	 * @brief Setups hardware interrupts.
 	 */
 	EXTERN void interrupt_setup(void);

--- a/include/nanvix/hal/core/interrupt.h
+++ b/include/nanvix/hal/core/interrupt.h
@@ -133,8 +133,11 @@
 	 * @brief Masks an interrupt.
 	 *
 	 * @param intnum Number of the target interrupt.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN void interrupt_mask(int intnum);
+	EXTERN int interrupt_mask(int intnum);
 
 	/**
 	 * @brief Unmasks an interrupt.
@@ -144,7 +147,7 @@
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error number is returned instead.
 	 */
-	EXTERN void interrupt_unmask(int intnum);
+	EXTERN int interrupt_unmask(int intnum);
 
 	/**
 	 * @brief Registers an interrupt handler.

--- a/include/nanvix/hal/core/interrupt.h
+++ b/include/nanvix/hal/core/interrupt.h
@@ -105,10 +105,13 @@
 	 * @param num     Number of the target interrupt.
 	 * @param handler Handler.
 	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
+	 *
 	 * @note This function does not check if a handler is already
 	 * set for the target hardware interrupt.
 	 */
-	EXTERN void interrupt_set_handler(int num, interrupt_handler_t handler);
+	EXTERN int interrupt_set_handler(int num, interrupt_handler_t handler);
 
 	/**
 	 * @brief Sets the interrupt level of the underlying core.

--- a/src/hal/arch/core/i486/8259.c
+++ b/src/hal/arch/core/i486/8259.c
@@ -164,13 +164,13 @@ PUBLIC void i486_pic_setup(uint8_t offset1, uint8_t offset2)
 	i486_iowait();
 	i486_output8(PIC_CTRL_SLAVE, 0x11);
 	i486_iowait();
-	
+
 	/* Send new vector offset. */
 	i486_output8(PIC_DATA_MASTER, offset1);
 	i486_iowait();
 	i486_output8(PIC_DATA_SLAVE, offset2);
 	i486_iowait();
-	
+
 	/*
 	 * Tell the master that there is a slave
 	 * PIC hired up at IRQ line 2 and tell
@@ -180,13 +180,13 @@ PUBLIC void i486_pic_setup(uint8_t offset1, uint8_t offset2)
 	i486_iowait();
 	i486_output8(PIC_DATA_SLAVE, 0x02);
 	i486_iowait();
-	
+
 	/* Set 8086 mode. */
 	i486_output8(PIC_DATA_MASTER, 0x01);
 	i486_iowait();
 	i486_output8(PIC_DATA_SLAVE, 0x01);
 	i486_iowait();
-	
+
 	/* Clears interrupt mask. */
 	i486_pic_lvl_set(I486_INTLVL_0);
 }

--- a/src/hal/arch/core/i486/8259.c
+++ b/src/hal/arch/core/i486/8259.c
@@ -25,6 +25,7 @@
 #include <nanvix/const.h>
 #include <arch/core/i486/8259.h>
 #include <arch/core/i486/pmio.h>
+#include <errno.h>
 #include <stdint.h>
 
 /**
@@ -63,11 +64,15 @@ PRIVATE uint16_t currmask = I486_INTLVL_MASK_5;
  * The i486_pic_mask() function masks the interrupt request line in
  * which the interrupt @p intnum is hooked up.
  */
-PUBLIC void i486_pic_mask(int intnum)
+PUBLIC int i486_pic_mask(int intnum)
 {
 	uint16_t port;
 	uint8_t value;
 	uint16_t newmask;
+
+	/* Invalid interrupt number. */
+	if ((intnum < 0) || (intnum >= I486_NUM_HWINT))
+		return (-EINVAL);
 
 	if (intnum < 8)
 	{
@@ -85,6 +90,8 @@ PUBLIC void i486_pic_mask(int intnum)
 	currmask = newmask;
 
 	i486_output8(port, value);
+
+	return (0);
 }
 
 /*============================================================================*
@@ -95,11 +102,15 @@ PUBLIC void i486_pic_mask(int intnum)
  * The i486_pic_unmask() function unmasks the interrupt request line
  * in which the interrupt @p intnum is hooked up.
  */
-PUBLIC void i486_pic_unmask(int intnum)
+PUBLIC int i486_pic_unmask(int intnum)
 {
 	uint16_t port;
 	uint8_t value;
 	uint16_t newmask;
+
+	/* Invalid interrupt number. */
+	if ((intnum < 0) || (intnum >= I486_NUM_HWINT))
+		return (-EINVAL);
 
 	if (intnum < 8)
 	{
@@ -117,6 +128,8 @@ PUBLIC void i486_pic_unmask(int intnum)
 	currmask = newmask;
 
 	i486_output8(port, value);
+
+	return (0);
 }
 
 /*============================================================================*

--- a/src/hal/arch/core/i486/clock.c
+++ b/src/hal/arch/core/i486/clock.c
@@ -34,12 +34,12 @@
 PUBLIC void i486_clock_init(unsigned freq)
 {
 	uint16_t freq_divisor;
-	
+
 	freq_divisor = PIT_FREQUENCY/freq;
-	
+
 	/* Send control byte: adjust frequency divisor. */
 	i486_output8(PIT_CTRL, 0x36);
-	
+
 	/* Send data byte: divisor_low and divisor_high. */
 	i486_output8(PIT_DATA, (uint8_t)(freq_divisor & 0xff));
 	i486_output8(PIT_DATA, (uint8_t)((freq_divisor >> 8)));

--- a/src/hal/arch/core/i486/hwint.c
+++ b/src/hal/arch/core/i486/hwint.c
@@ -53,7 +53,7 @@ PRIVATE void (*i486_handlers[I486_NUM_HWINT])(int) = {
 PUBLIC void i486_do_hwint(int num, const struct context *ctx)
 {
 	UNUSED(ctx);
-	
+
 	/* Nothing to do. */
 	if (i486_handlers[num] == NULL)
 		return;

--- a/src/hal/arch/core/i486/hwint.c
+++ b/src/hal/arch/core/i486/hwint.c
@@ -66,7 +66,9 @@ PUBLIC void i486_do_hwint(int num, const struct context *ctx)
  * by @p handler as the handler for the hardware interrupt whose
  * number is @p num.
  */
-PUBLIC void i486_hwint_handler_set(int num, void (*handler)(int))
+PUBLIC int i486_hwint_handler_set(int num, void (*handler)(int))
 {
 	i486_handlers[num] = handler;
+
+	return (0);
 }

--- a/src/hal/arch/core/i486/hwint.c
+++ b/src/hal/arch/core/i486/hwint.c
@@ -26,6 +26,7 @@
 #include <arch/core/i486/int.h>
 #include <nanvix/const.h>
 #include <nanvix/klib.h>
+#include <errno.h>
 
 /**
  * @brief Interrupt handlers.
@@ -68,6 +69,10 @@ PUBLIC void i486_do_hwint(int num, const struct context *ctx)
  */
 PUBLIC int i486_hwint_handler_set(int num, void (*handler)(int))
 {
+	/* Invalid interrupt number. */
+	if ((num < 0) || (num >= I486_NUM_HWINT))
+		return (-EINVAL);
+
 	i486_handlers[num] = handler;
 
 	return (0);

--- a/src/hal/arch/core/k1b/hwint.c
+++ b/src/hal/arch/core/k1b/hwint.c
@@ -79,6 +79,10 @@ found:
  */
 PUBLIC int k1b_hwint_handler_set(int num, void (*handler)(int))
 {
+	/* Invalid interrupt number. */
+	if ((num < 0) || (num >= K1B_NUM_HWINT))
+		return (-EINVAL);
+
 	k1b_handlers[num] = handler;
 	k1b_dcache_inval();
 

--- a/src/hal/arch/core/k1b/hwint.c
+++ b/src/hal/arch/core/k1b/hwint.c
@@ -77,8 +77,10 @@ found:
  * by @p handler as the handler for the hardware interrupt whose
  * number is @p num.
  */
-PUBLIC void k1b_hwint_handler_set(int num, void (*handler)(int))
+PUBLIC int k1b_hwint_handler_set(int num, void (*handler)(int))
 {
 	k1b_handlers[num] = handler;
 	k1b_dcache_inval();
+
+	return (0);
 }

--- a/src/hal/arch/core/or1k/hwint.c
+++ b/src/hal/arch/core/or1k/hwint.c
@@ -49,7 +49,7 @@ PRIVATE int or1k_next_irq()
 
 	while (!(picsr & 1) && bit < 32)
 	{
-		picsr >>= 1;	
+		picsr >>= 1;
 		bit++;
 	}
 
@@ -74,7 +74,7 @@ PUBLIC void or1k_do_hwint(int num, const struct context *ctx)
 {
 	int interrupt;
 	UNUSED(ctx);
-	
+
 	/*
 	 * If clock, lets handle immediately.
 	 *
@@ -93,7 +93,7 @@ PUBLIC void or1k_do_hwint(int num, const struct context *ctx)
 
 		or1k_handlers[num](num);
 	}
-	
+
 	/*
 	 * Lets also check for external interrupt, if
 	 * there's any pending, handle.
@@ -102,7 +102,7 @@ PUBLIC void or1k_do_hwint(int num, const struct context *ctx)
 	{
 		/* ack. */
 		or1k_pic_ack(interrupt);
-		
+
 		/* Nothing to do. */
 		if (or1k_handlers[interrupt] == NULL)
 			return;

--- a/src/hal/arch/core/or1k/hwint.c
+++ b/src/hal/arch/core/or1k/hwint.c
@@ -25,6 +25,7 @@
 #include <arch/core/or1k/int.h>
 #include <nanvix/const.h>
 #include <nanvix/klib.h>
+#include <errno.h>
 
 /**
  * @brief Interrupt handlers.
@@ -118,6 +119,10 @@ PUBLIC void or1k_do_hwint(int num, const struct context *ctx)
  */
 PUBLIC int or1k_hwint_handler_set(int num, void (*handler)(int))
 {
+	/* Invalid interrupt number. */
+	if ((num < 0) || (num >= OR1K_NUM_HWINT))
+		return (-EINVAL);
+
 	or1k_handlers[num] = handler;
 
 	return (0);

--- a/src/hal/arch/core/or1k/hwint.c
+++ b/src/hal/arch/core/or1k/hwint.c
@@ -116,7 +116,9 @@ PUBLIC void or1k_do_hwint(int num, const struct context *ctx)
  * by @p handler as the handler for the hardware interrupt whose
  * number is @p num.
  */
-PUBLIC void or1k_hwint_handler_set(int num, void (*handler)(int))
+PUBLIC int or1k_hwint_handler_set(int num, void (*handler)(int))
 {
 	or1k_handlers[num] = handler;
+
+	return (0);
 }

--- a/src/hal/core/interrupt.c
+++ b/src/hal/core/interrupt.c
@@ -67,7 +67,7 @@ PUBLIC int interrupt_register(int num, interrupt_handler_t handler)
 	dcache_invalidate();
 	interrupt_set_handler(num, handler);
 
-	kprintf("interrupt handler registered for irq %d", num);
+	kprintf("[hal] interrupt handler registered for irq %d", num);
 
 	return (0);
 }

--- a/src/hal/core/interrupt.c
+++ b/src/hal/core/interrupt.c
@@ -70,6 +70,28 @@ PUBLIC int interrupt_register(int num, interrupt_handler_t handler)
 	return (0);
 }
 
+/**
+ * The interrupt_unregister() function unregisters a handler function
+ * for the interrupt whose number is @p num. If no handler function
+ * was previously registered with this number, the
+ * interrupt_unregister() function fails.
+ */
+PUBLIC int interrupt_unregister(int num)
+{
+	KASSERT(num >= 0);
+
+	/* No handler function is registered. */
+	if (!interrupts[num].handled)
+		return (-EINVAL);
+
+	interrupts[num].handled = FALSE;
+	dcache_invalidate();
+	interrupt_set_handler(num, default_handler);
+
+	kprintf("[hal] interrupt handler unregistered for irq %d", num);
+
+	return (0);
+}
 
 /**
  * Initializes hardware interrupts by registering a default handler to

--- a/src/hal/core/interrupt.c
+++ b/src/hal/core/interrupt.c
@@ -55,7 +55,9 @@ PRIVATE void default_handler(int num)
  */
 PUBLIC int interrupt_register(int num, interrupt_handler_t handler)
 {
-	KASSERT(num >= 0);
+	/* Invalid interrupt number. */
+	if ((num < 0) || (num >= HAL_INT_NR))
+		return (-EINVAL);
 
 	/* Handler function already registered. */
 	if (interrupts[num].handled)
@@ -78,7 +80,9 @@ PUBLIC int interrupt_register(int num, interrupt_handler_t handler)
  */
 PUBLIC int interrupt_unregister(int num)
 {
-	KASSERT(num >= 0);
+	/* Invalid interrupt number. */
+	if ((num < 0) || (num >= HAL_INT_NR))
+		return (-EINVAL);
 
 	/* No handler function is registered. */
 	if (!interrupts[num].handled)


### PR DESCRIPTION
Description
----------------

In this PR, I introduce several enhancements in the Hardware Interrupt Interface:

- Adding a return value for `interrupt_set_handler()`
- Adding `interrupt_unregister()` routine
- Adding parameter checking
- Using the standard output format for messages

Related Issues
--------------------

- [[hal] Hardware Interrupt Interface](https://github.com/nanvix/hal/issues/8)