### PR TITLE
[openrisc] Feature: OpenRISC MMIO

### DIFF
--- a/include/arch/cluster/i486.h
+++ b/include/arch/cluster/i486.h
@@ -54,7 +54,6 @@
 	#define CLUSTER_IS_MULTICORE  1 /**< Multicore Cluster */
 	#define CLUSTER_IS_IO         1 /**< I/O Cluster       */
 	#define CLUSTER_IS_COMPUTE    0 /**< Compute Cluster   */
-	#define CLUSTER_SUPPORTS_MMIO 0 /**< MMIO Support      */
 	/**@}*/
 
 /**@}*/

--- a/include/arch/cluster/k1b.h
+++ b/include/arch/cluster/k1b.h
@@ -59,7 +59,6 @@
 		#define CLUSTER_IS_IO      0 /**< I/O Cluster       */
 		#define CLUSTER_IS_COMPUTE 1 /**< Compute Cluster   */
 	#endif
-	#define CLUSTER_SUPPORTS_MMIO  0 /**< MMIO Support      */
 	/**@}*/
 
 /**@}*/

--- a/include/arch/cluster/or1k.h
+++ b/include/arch/cluster/or1k.h
@@ -50,7 +50,6 @@
 	#define CLUSTER_IS_MULTICORE  1 /**< Multicore Cluster */
 	#define CLUSTER_IS_IO         1 /**< I/O Cluster       */
 	#define CLUSTER_IS_COMPUTE    0 /**< Compute Cluster   */
-	#define CLUSTER_SUPPORTS_MMIO 0 /**< MMIO Support      */
 	/**@}*/
 
 /**@}*/

--- a/include/arch/cluster/or1k/memory.h
+++ b/include/arch/cluster/or1k/memory.h
@@ -132,7 +132,6 @@
 	#define _USTACK_ADDR OR1K_USTACK_ADDR /**< User Stack       */
 	#define _KBASE_VIRT  OR1K_KBASE_VIRT  /**< Kernel Base      */
 	#define _KPOOL_VIRT  OR1K_KPOOL_VIRT  /**< Kernel Page Pool */
-	#define _UART_ADDR   OR1K_UART_VIRT   /**< UART Device      */
 	/**@}*/
 
 	/**
@@ -142,6 +141,7 @@
 	#define _KBASE_PHYS OR1K_KBASE_PHYS /**< Kernel Base      */
 	#define _KPOOL_PHYS OR1K_KPOOL_PHYS /**< Kernel Page Pool */
 	#define _UBASE_PHYS OR1K_UBASE_PHYS /**< User Base        */
+	#define _UART_ADDR  OR1K_UART_PHYS  /**< UART Device      */
 	/**@}*/
 
 /**@endcond*/

--- a/include/arch/core/i486/mmu.h
+++ b/include/arch/core/i486/mmu.h
@@ -133,6 +133,7 @@
 	#define __pte_present_set_fn /**< pte_present_set() */
 	#define __pte_user_set_fn    /**< pte_user_set()    */
 	#define __pte_write_set_fn   /**< pte_write_set()   */
+	#define __mmu_is_enabled_fn  /**< mmu_is_enabled()  */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -580,6 +581,17 @@
 			return (NULL);
 
 		return (&pgtab[pte_idx_get(vaddr)]);
+	}
+
+	/**
+	 * @brief Checks if the MMU is enabled.
+	 *
+	 * @returns A non-zero value if the MMU is enabled, and
+	 * 0 otherwise.
+	 */
+	static inline int mmu_is_enabled(void)
+	{
+		return (1);
 	}
 
 #endif

--- a/include/arch/core/k1b/mmu.h
+++ b/include/arch/core/k1b/mmu.h
@@ -165,6 +165,7 @@
 	#define __pte_present_set_fn /**< pte_present_set() */
 	#define __pte_user_set_fn    /**< pte_user_set()    */
 	#define __pte_write_set_fn   /**< pte_write_set()   */
+	#define __mmu_is_enabled_fn  /**< mmu_is_enabled()  */
 	/**@}*/
 
 	/**
@@ -608,6 +609,17 @@
 			return (NULL);
 
 		return (&pgtab[pte_idx_get(vaddr)]);
+	}
+	
+	/**
+	 * @brief Checks if the MMU is enabled.
+	 *
+	 * @returns A non-zero value if the MMU is enabled, and
+	 * 0 otherwise.
+	 */
+	static inline int mmu_is_enabled(void)
+	{
+		return (1);
 	}
 
 /**@endcond**/

--- a/include/arch/core/or1k/mmu.h
+++ b/include/arch/core/or1k/mmu.h
@@ -188,6 +188,7 @@
 	#define __pte_present_set_fn /**< pte_present_set() */
 	#define __pte_user_set_fn    /**< pte_user_set()    */
 	#define __pte_write_set_fn   /**< pte_write_set()   */
+	#define __mmu_is_enabled_fn  /**< mmu_is_enabled()  */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -599,6 +600,17 @@
 			return (NULL);
 
 		return (&pgtab[pte_idx_get(vaddr)]);
+	}
+	
+	/**
+	 * @brief Checks if the MMU is enabled.
+	 *
+	 * @returns A non-zero value if the MMU is enabled, and
+	 * 0 otherwise.
+	 */
+	static inline int mmu_is_enabled(void)
+	{
+		return (or1k_mfspr(OR1K_SPR_SR) & (OR1K_SPR_SR_DME | OR1K_SPR_SR_IME));
 	}
 
 #endif /* _ASM_FILE_ */

--- a/include/arch/core/rv32i.h
+++ b/include/arch/core/rv32i.h
@@ -36,6 +36,7 @@
 
 	#include <arch/core/rv32i/cache.h>
 	#include <arch/core/rv32i/core.h>
+	#include <arch/core/rv32i/mmu.h>
 	#include <arch/core/rv32i/spinlock.h>
 
 	#define __NEED_CORE_TYPES

--- a/include/arch/core/rv32i/mmu.h
+++ b/include/arch/core/rv32i/mmu.h
@@ -22,35 +22,58 @@
  * SOFTWARE.
  */
 
-#ifndef CLUSTER_RISCV32_SMP_H_
-#define CLUSTER_RISCV32_SMP_H_
-
-	#ifndef __NEED_CLUSTER_RISCV32_SMP
-		#error "bad cluster configuration?"
-	#endif
-
-	/* Cluster Interface Implementation */
-	#include <arch/cluster/riscv32-smp/_riscv32-smp.h>
+#ifndef ARCH_RV32I_MMU_H_
+#define ARCH_RV32I_MMU_H_
 
 /**
- * @addtogroup riscv-cluster RISC-V 32-Bit Cluster
- * @ingroup clusters
+ * @addtogroup rv32i-core-mmu MMU
+ * @ingroup rv32i-core
  *
- * @brief RISC-V 32-Bit Cluster
+ * @brief Memory Management Unit
  */
 /**@{*/
 
-	#include <arch/cluster/riscv32-smp/cores.h>
+	/* Must comme first. */
+	#define __NEED_MEMORY_TYPES
 
-	/**
-	 * @name Provided Features
-	 */
-	/**@{*/
-	#define CLUSTER_IS_MULTICORE  1 /**< Multicore Cluster */
-	#define CLUSTER_IS_IO         1 /**< I/O Cluster       */
-	#define CLUSTER_IS_COMPUTE    0 /**< Compute Cluster   */
-	/**@}*/
+	#include <arch/core/rv32i/types.h>
+#ifndef _ASM_FILE_
+	#include <nanvix/klib.h>
+	#include <errno.h>
+#endif
 
 /**@}*/
 
-#endif /* CLUSTER_RISCV32_SMP_H_ */
+/*============================================================================*
+ * Exported Interface                                                         *
+ *============================================================================*/
+
+/**
+ * @cond rv32i
+ */
+
+	/**
+	 * @brief Exported Functions
+	 */
+	/**@{*/
+	#define __mmu_is_enabled_fn  /**< mmu_is_enabled()  */
+	/**@}*/
+
+#ifndef _ASM_FILE_
+
+	/**
+	 * @brief Checks if the MMU is enabled.
+	 *
+	 * @returns A non-zero value if the MMU is enabled, and
+	 * 0 otherwise.
+	 */
+	static inline int mmu_is_enabled(void)
+	{
+		return (1);
+	}
+
+#endif
+
+/**@endcond*/
+
+#endif /* ARCH_RV32I_MMU_H_ */

--- a/include/nanvix/hal/cluster/mmio.h
+++ b/include/nanvix/hal/cluster/mmio.h
@@ -31,37 +31,6 @@
 	#include <nanvix/const.h>
 
 /*============================================================================*
- * Interface Implementation Checking                                          *
- *============================================================================*/
-
-#ifdef __INTERFACE_CHECK
-
-	/* Constants */
-	#ifndef CLUSTER_SUPPORTS_MMIO
-	#error "does this cluster supports memory-mapped i/o devices?"
-	#endif
-
-	#if (CLUSTER_SUPPORTS_MMIO)
-
-		/* Functions*/
-		#ifndef __mmio_write8_fn
-		#error "mmio_write8() not defined?"
-		#endif
-		#ifndef __mmio_write8s_fn
-		#error "mmio_write8s() not defined?"
-		#endif
-		#ifndef __mmio_read8_fn
-		#error "mmio_read8() not defined?"
-		#endif
-		#ifndef __mmio_read8s_fn
-		#error "mmio_read8s() not defined?"
-		#endif
-
-	#endif
-
-#endif
-
-/*============================================================================*
  * MMIO Interface                                                             *
  *============================================================================*/
 
@@ -73,53 +42,23 @@
  */
 /**@{*/
 
-#if (CLUSTER_SUPPORTS_MMIO)
-
-	/**
-	 * @brief Writes an 8-bit value to a memory-mapped i/o device.
-	 *
-	 * @param vaddr Target virtual address.
-	 * @param value 8-bit value.
-	 *
-	 * @returns Upon successful completion, zero is returned. Upon
-	 * failure, a negative error code is returned instead.
-	 */
-	EXTERN int mmio_write8(vaddr_t vaddr, uint8_t value);
-
-	/**
-	 * @brief Writes an 8-bit string to a memory-mapped i/o device.
-	 *
-	 * @param vaddr Target virtual address.
-	 * @param str   8-bit string.
-	 *
-	 * @returns Upon successful completion, zero is returned. Upon
-	 * failure, a negative error code is returned instead.
-	 */
-	EXTERN int mmio_write8s(vaddt_t vaddr, const uint8_t *str);
-
-	/**
-	 * @brief Reads an 8-bit value from a memory-mapped i/o device.
-	 *
-	 * @param vaddr  Target virtual address.
-	 * @param valuep Target store location for 8-bit value.
-	 *
-	 * @returns Upon successful completion, zero is returned. Upon
-	 * failure, a negative error code is returned instead.
-	 */
-	EXTERN int mmio_read8(vaddr_t vaddr, uint8_t *valuep);
-
-	/**
-	 * @brief Reads an 8-bit string from a memory-mapped i/o device.
-	 *
-	 * @param vaddr Target virtual address.
-	 * @param strp  Target store location for 8-bit string.
-	 *
-	 * @returns Upon successful completion, zero is returned. Upon
-	 * failure, a negative error code is returned instead.
-	 */
-	EXTERN int mmio_read8s(vaddr_t vaddr, uint8_t **strp);
-
-#endif /* CLUSTER_SUPPORTS_MMIO */
+/**
+ * @brief Gets the equivalent address accordingly with
+ * the current state of the MMU.
+ *
+ * @param paddr Target virtual physical address.
+ *
+ * @returns If mmu is enabled, returns the equivalent
+ * virtual address, otherwise, returns the same physical
+ * address.
+ */
+static inline void* mmio_get(paddr_t paddr)
+{
+	if (mmu_is_enabled())
+		return (mmu_page_walk(paddr));
+	else
+		return ((void*)paddr);
+}
 
 /**@{*/
 

--- a/include/nanvix/hal/core/mmu.h
+++ b/include/nanvix/hal/core/mmu.h
@@ -149,6 +149,9 @@
 	#ifndef __pte_write_set_fn
 	#error "pte_write_set() not defined?"
 	#endif
+	#ifndef __mmu_is_enabled_fn
+	#error "mmu_is_enabled() not defined?"
+	#endif
 
 #endif
 
@@ -178,6 +181,12 @@
 	 * @brief Kernel page pool page table.
 	 */
 	EXTERN struct pte *kpool_pgtab;
+	
+	/**
+	 * @brief Searches for a page belonging to a 
+	 * given physical address.
+	 */
+	EXTERN void* mmu_page_walk(paddr_t paddr);
 
 /**@}*/
 

--- a/src/hal/core/mmu.c
+++ b/src/hal/core/mmu.c
@@ -1,0 +1,113 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/const.h>
+#include <nanvix/klib.h>
+#include <nanvix/hal/core/_core.h>
+#include <nanvix/hal/core/mmu.h>
+
+/**
+ * @brief Megabyte shift
+ */
+#define MEGABYTE_SHIFT 20
+
+/**
+ * @brief Page directory address offset.
+ */
+#define PGDIR_ADDR_OFFSET                   \
+	(((1UL << (VADDR_BIT - MEGABYTE_SHIFT)) \
+		>> (VADDR_BIT - PGTAB_SHIFT))       \
+		<< MEGABYTE_SHIFT)
+
+/**
+ * @brief Page directory last valid address.
+ */
+#define PGDIR_ADDR_END                           \
+	(((1UL << (VADDR_BIT - MEGABYTE_SHIFT))      \
+		- (PGDIR_ADDR_OFFSET >> MEGABYTE_SHIFT)) \
+		<< MEGABYTE_SHIFT)
+
+/**
+ * @brief Page table last valid address.
+ */
+#define PGTAB_ADDR_END ((PGDIR_ADDR_OFFSET) - (PAGE_SIZE))
+
+/**
+ * @brief Searches for a page belonging to a given physical
+ * address.
+ *
+ * The mmu_page_walk function does a page walk in the system
+ * and returns the virtual address of the page belonging the
+ * given physical address.
+ *
+ * @param paddr Physical address.
+ * @return Returns the virtual address of the page, if not found,
+ * null.
+ *
+ * @author Davidson Francis
+ */
+PUBLIC void* mmu_page_walk(paddr_t paddr)
+{
+	paddr_t paddr_aligned; /* Physical address aligned.       */
+	vaddr_t vaddr_pgdir;   /* Page dir loop index.            */
+	vaddr_t vaddr_pgtab;   /* Page tab loop index.            */
+	vaddr_t vaddr;         /* Virtual address found.          */
+
+	struct pte *pte;       /* Working page table table entry. */
+	struct pde *pde;       /* Working page directory entry.   */
+	struct pte *pgtab;     /* Working page table.             */
+
+	vaddr = 0;
+	paddr_aligned = (paddr & PAGE_MASK);
+
+	for (vaddr_pgdir = 0; vaddr_pgdir < PGDIR_ADDR_END;
+		vaddr_pgdir += PGDIR_ADDR_OFFSET)
+	{
+		pde = pde_get(root_pgdir, vaddr_pgdir);
+		if (!pde_is_present(pde))
+			continue;
+
+		pgtab = (struct pte *)(pde_frame_get(pde) << OR1K_PAGE_SHIFT);
+		
+		for (vaddr_pgtab = 0; vaddr_pgtab < PGTAB_ADDR_END;
+			vaddr_pgtab += PAGE_SIZE)
+		{
+			pte = pte_get(pgtab, vaddr_pgdir + vaddr_pgtab);
+			if (!pte_is_present(pte))
+				continue;
+
+			if ( (pte_frame_get(pte) << PAGE_SHIFT) == paddr_aligned )
+			{
+				vaddr = vaddr_pgdir + vaddr_pgtab;
+				goto out;
+			}
+		}
+	}
+
+out:
+	if (!vaddr)
+		return (NULL);
+	else
+		return (void*)(vaddr + (paddr - paddr_aligned));
+}

--- a/src/hal/core/mmu.c
+++ b/src/hal/core/mmu.c
@@ -88,7 +88,7 @@ PUBLIC void* mmu_page_walk(paddr_t paddr)
 		if (!pde_is_present(pde))
 			continue;
 
-		pgtab = (struct pte *)(pde_frame_get(pde) << OR1K_PAGE_SHIFT);
+		pgtab = (struct pte *)(pde_frame_get(pde) << PAGE_SHIFT);
 		
 		for (vaddr_pgtab = 0; vaddr_pgtab < PGTAB_ADDR_END;
 			vaddr_pgtab += PAGE_SIZE)

--- a/src/hal/stdout/8250.c
+++ b/src/hal/stdout/8250.c
@@ -23,12 +23,8 @@
  */
 
 #include <arch/stdout/8250.h>
+#include <nanvix/hal/cluster/mmio.h>
 #include <nanvix/const.h>
-
-/**
- * @brief uart8250 memory.
- */
-PRIVATE uint8_t *uart8250 = (uint8_t*)UART_ADDR;
 
 /**
  * @brief Flag that indicates if the device was initialized.
@@ -41,6 +37,7 @@ PRIVATE int uart8250_initialized = 0;
  */
 PUBLIC void uart8250_write(const char *buf, size_t n)
 {
+	uint8_t *uart8250;
 	size_t counter;
 	counter = 0;
 
@@ -50,6 +47,9 @@ PUBLIC void uart8250_write(const char *buf, size_t n)
 	 */
 	if (!uart8250_initialized)
 		return;
+
+	/* Get address of uart. */
+	uart8250 = mmio_get(UART_ADDR);
 
 	while (n)
 	{
@@ -69,7 +69,11 @@ PUBLIC void uart8250_write(const char *buf, size_t n)
  */
 PUBLIC void uart8250_init(void)
 {
+	uint8_t *uart8250;
 	uint16_t divisor;
+
+	/* Get address of uart. */
+	uart8250 = mmio_get(UART_ADDR);
 
 	/* Calculate and set divisor. */
 	divisor = UART_CLOCK_SIGNAL / (UART_BAUD << 4);


### PR DESCRIPTION
Description
---------------

Although this PR is intended to cover the MMIO interface in OpenRISC, it also changes the HAL MMIO interface, since my last talk to @ppenna, this simplified version requires a minimal change in the other targets and it's generic enough to fit in the HAL.

Note: it's up to the other targets to implement the required function `mmu_is_enabled()`, which justifies the Travis CI building errors (for x86 and riscv)..

Related Issues
--------------------

[[hal] Simpler MMIO Interface](https://github.com/nanvix/hal/issues/236)
[[hal] Page Walk](https://github.com/nanvix/hal/issues/237)
[[openrisc-qemu] Freezing While Trying to Write into Serial Device](https://github.com/nanvix/hal/issues/116)