### PR TITLE
[hal] Auto Mask/Unmask Interrupts

### DIFF
--- a/src/hal/core/interrupt.c
+++ b/src/hal/core/interrupt.c
@@ -67,6 +67,8 @@ PUBLIC int interrupt_register(int num, interrupt_handler_t handler)
 	dcache_invalidate();
 	interrupt_set_handler(num, handler);
 
+	interrupt_unmask(num);
+
 	kprintf("[hal] interrupt handler registered for irq %d", num);
 
 	return (0);
@@ -91,6 +93,8 @@ PUBLIC int interrupt_unregister(int num)
 	interrupts[num].handled = FALSE;
 	dcache_invalidate();
 	interrupt_set_handler(num, default_handler);
+
+	interrupt_mask(num);
 
 	kprintf("[hal] interrupt handler unregistered for irq %d", num);
 


### PR DESCRIPTION
Description
----------------

Previously, after registering/unregistering an interrupt handler for a given interrupt, the interrupt would need to be masked/unmasked by explicitly calling either `interrupt_mask()` or `interrupt_unmask()`. In this commit, I make things more natural: the interrupt is automatically masked/unmasked when a handler is registered/unregistered for it.

Related Issues
---------------------

- [[hal] Auto Mask/Unmask Interrupts](https://github.com/nanvix/hal/issues/235)