### PR TITLE
[k1b-core] Bad Trap Call Arguments

### DIFF
--- a/src/hal/arch/core/k1b/hooks.S
+++ b/src/hal/arch/core/k1b/hooks.S
@@ -99,6 +99,14 @@ _do_syscall:
 		/* Save preserved registers. */
 		_do_prologue_slow
 		;;
+
+		/* mOS supports trap calls with 8 arguments, and thus the trap
+		 * call number is stored in the R7.  However, we support trap
+		 * calls only with 5 arguments, so we should fix the arguments
+		 * of the trap call here, by storing into the register R5 the
+		 * trap call number.
+		 */
+		copy $r5, $r7
 		;;
 
 		/*

--- a/src/hal/arch/core/k1b/hooks.S
+++ b/src/hal/arch/core/k1b/hooks.S
@@ -96,16 +96,9 @@ _do_syscall:
 
 	_do_syscall.continue:
 
-		/* Save system call context. */
-		add $sp = $sp, -K1B_DWORD_SIZE
+		/* Save preserved registers. */
+		_do_prologue_slow
 		;;
-		get $r8 = $ra
-		;;
-		copy $bp = $r7
-		;;
-		sw 0 [$sp] = $bp
-		;;
-		sw 4 [$sp] = $r8
 		;;
 
 		/*
@@ -118,14 +111,8 @@ _do_syscall:
 		redzone_free
 		;;
 
-		/* Restore system call context. */
-		lw $r8 = 4 [$sp]
-		;;
-		lw $bp = 0 [$sp]
-		;;
-		add $sp = $sp, K1B_DWORD_SIZE
-		;;
-		set $ra = $r8
+		/* Restore preserved registers. */
+		_do_epilogue_slow
 		;;
 
 	_do_syscall.out:


### PR DESCRIPTION
Description
---------------

mOS supports trap calls with 8 arguments, and thus the trap call number is stored in the R7.  However, we support trap calls only with 5 arguments, but we were missing to use R5 register to store the trap call number, previously. In this commit, I fix this bug.

Related Pull Requests
------------------------------

- [[k1b-core] Save Preserved Regs in Trap](https://github.com/nanvix/hal/pull/168)