### PR TITLE
[hal] Track Spurious Interrupts

### DIFF
--- a/include/nanvix/hal/core/interrupt.h
+++ b/include/nanvix/hal/core/interrupt.h
@@ -89,6 +89,15 @@
 	#define INTERRUPTS_NUM _INTERRUPTS_NUM
 
 	/**
+	 * @brief Threshold for spurious interrupts.
+	 *
+	 * INTERRUPT_SPURIOUS_THRESHOLD states the number of spurious
+	 * interrupts that we are willing to get, before enter in verbose
+	 * mode.
+	 */
+	#define INTERRUPT_SPURIOUS_THRESHOLD 100
+
+	/**
 	 * @brief Hardware interrupt handler.
 	 */
 	typedef void (*interrupt_handler_t)(int);

--- a/src/hal/core/interrupt.c
+++ b/src/hal/core/interrupt.c
@@ -35,6 +35,12 @@ PRIVATE struct
 	int handled; /**< Handled? */
 } interrupts[INTERRUPTS_NUM];
 
+
+/**
+ * @brief Number of spurious interrupts.
+ */
+PRIVATE unsigned spurious = 0;
+
 /**
  * @brief Default hardware interrupt handler.
  *
@@ -43,6 +49,10 @@ PRIVATE struct
 PRIVATE void default_handler(int num)
 {
 	UNUSED(num);
+
+	/* Too many spurious interrupts. */
+	if (spurious >= INTERRUPT_SPURIOUS_THRESHOLD)
+		kprintf("[hal] spurious interrupt %d", num);
 
 	noop();
 }

--- a/src/hal/core/interrupt.c
+++ b/src/hal/core/interrupt.c
@@ -67,6 +67,8 @@ PUBLIC int interrupt_register(int num, interrupt_handler_t handler)
 	dcache_invalidate();
 	interrupt_set_handler(num, handler);
 
+	interrupt_unmask(num);
+
 	kprintf("[hal] interrupt handler registered for irq %d", num);
 
 	return (0);
@@ -91,6 +93,8 @@ PUBLIC int interrupt_unregister(int num)
 	interrupts[num].handled = FALSE;
 	dcache_invalidate();
 	interrupt_set_handler(num, default_handler);
+
+	interrupt_mask(num);
 
 	kprintf("[hal] interrupt handler unregistered for irq %d", num);
 


### PR DESCRIPTION
Description
---------------
A lot of spurious interrupts may suggest that the software is buggy. In this commit, I introduce a simple mechanism that keeps track of the number of spurious interrupts that were are getting and, if this number grows to much we pedantically output warning messages.

Related Issues
---------------------

- [[hal] Keep Track of Spurious Interrupts](https://github.com/nanvix/hal/issues/238)

Pull Request Dependency List
-----------------------------------------

- [[hal] Auto Mask/Unmask Interrupts](https://github.com/nanvix/hal/pull/239)