### PR TITLE
[k1b-core] Bad TLB Lookups

### DIFF
--- a/include/arch/core/k1b/tlb.h
+++ b/include/arch/core/k1b/tlb.h
@@ -38,30 +38,13 @@
 	#include <mOS_vcore_u.h>
 	#include <mOS_segment_manager_u.h>
 
-/**
- * @cond k1b
- */
-
 	/**
-	 * @brief Software-managed TLB.
-	 */
-	#define HAL_TLB_SOFTWARE
-
-	/**
-	 * @brief Provided Interface
+	 * @name TLB Types
 	 */
 	/**@{*/
-	#define __tlbe_st             /**< TLB Entry           */
-	#define __tlbe_vaddr_get_fn   /**< tlbe_vaddr_get()    */
-	#define __tlbe_paddr_get_fn   /**< tlbe_paddr_get()    */
-	#define __tlb_lookup_vaddr_fn /**< tlbe_lookup_vaddr() */
-	#define __tlb_lookup_paddr_fn /**< tlbe_lookup()       */
-	#define __tlb_write_fn        /**< tlb_write()         */
-	#define __tlb_inval_fn        /**< tlb_inval()         */
-	#define __tlb_flush_fn        /**< tlb_flush()         */
+	#define K1B_TLB_INSTRUCTION 0 /**< Instruction TLB */
+	#define K1B_TLB_DATA        1 /**< Data TLB        */
 	/**@}*/
-
-/**@endcond*/
 
 	/**
 	 * @brief Length of Locked TLB (number of entries).
@@ -304,9 +287,34 @@
 	 */
 	extern void k1b_tlb_init(void);
 
+/**@}*/
+
+/*============================================================================*
+ * Exported Interface                                                         *
+ *============================================================================*/
+
 /**
  * @cond k1b
  */
+
+	/**
+	 * @brief Software-managed TLB.
+	 */
+	#define HAL_TLB_SOFTWARE
+
+	/**
+	 * @brief Provided Interface
+	 */
+	/**@{*/
+	#define __tlbe_st             /**< TLB Entry           */
+	#define __tlbe_vaddr_get_fn   /**< tlbe_vaddr_get()    */
+	#define __tlbe_paddr_get_fn   /**< tlbe_paddr_get()    */
+	#define __tlb_lookup_vaddr_fn /**< tlbe_lookup_vaddr() */
+	#define __tlb_lookup_paddr_fn /**< tlbe_lookup()       */
+	#define __tlb_write_fn        /**< tlb_write()         */
+	#define __tlb_inval_fn        /**< tlb_inval()         */
+	#define __tlb_flush_fn        /**< tlb_flush()         */
+	/**@}*/
 
 	/**
 	 * @brief Length of TLB (number of entries).
@@ -318,6 +326,14 @@
 	 * the JTLB, therefore this should not be @p K1B_TLB_SIZE.
 	 */
 	#define TLB_LENGTH K1B_JTLB_LENGTH
+
+	/**
+	 * @name TLB Types
+	 */
+	/**@{*/
+	#define TLB_INSTRUCTION K1B_TLB_INSTRUCTION /**< Instruction TLB */
+	#define TLB_DATA        K1B_TLB_DATA        /**< Data TLB        */
+	/**@}*/
 
 	/**
 	 * @see k1b_tlbe_vaddr_get().
@@ -338,36 +354,36 @@
 	/**
 	 * @see k1b_tlb_lookup_vaddr().
 	 */
-	static inline const struct tlbe *tlb_lookup_vaddr(int tlb, vaddr_t vaddr)
+	static inline const struct tlbe *tlb_lookup_vaddr(int tlb_type, vaddr_t vaddr)
 	{
-		UNUSED(tlb);
+		UNUSED(tlb_type);
 		return (k1b_tlb_lookup_vaddr(vaddr));
 	}
 
 	/**
 	 * @see k1b_tlb_lookup_paddr().
 	 */
-	static inline const struct tlbe *tlb_lookup_paddr(int tlb, paddr_t paddr)
+	static inline const struct tlbe *tlb_lookup_paddr(int tlb_type, paddr_t paddr)
 	{
-		UNUSED(tlb);
+		UNUSED(tlb_type);
 		return (k1b_tlb_lookup_paddr(paddr));
 	}
 
 	/**
 	 * @see k1b_tlb_write()
 	 */
-	static inline int tlb_write(int tlb, vaddr_t vaddr, paddr_t paddr)
+	static inline int tlb_write(int tlb_type, vaddr_t vaddr, paddr_t paddr)
 	{
-		UNUSED(tlb);
+		UNUSED(tlb_type);
 		return (k1b_tlb_write(vaddr, paddr, 12, 0, K1B_TLBE_PROT_RW));
 	}
 
 	/**
 	 * @see k1b_tlb_inval()
 	 */
-	static inline int tlb_inval(int tlb, vaddr_t vaddr)
+	static inline int tlb_inval(int tlb_type, vaddr_t vaddr)
 	{
-		UNUSED(tlb);
+		UNUSED(tlb_type);
 		return (k1b_tlb_inval(vaddr, 12, 0));
 	}
 
@@ -380,11 +396,5 @@
 	}
 
 /**@endcond*/
-
-/**@}*/
-
-/*============================================================================*
- * Exported Interface                                                         *
- *============================================================================*/
 
 #endif /* ARCH_CORE_K1B_TLB_H_ */

--- a/include/arch/core/or1k/tlb.h
+++ b/include/arch/core/or1k/tlb.h
@@ -38,6 +38,14 @@
 	#include <arch/core/or1k/mmu.h>
 
 	/**
+	 * @name TLB Types
+	 */
+	/**@{*/
+	#define OR1K_TLB_INSTRUCTION 0 /**< Instruction TLB */
+	#define OR1K_TLB_DATA        1 /**< Data TLB        */
+	/**@}*/
+
+	/**
 	 * @brief Length of architectural TLB (number of entries).
 	 */
 	#define OR1K_TLB_LENGTH 64
@@ -177,51 +185,43 @@
 	/**
 	 * @brief Lookups a TLB entry by virtual address.
 	 *
-	 * @param handler_num Handler number, identifies which TLB
-	 * type should be used.
-	 *
-	 * @param vaddr Target virtual address.
+	 * @param tlb_type Target TLB.
+	 * @param vaddr    Target virtual address.
 	 *
 	 * @returns Upon successful completion, a pointer to the TLB entry
 	 * that matches the virtual address @p vaddr is returned. If no
 	 * entry that meets this criteria is found, @p NULL is returned.
 	 */
-	EXTERN const struct tlbe *or1k_tlb_lookup_vaddr(int handler_num, vaddr_t vaddr);
+	EXTERN const struct tlbe *or1k_tlb_lookup_vaddr(int tlb_type, vaddr_t vaddr);
 
 	/**
 	 * @brief Lookups a TLB entry by physical address.
 	 *
-	 * @param handler_num Handler number, identifies which TLB
-	 * type should be used.
-	 *
-	 * @param paddr Target physical address.
+	 * @param tlb_type Target TLB.
+	 * @param paddr    Target physical address.
 	 *
 	 * @returns Upon successful completion, a pointer to the TLB entry
 	 * that matches the physical address @p paddr is returned. If no
 	 * entry that meets this criteria is found, @p NULL is returned.
 	 */
-	EXTERN const struct tlbe *or1k_tlb_lookup_paddr(int handler_num, paddr_t paddr);
+	EXTERN const struct tlbe *or1k_tlb_lookup_paddr(int tlb_type, paddr_t paddr);
 
 	/**
 	 * @brief Writes a TLB entry.
 	 *
-	 * @param handler_num Handler number, identifies which TLB
-	 * type should be used.
-	 *
-	 * @param vaddr  Target virtual address.
-	 * @param paddr  Target physical address.
+	 * @param tlb_type Target TLB.
+	 * @param vaddr    Target virtual address.
+	 * @param paddr    Target physical address.
 	 */
-	EXTERN int or1k_tlb_write(int handler_num, vaddr_t vaddr, paddr_t paddr);
+	EXTERN int or1k_tlb_write(int tlb_type, vaddr_t vaddr, paddr_t paddr);
 
 	/**
 	 * @brief Invalidates a TLB entry.
 	 *
-	 * @param handler_num Handler number, identifies which TLB
-	 * type should be used.
-	 *
-	 * @param vaddr Target virtual address.
+	 * @param tlb_type Target TLB.
+	 * @param vaddr    Target virtual address.
 	 */
-	EXTERN int or1k_tlb_inval(int handler_num, vaddr_t vaddr);
+	EXTERN int or1k_tlb_inval(int tlb_type, vaddr_t vaddr);
 
 	/**
 	 * @brief Flushes the TLB.
@@ -271,6 +271,14 @@
 	#define TLB_LENGTH OR1K_TLB_LENGTH
 
 	/**
+	 * @name TLB Types
+	 */
+	/**@{*/
+	#define TLB_INSTRUCTION OR1K_TLB_INSTRUCTION /**< Instruction TLB */
+	#define TLB_DATA        OR1K_TLB_DATA        /**< Data TLB        */
+	/**@}*/
+
+	/**
 	 * @see or1k_tlbe_vaddr_get().
 	 */
 	static inline vaddr_t tlbe_vaddr_get(const struct tlbe *tlbe)
@@ -289,33 +297,33 @@
 	/**
 	 * @see or1k_tlb_lookup_vaddr().
 	 */
-	static inline const struct tlbe *tlb_lookup_vaddr(int handler_num, vaddr_t vaddr)
+	static inline const struct tlbe *tlb_lookup_vaddr(int tlb_type, vaddr_t vaddr)
 	{
-		return (or1k_tlb_lookup_vaddr(handler_num, vaddr));
+		return (or1k_tlb_lookup_vaddr(tlb_type, vaddr));
 	}
 
 	/**
 	 * @see or1k_tlb_lookup_paddr().
 	 */
-	static inline const struct tlbe *tlb_lookup_paddr(int handler_num, paddr_t paddr)
+	static inline const struct tlbe *tlb_lookup_paddr(int tlb_type, paddr_t paddr)
 	{
-		return (or1k_tlb_lookup_paddr(handler_num, paddr));
+		return (or1k_tlb_lookup_paddr(tlb_type, paddr));
 	}
 
 	/**
 	 * @see or1k_tlb_write()
 	 */
-	static inline int tlb_write(int handler_num, vaddr_t vaddr, paddr_t paddr)
+	static inline int tlb_write(int tlb_type, vaddr_t vaddr, paddr_t paddr)
 	{
-		return (or1k_tlb_write(handler_num, vaddr, paddr));
+		return (or1k_tlb_write(tlb_type, vaddr, paddr));
 	}
 
 	/**
 	 * @see or1k_tlb_inval()
 	 */
-	static inline int tlb_inval(int handler_num, vaddr_t vaddr)
+	static inline int tlb_inval(int tlb_type, vaddr_t vaddr)
 	{
-		return (or1k_tlb_inval(handler_num, vaddr));
+		return (or1k_tlb_inval(tlb_type, vaddr));
 	}
 
 	/**

--- a/include/nanvix/hal/core.h
+++ b/include/nanvix/hal/core.h
@@ -39,6 +39,7 @@
 	#include <nanvix/hal/core/interrupt.h>
 	#include <nanvix/hal/core/mmu.h>
 	#include <nanvix/hal/core/spinlock.h>
+	#include <nanvix/hal/core/tlb.h>
 	#include <nanvix/hal/core/trap.h>
 	#include <nanvix/hal/core/upcall.h>
 	#include <nanvix/const.h>

--- a/include/nanvix/hal/core/tlb.h
+++ b/include/nanvix/hal/core/tlb.h
@@ -89,6 +89,20 @@
 
 	#include <nanvix/const.h>
 
+#if defined(HAL_TLB_HARDWARE)
+
+	/**
+	 * @name TLB Types
+	 */
+	/**@{*/
+	#define TLB_INSTRUCTION 0 /**< Instruction TLB */
+	#define TLB_DATA        1 /**< Data TLB        */
+	/**@}*/
+
+#endif
+
+
+
 	/**
 	 * @brief TLB entry.
 	 */
@@ -117,43 +131,43 @@
 	/**
 	 * @brief Lookups a TLB entry by virtual address.
 	 *
-	 * @param tlb   Target TLB (D-TLB or I-TLB).
-	 * @param vaddr Target virtual address.
+	 * @param tlb_type Target TLB (D-TLB or I-TLB).
+	 * @param vaddr    Target virtual address.
 	 *
 	 * @returns Upon successful completion, a pointer to the TLB entry
 	 * that matches the virtual address @p vaddr is returned. If no
 	 * TLB entry matches @p vaddr, @p NULL is returned instead.
 	 */
-	EXTERN const struct tlbe *tlb_lookup_vaddr(int tlb, vaddr_t vaddr);
+	EXTERN const struct tlbe *tlb_lookup_vaddr(int tlb_type, vaddr_t vaddr);
 
 	/**
 	 * @brief Lookups a TLB entry by physical address.
 	 *
-	 * @param tlb   Target TLB (D-TLB or I-TLB).
-	 * @param paddr Target physical address.
+	 * @param tlb_type Target TLB (D-TLB or I-TLB).
+	 * @param paddr    Target physical address.
 	 *
 	 * @returns Upon successful completion, a pointer to the TLB entry
 	 * that matches the physical address @p paddr is returned. If no
 	 * TLB entry matches @p paddr, @p NULL is returned instead.
 	 */
-	EXTERN const struct tlbe *tlb_lookup_paddr(int tlb, paddr_t paddr);
+	EXTERN const struct tlbe *tlb_lookup_paddr(int tlb_type, paddr_t paddr);
 
 	/**
 	 * @brief Encodes a virtual address into the TLB.
 	 *
-	 * @param tlb   Target TLB (D-TLB or I-TLB).
-	 * @param vaddr Target virtual address.
-	 * @param paddr Target physical address.
+	 * @param tlb_type Target TLB (D-TLB or I-TLB).
+	 * @param vaddr    Target virtual address.
+	 * @param paddr    Target physical address.
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
 #if !((defined(HAL_TLB_HARDWARE) && !defined(__tlb_write_fn)))
-	EXTERN int tlb_write(int tlb, vaddr_t vaddr, paddr_t paddr);
+	EXTERN int tlb_write(int tlb_type, vaddr_t vaddr, paddr_t paddr);
 #else
-	static inline int tlb_write(int tlb, vaddr_t vaddr, paddr_t paddr)
+	static inline int tlb_write(int tlb_type, vaddr_t vaddr, paddr_t paddr)
 	{
-		((void) tlb);
+		((void) tlb_type);
 		((void) vaddr);
 		((void) paddr);
 
@@ -164,18 +178,18 @@
 	/**
 	 * @brief Invalidates a virtual address in the TLB.
 	 *
-	 * @param tlb   Target TLB (D-TLB or I-TLB).
-	 * @param vaddr Target virtual address.
+	 * @param tlb_type Target TLB (D-TLB or I-TLB).
+	 * @param vaddr    Target virtual address.
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
 #if !((defined(HAL_TLB_HARDWARE) && !defined(__tlb_inval_fn)))
-	EXTERN int tlb_inval(int tlb, vaddr_t vaddr);
+	EXTERN int tlb_inval(int tlb_type, vaddr_t vaddr);
 #else
-	static inline int tlb_inval(int tlb, vaddr_t vaddr)
+	static inline int tlb_inval(int tlb_type, vaddr_t vaddr)
 	{
-		((void) tlb);
+		((void) tlb_type);
 		((void) vaddr);
 
 		return (0);

--- a/include/nanvix/hal/core/tlb.h
+++ b/include/nanvix/hal/core/tlb.h
@@ -97,6 +97,20 @@
 
 	#include <nanvix/const.h>
 
+	/**
+	 * @brief Casts something to a virtual address.
+	 *
+	 * @param x Something.
+	 */
+	#define VADDR(x) ((vaddr_t) (x))
+
+	/**
+	 * @brief Casts something to a physical address.
+	 *
+	 * @param x Something.
+	 */
+	#define PADDR(x) ((paddr_t) (x))
+
 #if defined(HAL_TLB_HARDWARE)
 
 	/**

--- a/include/nanvix/hal/core/tlb.h
+++ b/include/nanvix/hal/core/tlb.h
@@ -48,6 +48,14 @@
 	 */
 	#ifdef HAL_TLB_SOFTWARE
 
+		/* Constants. */
+		#ifndef TLB_INSTRUCTION
+		#error "TLB_INSTRUCTION not defined!"
+		#endif
+		#ifndef TLB_DATA
+		#error "TLB_DATA not defined!"
+		#endif
+
 		/* Types and Structures */
 		#ifndef __tlbe_st
 			#error "struct tlbe not defined?"

--- a/include/nanvix/hal/core/trap.h
+++ b/include/nanvix/hal/core/trap.h
@@ -157,13 +157,12 @@
 	 * @brief Handles a system call.
 	 */
 	EXTERN int do_syscall(
-		int arg0,
-		int arg1,
-		int arg2,
-		int arg3,
-		int arg4,
-		int arg5,
-		int syscall_nr);
+		unsigned arg0,
+		unsigned arg1,
+		unsigned arg2,
+		unsigned arg3,
+		unsigned arg4,
+		unsigned syscall_nr);
 
 /**@*/
 

--- a/src/hal/arch/core/k1b/hooks.S
+++ b/src/hal/arch/core/k1b/hooks.S
@@ -99,6 +99,14 @@ _do_syscall:
 		/* Save preserved registers. */
 		_do_prologue_slow
 		;;
+
+		/* mOS supports trap calls with 8 arguments, and thus the trap
+		 * call number is stored in the R7.  However, we support trap
+		 * calls only with 5 arguments, so we should fix the arguments
+		 * of the trap call here, by storing into the register R5 the
+		 * trap call number.
+		 */
+		copy $r5, $r7
 		;;
 
 		/*

--- a/src/hal/arch/core/k1b/hooks.S
+++ b/src/hal/arch/core/k1b/hooks.S
@@ -96,16 +96,9 @@ _do_syscall:
 
 	_do_syscall.continue:
 
-		/* Save system call context. */
-		add $sp = $sp, -K1B_DWORD_SIZE
+		/* Save preserved registers. */
+		_do_prologue_slow
 		;;
-		get $r8 = $ra
-		;;
-		copy $bp = $r7
-		;;
-		sw 0 [$sp] = $bp
-		;;
-		sw 4 [$sp] = $r8
 		;;
 
 		/*
@@ -118,14 +111,8 @@ _do_syscall:
 		redzone_free
 		;;
 
-		/* Restore system call context. */
-		lw $r8 = 4 [$sp]
-		;;
-		lw $bp = 0 [$sp]
-		;;
-		add $sp = $sp, K1B_DWORD_SIZE
-		;;
-		set $ra = $r8
+		/* Restore preserved registers. */
+		_do_epilogue_slow
 		;;
 
 	_do_syscall.out:

--- a/src/hal/arch/core/k1b/tlb.c
+++ b/src/hal/arch/core/k1b/tlb.c
@@ -165,7 +165,10 @@ PUBLIC const struct tlbe *k1b_tlb_lookup_vaddr(vaddr_t vaddr)
 
 		/* Found */
 		if (k1b_tlbe_vaddr_get(tlbe) == vaddr)
-			return (tlbe);
+		{
+			if (tlbe->status != K1B_TLBE_STATUS_INVALID)
+				return (tlbe);
+		}
 	}
 
 	/* Search in LTLB. */
@@ -175,7 +178,10 @@ PUBLIC const struct tlbe *k1b_tlb_lookup_vaddr(vaddr_t vaddr)
 
 		/* Found */
 		if (k1b_tlbe_vaddr_get(tlbe) == vaddr)
-			return (tlbe);
+		{
+			if (tlbe->status != K1B_TLBE_STATUS_INVALID)
+				return (tlbe);
+		}
 	}
 
 	return (NULL);
@@ -205,7 +211,10 @@ PUBLIC const struct tlbe *k1b_tlb_lookup_paddr(paddr_t paddr)
 
 		/* Found */
 		if (k1b_tlbe_paddr_get(tlbe) == paddr)
-			return (tlbe);
+		{
+			if (tlbe->status != K1B_TLBE_STATUS_INVALID)
+				return (tlbe);
+		}
 	}
 
 	/* Search in LTLB. */
@@ -215,7 +224,10 @@ PUBLIC const struct tlbe *k1b_tlb_lookup_paddr(paddr_t paddr)
 
 		/* Found */
 		if (k1b_tlbe_paddr_get(tlbe) == paddr)
-			return (tlbe);
+		{
+			if (tlbe->status != K1B_TLBE_STATUS_INVALID)
+				return (tlbe);
+		}
 	}
 
 	return (NULL);
@@ -264,7 +276,7 @@ PUBLIC int k1b_tlb_write(
 	/* Write to hardware TLB. */
 	if (mOS_mem_write_jtlb(_tlbe, way) != 0)
 	{
-		kprintf("[hal] failed to invalidate tlb %x", vaddr);
+		kprintf("[hal] failed to write tlb %x", vaddr);
 		return (-EAGAIN);
 	}
 

--- a/src/hal/arch/core/or1k/hooks.S
+++ b/src/hal/arch/core/or1k/hooks.S
@@ -138,7 +138,7 @@ _do_excp:
 
 	l.mfspr r3, r0, OR1K_SPR_EEAR_BASE
 	l.sw OR1K_EXCEPTION_EEAR(sp), r3
-	
+
 	l.mfspr r3, r0, OR1K_SPR_EPCR_BASE
 	l.sw OR1K_EXCEPTION_EPCR(sp), r3
 

--- a/src/hal/arch/core/or1k/mmu.c
+++ b/src/hal/arch/core/or1k/mmu.c
@@ -76,6 +76,7 @@ PRIVATE void or1k_do_tlb_fault(
 	const struct context *ctx
 )
 {
+	int tlb;           /* Target TLB.                     */
 	paddr_t paddr;     /* Physical address.               */
 	vaddr_t vaddr;     /* Faulting address.               */
 	struct pte *pte;   /* Working page table table entry. */
@@ -101,7 +102,9 @@ PRIVATE void or1k_do_tlb_fault(
 
 	/* Writing mapping to TLB. */
 	paddr = pte_frame_get(pte) << OR1K_PAGE_SHIFT;
-	if (or1k_tlb_write(excp->num, vaddr, paddr) < 0)
+	tlb = (excp->num == OR1K_EXCEPTION_ITLB_FAULT) ?
+		OR1K_TLB_INSTRUCTION : OR1K_TLB_DATA;
+	if (or1k_tlb_write(tlb, vaddr, paddr) < 0)
 		kpanic("[hal] cannot write to tlb");
 }
 

--- a/src/test/syscalls.c
+++ b/src/test/syscalls.c
@@ -36,13 +36,18 @@
  * @brief Magic Numbers.
  */
 /**@{*/
-#define SYSCALL_NR         1
-#define MAGIC0    0xBEEFCACE
-#define MAGIC1    0xC00010FF
-#define MAGIC2    0xCAFEBABE
-#define MAGIC3    0xCAFED00D
-#define MAGIC4    0x0D15EA5E
-#define MAGIC5    0xDEAD10CC
+#define SYSCALL0_NR          1
+#define SYSCALL1_NR          2
+#define SYSCALL2_NR          3
+#define SYSCALL3_NR          4
+#define SYSCALL4_NR          5
+#define SYSCALL5_NR          6
+#define MAGIC0       0xbeefcace
+#define MAGIC1       0xC00010FF
+#define MAGIC2       0xcafebabe
+#define MAGIC3       0xcafed00d
+#define MAGIC4       0x0d15ea5e
+#define MAGIC5       0xdead10cc
 /**@}*/
 
 /**
@@ -60,28 +65,31 @@
  * failure, a negative error code is returned instead.
  */
 PUBLIC int do_syscall(
-	int arg0,
-	int arg1,
-	int arg2,
-	int arg3,
-	int arg4,
-	int arg5,
-	int syscall_nr)
+	unsigned arg0,
+	unsigned arg1,
+	unsigned arg2,
+	unsigned arg3,
+	unsigned arg4,
+	unsigned syscall_nr)
 {
-	((void) arg0);
-	((void) arg1);
-	((void) arg2);
-	((void) arg3);
-	((void) arg4);
-	((void) arg5);
-	((void) syscall_nr);
 
 #if (TEST_TRAP_VERBOSE)
 	kprintf("syscall() nr=%x");
 	kprintf("syscall() arg0=%x arg1=%x", arg0, arg1);
 	kprintf("syscall() arg2=%x arg3=%x", arg2, arg3);
-	kprintf("syscall() arg4=%x arg5=%x", arg4, arg5);
+	kprintf("syscall() arg4=%x", arg4);
 #endif
+
+	if (syscall_nr >= SYSCALL1_NR)
+		KASSERT(arg0 == MAGIC0);
+	if (syscall_nr >= SYSCALL2_NR)
+		KASSERT(arg1 == MAGIC1);
+	if (syscall_nr >= SYSCALL3_NR)
+		KASSERT(arg2 == MAGIC2);
+	if (syscall_nr >= SYSCALL4_NR)
+		KASSERT(arg3 == MAGIC3);
+	if (syscall_nr >= SYSCALL5_NR)
+		KASSERT(arg4 == MAGIC4);
 
 	return (MAGIC5);
 }
@@ -90,13 +98,102 @@ PUBLIC int do_syscall(
  * API Tests                                                                  *
  *============================================================================*/
 
+/*----------------------------------------------------------------------------*
+ * Issue a Trap with No Arguments                                             *
+ *----------------------------------------------------------------------------*/
+
 /**
- * @brief API Test: Issue a Trap
+ * @brief API Test: Issue a Trap with No Arguments
  */
-PRIVATE void test_trap_issue(void)
+PRIVATE void test_trap_issue0(void)
+{
+	KASSERT(syscall0(
+		SYSCALL0_NR
+	  ) == MAGIC5
+	);
+}
+
+/*----------------------------------------------------------------------------*
+ * Issue a Trap with One Argument                                             *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief API Test: Issue a Trap with One Argument
+ */
+PRIVATE void test_trap_issue1(void)
+{
+	KASSERT(syscall1(
+		SYSCALL1_NR,
+		MAGIC0
+	  ) == MAGIC5
+	);
+}
+
+/*----------------------------------------------------------------------------*
+ * Issue a Trap with Two Arguments                                            *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief API Test: Issue a Trap with Two Arguments
+ */
+PRIVATE void test_trap_issue2(void)
+{
+	KASSERT(syscall2(
+		SYSCALL2_NR,
+		MAGIC0,
+		MAGIC1
+	  ) == MAGIC5
+	);
+}
+
+/*----------------------------------------------------------------------------*
+ * Issue a Trap with Three Arguments                                          *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief API Test: Issue a Trap with Three Arguments
+ */
+PRIVATE void test_trap_issue3(void)
+{
+	KASSERT(syscall3(
+		SYSCALL3_NR,
+		MAGIC0,
+		MAGIC1,
+		MAGIC2
+	  ) == MAGIC5
+	);
+}
+
+/*----------------------------------------------------------------------------*
+ * Issue a Trap with Four Arguments                                           *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief API Test: Issue a Trap with Four Arguments
+ */
+PRIVATE void test_trap_issue4(void)
+{
+	KASSERT(syscall4(
+		SYSCALL4_NR,
+		MAGIC0,
+		MAGIC1,
+		MAGIC2,
+		MAGIC3
+	  ) == MAGIC5
+	);
+}
+
+/*----------------------------------------------------------------------------*
+ * Issue a Trap with Five Arguments                                           *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief API Test: Issue a Trap with Five Arguments
+ */
+PRIVATE void test_trap_issue5(void)
 {
 	KASSERT(syscall5(
-		SYSCALL_NR,
+		SYSCALL5_NR,
 		MAGIC0,
 		MAGIC1,
 		MAGIC2,
@@ -106,17 +203,26 @@ PRIVATE void test_trap_issue(void)
 	);
 }
 
-/*============================================================================*
- * Test Driver                                                                *
- *============================================================================*/
+/*----------------------------------------------------------------------------*
+ * Test Driver Table                                                          *
+ *----------------------------------------------------------------------------*/
 
 /**
  * @brief Unit tests.
  */
 PRIVATE struct test trap_tests_api[] = {
-	{ test_trap_issue, "Issue a Trap" },
-	{ NULL,             NULL          },
+	{ test_trap_issue0, "issue a trap no arguments"    },
+	{ test_trap_issue1, "issue a trap one argument"    },
+	{ test_trap_issue2, "issue a trap two arguments"   },
+	{ test_trap_issue3, "issue a trap three arguments" },
+	{ test_trap_issue4, "issue a trap four arguments"  },
+	{ test_trap_issue5, "issue a trap five arguments"  },
+	{ NULL,             NULL                           },
 };
+
+/*============================================================================*
+ * Test Driver                                                                *
+ *============================================================================*/
 
 /**
  * The test_trap() function launches testing units on the trap


### PR DESCRIPTION
Description
----------------

Previously, whenever looking up an TLB entry, either by a physical or virtual address, we would return an TLB entry even if it was an invalid one. In this commit, I fix this bug.

Related Pull Requests
------------------------------

- [[hal] Casts for Virtual and Physical Address](https://github.com/nanvix/hal/pull/172)