### PR TITLE
[or1k-core] Bug Fix: Wrong Permissions in TLB Entry

### DIFF
--- a/src/hal/arch/core/or1k/tlb.c
+++ b/src/hal/arch/core/or1k/tlb.c
@@ -91,8 +91,8 @@ struct tlbe_value
  */
 PRIVATE int or1k_tlb_check_inst(vaddr_t vaddr)
 {
-	vaddr_t kcode; /* Kernel text start address. */
-	vaddr_t kdata; /* Kernel data start address. */
+	volatile vaddr_t kcode; /* Kernel text start address. */
+	volatile vaddr_t kdata; /* Kernel data start address. */
 
 	kcode = (vaddr_t)&KSTART_CODE;
 	kdata = (vaddr_t)&KSTART_DATA;
@@ -258,7 +258,7 @@ PUBLIC int or1k_tlb_write(int tlb_type, vaddr_t vaddr, paddr_t paddr)
 	unsigned idx;            /* TLB Index.         */
 	unsigned user;           /* User address flag. */
 	unsigned inst;           /* Instruction flag.  */
-	vaddr_t kcode;           /* Kernel start code. */
+	volatile vaddr_t kcode;  /* Kernel start code. */
 	int coreid;              /* Core ID.           */
 
 	coreid = or1k_core_get_id();


### PR DESCRIPTION
In issue #176, we are getting page fault due to wrong permissions on the `or1k_tlb_write` function. This behavior occurred because the `kcode` variable was wrong during the comparison and thus erroneously identified the address as kernel code rather than user.

To force the correct behavior, I've used the `volatile` keyword, so we can ensure that the value is on the stack and is retrieved correctly, without being used elsewhere and getting dirty.