### PR TITLE
[or1k-core] Enhancement: ASM Macros

### DIFF
--- a/include/arch/core/or1k/asm.h
+++ b/include/arch/core/or1k/asm.h
@@ -296,7 +296,7 @@
 	.endm
 
 /*============================================================================*
- * General macros                                                             *
+ * Misc                                                                       *
  *============================================================================*/
 
 	/*
@@ -313,6 +313,36 @@
 		l.ori r25, r0, 0; l.ori r26, r0, 0; l.ori r27, r0, 0; l.ori r28, r0, 0;
 		l.ori r29, r0, 0; l.ori r30, r0, 0; l.ori r31, r0, 0;
 
+	.endm
+
+	/*
+	 * Unconditional jump with delay slot.
+	 */
+	.macro jump N
+		l.j \N
+		l.nop
+	.endm
+
+/*============================================================================*
+ * Stack Operations                                                           *
+ *============================================================================*/
+
+	/*
+	 * Pushes a 32-bit register onto the stack.
+	 *   - rA Target register.
+	 */
+	.macro pushw rA
+		l.addi sp, sp, -4
+		l.sw 0(sp), \rA
+	.endm
+
+	/*
+	 * Pops a 32-bit register from the stack.
+	 *   - rA Target register.
+	 */
+	.macro popw rA
+		l.lwz \rA, 0(sp)
+		l.addi sp, sp, 4
 	.endm
 
 #endif /* ARCH_CORE_OR1K_ASM_H_ */


### PR DESCRIPTION
Description
---------------

This PR introduces the macros suggested in #154.
Since OpenRISC 32-bit does not makes use of 64-bit registers and structures, does not makes sense at all to use the pseudo-instructions `pushd` and `popd` so they will not be implemented.

@ppenna Just a side note: this pull request also contains the changes included in PR #166, so please review the previous PR before this one.

Related Issues
---------------------

- [[or1k-core] ASM Macros](https://github.com/nanvix/hal/issues/154)