### PR TITLE
Enhancement: Drop Some Useless QEMU Targets

### DIFF
--- a/tools/dev/setup-qemu.sh
+++ b/tools/dev/setup-qemu.sh
@@ -40,7 +40,7 @@ wget "http://wiki.qemu-project.org/download/qemu-$QEMU_VERSION.tar.bz2"
 # Build qemu
 tar -xjvf qemu-$QEMU_VERSION.tar.bz2
 cd qemu-$QEMU_VERSION
-./configure --target-list=i386-softmmu,or1k-softmmu,or1k-linux-user --enable-sdl --enable-curses
+./configure --target-list=i386-softmmu,or1k-softmmu --enable-sdl --enable-curses
 make -j $NCORES all
 make install
 


### PR DESCRIPTION
In this commit, I have removed the or1k-linux-user QEMU target. We do
not use it.