### PR TITLE
[build] Cleanup OpenRISC Toolchain

### DIFF
--- a/tools/dev/arch/or1k.sh
+++ b/tools/dev/arch/or1k.sh
@@ -67,12 +67,5 @@ make install-target-libgcc
 cd $WORKDIR
 rm -rf gcc*
 
-# GCC for Linux
-wget "https://github.com/openrisc/musl-cross/releases/download/gcc5.3.0-musl1.1.14/or1k-linux-musl_gcc5.3.0_binutils2.26_musl1.1.14.tgz"
-tar -xvf or1k-linux-musl_gcc5.3.0_binutils2.26_musl1.1.14.tgz
-
-# Cleanup.
-rm -rf or1k-linux-musl_gcc5.3.0_binutils2.26_musl1.1.14.tgz
-
 # Back to the current folder
 cd $CURDIR


### PR DESCRIPTION
We don't need the GCC for Linux. In this commit I have dropped this from
the toolchain build.