### PR TITLE
[or1k-core] Properly Resetting Core

### DIFF
--- a/include/arch/core/or1k/asm.h
+++ b/include/arch/core/or1k/asm.h
@@ -295,4 +295,24 @@
 
 	.endm
 
+/*============================================================================*
+ * General macros                                                             *
+ *============================================================================*/
+
+	/*
+	 * Clear all GPR registers.
+	 */
+	.macro or1k_clear_gprs
+
+		l.ori r1, r0,  0; l.ori r2,  r0, 0; l.ori r3,  r0, 0; l.ori r4,  r0, 0;
+		l.ori r5, r0,  0; l.ori r6,  r0, 0; l.ori r7,  r0, 0; l.ori r8,  r0, 0;
+		l.ori r9, r0,  0; l.ori r10, r0, 0; l.ori r11, r0, 0; l.ori r12, r0, 0;
+		l.ori r13, r0, 0; l.ori r14, r0, 0; l.ori r15, r0, 0; l.ori r16, r0, 0;
+		l.ori r17, r0, 0; l.ori r18, r0, 0; l.ori r19, r0, 0; l.ori r20, r0, 0;
+		l.ori r21, r0, 0; l.ori r22, r0, 0; l.ori r23, r0, 0; l.ori r24, r0, 0;
+		l.ori r25, r0, 0; l.ori r26, r0, 0; l.ori r27, r0, 0; l.ori r28, r0, 0;
+		l.ori r29, r0, 0; l.ori r30, r0, 0; l.ori r31, r0, 0;
+
+	.endm
+
 #endif /* ARCH_CORE_OR1K_ASM_H_ */

--- a/src/hal/arch/core/or1k/_core.S
+++ b/src/hal/arch/core/or1k/_core.S
@@ -24,10 +24,15 @@
 
 /* Must come first. */
 #define _ASM_FILE_
+#define __NEED_OR1K_REGS
 
+#include <arch/core/or1k/asm.h>
 #include <arch/core/or1k/core.h>
+#include <arch/core/or1k/mmu.h>
 
+/* Exported symbols. */
 .global _or1k_core_reset
+.global core.kstack
 
 .section .text
 
@@ -39,5 +44,25 @@
  * Resets the underlying core.
  */
 _or1k_core_reset:
+	/* Clear GPRs. */
+	or1k_clear_gprs
+
+	/* Get core id. */
+	OR1K_LOAD_SYMBOL_2_GPR(r1, core.kstack)
+	l.mfspr r3, r0, OR1K_SPR_COREID
+	l.addi  r3, r3, 1
+
+	/* Setup kernel stack. */
+	l.slli  r3, r3, OR1K_PAGE_SHIFT
+	l.add   r1, r1, r3
+	l.addi  r1, r1, -OR1K_WORD_SIZE  /* Stack pointer. */
+	l.or    r2, r1, r0               /* Frame pointer. */
+
+	/* Restart core. */
+	l.j or1k_slave_setup
 	l.nop
-	l.nop
+
+	/* Never gets here. */
+	_or1k_core_reset.halt:
+		l.j _or1k_core_reset.halt
+		l.nop

--- a/src/hal/arch/core/or1k/hooks.S
+++ b/src/hal/arch/core/or1k/hooks.S
@@ -299,14 +299,6 @@ _syscall:
  */
 
 _do_start:
-	l.ori r1, r0,  0; l.ori r2,  r0, 0; l.ori r3,  r0, 0; l.ori r4,  r0, 0;
-	l.ori r5, r0,  0; l.ori r6,  r0, 0; l.ori r7,  r0, 0; l.ori r8,  r0, 0;
-	l.ori r9, r0,  0; l.ori r10, r0, 0; l.ori r11, r0, 0; l.ori r12, r0, 0;
-	l.ori r13, r0, 0; l.ori r14, r0, 0; l.ori r15, r0, 0; l.ori r16, r0, 0;
-	l.ori r17, r0, 0; l.ori r18, r0, 0; l.ori r19, r0, 0; l.ori r20, r0, 0;
-	l.ori r21, r0, 0; l.ori r22, r0, 0; l.ori r23, r0, 0; l.ori r24, r0, 0;
-	l.ori r25, r0, 0; l.ori r26, r0, 0; l.ori r27, r0, 0; l.ori r28, r0, 0;
-	l.ori r29, r0, 0; l.ori r30, r0, 0; l.ori r31, r0, 0;
-
+	or1k_clear_gprs
 	l.jal start
 	l.nop


### PR DESCRIPTION
In issue #143 was observed that `_or1k_core_reset` was literally doing nothing. This is reminiscent of the much earlier stages of the HAL port to or1k. Since the port is in advanced stage, it is essential to implement this function.