### PR TITLE
[hal] Clock Timer Reset

### DIFF
--- a/include/arch/core/i486/8253.h
+++ b/include/arch/core/i486/8253.h
@@ -46,7 +46,7 @@
 	 * @brief Oscillator frequency (in Hz)
 	 */
 	#define PIT_FREQUENCY 1193182
-	
+
 	/**
 	 * @name Registers
 	 */
@@ -56,21 +56,54 @@
 	/**@}*/
 
 	/**
-	 * @brief Initializes the clock driver in the i486 architecture.
+	 * @brief Initializes the clock device.
 	 *
 	 * @param freq Target frequency for the clock device.
 	 */
 	EXTERN void i486_clock_init(unsigned freq);
 
 	/**
-	 * @see i486_clock_init()
+	 * @brief Resets the clock device.
+	 */
+	static inline void i486_clock_reset(void)
+	{
+	}
+
+/**@}*/
+
+/*============================================================================*
+ * Exported Interface                                                         *
+ *============================================================================*/
+
+/**
+ * @cond i486
+ */
+
+	/**
+	 * @name Exported functions
+	 */
+	/**@{*/
+	#define __clock_init_fn  /**< clock_init(   */
+	#define __clock_reset_fn /**< clock_reset() */
+	/**@}*/
+
+	/**
+	 * @see i486_clock_init().
 	 */
 	static inline void clock_init(unsigned freq)
 	{
 		i486_clock_init(freq);
 	}
 
-/**@}*/
+	/**
+	 * @see i486_clock_reset().
+	 */
+	static inline void clock_reset(void)
+	{
+		i486_clock_reset();
+	}
+
+/**@endcond*/
 
 #endif /* ARCH_I486_8253_H_ */
 

--- a/include/arch/core/k1b/clock.h
+++ b/include/arch/core/k1b/clock.h
@@ -32,13 +32,20 @@
  * @brief Programmable Timer Interface
  */
 /**@{*/
-	
+
 	/**
 	 * @brief Initializes the clock driver in the k1b architecture.
 	 *
 	 * @param freq Target frequency for the clock device.
 	 */
 	extern void k1b_clock_init(unsigned freq);
+
+	/**
+	 * @brief Resets the clock device.
+	 */
+	static inline void k1b_clock_reset(void)
+	{
+	}
 
 /**@}*/
 
@@ -51,10 +58,11 @@
  */
 
 	/**
-	 * @name Provided Interface
+	 * @name Exported Functions
 	 */
 	/**@{*/
-	#define __clock_init_fn /**< clock_init() */
+	#define __clock_init_fn  /**< clock_init()  */
+	#define __clock_reset_fn /**< clock_reset() */
 	/**@}*/
 
 	/**
@@ -63,6 +71,14 @@
 	static inline void clock_init(unsigned freq)
 	{
 		k1b_clock_init(freq);
+	}
+
+	/**
+	 * @see k1b_clock_reset().
+	 */
+	static inline void clock_reset(void)
+	{
+		k1b_clock_reset();
 	}
 
 /**@endcond*/

--- a/include/arch/core/mor1kx/clock.h
+++ b/include/arch/core/mor1kx/clock.h
@@ -48,9 +48,9 @@
 	EXTERN void or1k_clock_init(unsigned freq);
 
 	/**
-	 * @brief ACKs the clock interrupt and adjusts the timer again.
+	 * @brief Resets the clock device.
 	 */
-	EXTERN void or1k_clock_ack(void);
+	EXTERN void or1k_clock_reset(void);
 
 /**@}*/
 
@@ -59,14 +59,15 @@
  *============================================================================*/
 
 /**
- * @cond or1k
+ * @cond mor1kx
  */
 
 	/**
-	 * @name Provided Interface
+	 * @name Exported Functions
 	 */
 	/**@{*/
-	#define __clock_init_fn /**< clock_init() */
+	#define __clock_init_fn  /**< clock_init()  */
+	#define __clock_reset_fn /**< clock_reset() */
 	/**@}*/
 
 	/**
@@ -75,6 +76,14 @@
 	static inline void clock_init(unsigned freq)
 	{
 		or1k_clock_init(freq);
+	}
+
+	/**
+	 * @see or1k_clock_reset().
+	 */
+	static inline void clock_reset(void)
+	{
+		or1k_clock_reset();
 	}
 
 /**@endcond*/

--- a/include/arch/core/mor1kx/clock.h
+++ b/include/arch/core/mor1kx/clock.h
@@ -70,11 +70,6 @@
 	/**@}*/
 
 	/**
-	 * @brief Estimated CPU frequency (in Hz)
-	 */
-	#define CPU_FREQUENCY OR1K_CPU_FREQUENCY
-
-	/**
 	 * @see or1k_clock_init().
 	 */
 	static inline void clock_init(unsigned freq)

--- a/include/arch/core/or1k/clock.h
+++ b/include/arch/core/or1k/clock.h
@@ -48,9 +48,9 @@
 	EXTERN void or1k_clock_init(unsigned freq);
 
 	/**
-	 * @brief ACKs the clock interrupt and adjusts the timer again.
+	 * @brief Resets the clock device.
 	 */
-	EXTERN void or1k_clock_ack(void);
+	EXTERN void or1k_clock_reset(void);
 
 /**@}*/
 
@@ -63,10 +63,11 @@
  */
 
 	/**
-	 * @name Provided Interface
+	 * @name Exported Functions
 	 */
 	/**@{*/
-	#define __clock_init_fn /**< clock_init() */
+	#define __clock_init_fn  /**< clock_init()  */
+	#define __clock_reset_fn /**< clock_reset() */
 	/**@}*/
 
 	/**
@@ -75,6 +76,14 @@
 	static inline void clock_init(unsigned freq)
 	{
 		or1k_clock_init(freq);
+	}
+
+	/**
+	 * @see or1k_clock_reset().
+	 */
+	static inline void clock_reset(void)
+	{
+		or1k_clock_reset();
 	}
 
 /**@endcond*/

--- a/include/arch/core/or1k/clock.h
+++ b/include/arch/core/or1k/clock.h
@@ -70,11 +70,6 @@
 	/**@}*/
 
 	/**
-	 * @brief Estimated CPU frequency (in Hz)
-	 */
-	#define CPU_FREQUENCY OR1K_CPU_FREQUENCY
-
-	/**
 	 * @see or1k_clock_init().
 	 */
 	static inline void clock_init(unsigned freq)

--- a/include/nanvix/hal/core/clock.h
+++ b/include/nanvix/hal/core/clock.h
@@ -28,6 +28,8 @@
 	/* Core Interface Implementation */
 	#include <nanvix/hal/core/_core.h>
 
+	#include <nanvix/const.h>
+
 /*============================================================================*
  * Interface Implementation Checking                                          *
  *============================================================================*/
@@ -42,6 +44,9 @@
 	/* Functions */
 	#ifndef __clock_init_fn
 	#error "clock_init() not defined?"
+	#endif
+	#ifndef __clock_reset_fn
+	#error "clock_reset() not defined?"
 	#endif
 
 #endif
@@ -58,14 +63,17 @@
  */
 /**@{*/
 
-	#include <nanvix/const.h>
-
 	/**
-	 * @brief Initializes the hardware dependent clock driver.
+	 * @brief Initializes the clock device
 	 *
 	 * @param freq Frequency for the clock device.
 	 */
 	EXTERN void clock_init(unsigned freq);
+
+	/**
+	 * @brief Resets the timer of the clock device.
+	 */
+	EXTERN void clock_reset(void);
 
 /**@}*/
 

--- a/include/nanvix/hal/core/interrupt.h
+++ b/include/nanvix/hal/core/interrupt.h
@@ -89,6 +89,15 @@
 	#define INTERRUPTS_NUM _INTERRUPTS_NUM
 
 	/**
+	 * @brief Threshold for spurious interrupts.
+	 *
+	 * INTERRUPT_SPURIOUS_THRESHOLD states the number of spurious
+	 * interrupts that we are willing to get, before enter in verbose
+	 * mode.
+	 */
+	#define INTERRUPT_SPURIOUS_THRESHOLD 100
+
+	/**
 	 * @brief Hardware interrupt handler.
 	 */
 	typedef void (*interrupt_handler_t)(int);

--- a/src/hal/arch/core/or1k/clock.c
+++ b/src/hal/arch/core/or1k/clock.c
@@ -28,9 +28,10 @@
 #include <arch/core/or1k/core.h>
 
 /**
- * ACKs the clock interrupt and adjusts the timer again.
+ * The or1k_clock_reset() function acknoledges the clock interrupt and
+ * resets the clock counter.
  */
-PUBLIC void or1k_clock_ack(void)
+PUBLIC void or1k_clock_reset(void)
 {
 	/* Ack. */
 	or1k_mtspr(OR1K_SPR_TTMR, OR1K_SPR_TTMR_DI);

--- a/src/hal/arch/core/or1k/clock.c
+++ b/src/hal/arch/core/or1k/clock.c
@@ -56,7 +56,7 @@ PUBLIC void or1k_clock_init(unsigned freq)
 	UNUSED(freq);
 
 	upr = or1k_mfspr(OR1K_SPR_UPR);
-	if ( !(upr & OR1K_SPR_UPR_TTP) )
+	if (!(upr & OR1K_SPR_UPR_TTP))
 		while (1);
 
 	/* Clock rate. */

--- a/src/hal/arch/core/or1k/hwint.c
+++ b/src/hal/arch/core/or1k/hwint.c
@@ -86,9 +86,6 @@ PUBLIC void or1k_do_hwint(int num, const struct context *ctx)
 	 */
 	if (num == OR1K_INT_CLOCK)
 	{
-		/* Acknowledge and reset. */
-		or1k_clock_reset();
-
 		/* Nothing to do. */
 		if (or1k_handlers[num] == NULL)
 			return;

--- a/src/hal/arch/core/or1k/hwint.c
+++ b/src/hal/arch/core/or1k/hwint.c
@@ -86,8 +86,8 @@ PUBLIC void or1k_do_hwint(int num, const struct context *ctx)
 	 */
 	if (num == OR1K_INT_CLOCK)
 	{
-		/* ack. */
-		or1k_clock_ack();
+		/* Acknowledge and reset. */
+		or1k_clock_reset();
 
 		/* Nothing to do. */
 		if (or1k_handlers[num] == NULL)

--- a/src/hal/core/interrupt.c
+++ b/src/hal/core/interrupt.c
@@ -35,6 +35,12 @@ PRIVATE struct
 	int handled; /**< Handled? */
 } interrupts[INTERRUPTS_NUM];
 
+
+/**
+ * @brief Number of spurious interrupts.
+ */
+PRIVATE unsigned spurious = 0;
+
 /**
  * @brief Default hardware interrupt handler.
  *
@@ -43,6 +49,10 @@ PRIVATE struct
 PRIVATE void default_handler(int num)
 {
 	UNUSED(num);
+
+	/* Too many spurious interrupts. */
+	if (spurious >= INTERRUPT_SPURIOUS_THRESHOLD)
+		kprintf("[hal] spurious interrupt %d", num);
 
 	noop();
 }

--- a/src/hal/core/interrupt.c
+++ b/src/hal/core/interrupt.c
@@ -67,6 +67,8 @@ PUBLIC int interrupt_register(int num, interrupt_handler_t handler)
 	dcache_invalidate();
 	interrupt_set_handler(num, handler);
 
+	interrupt_unmask(num);
+
 	kprintf("[hal] interrupt handler registered for irq %d", num);
 
 	return (0);
@@ -91,6 +93,8 @@ PUBLIC int interrupt_unregister(int num)
 	interrupts[num].handled = FALSE;
 	dcache_invalidate();
 	interrupt_set_handler(num, default_handler);
+
+	interrupt_mask(num);
 
 	kprintf("[hal] interrupt handler unregistered for irq %d", num);
 


### PR DESCRIPTION
Description
---------------

In some architectures, such as OpenRISC, the counter of the integrated clock device should be explicitly reset at each clock interrupt, so that a next interrupt will follow.

In this Pull Request, I introduce the `clock_reset()` operation to the Clock Interface.

Related Issues
---------------------

- [[hal] Clock Timer Reset](https://github.com/nanvix/hal/issues/241)

Pull Request Dependency List
-----------------------------------------

- [[hal] Auto Mask/Unmask Interrupts](https://github.com/nanvix/hal/pull/239)
- [[hal] Track Spurious Interrupts](https://github.com/nanvix/hal/pull/240)