### PR TITLE
[hal] Use One Slave Core in Unit tests

### DIFF
--- a/src/test/core.c
+++ b/src/test/core.c
@@ -39,7 +39,7 @@
 /**
  * @brief API Test: Number of cores started.
  */
-PRIVATE int cores_started = 1;
+PRIVATE int cores_started = 0;
 
 /**
  * @brief API Test: Spinlock for number of cores.
@@ -109,20 +109,23 @@ PRIVATE void test_core_start_slave(void)
 	for (int i = 0; i < CORES_NUM; i++)
 	{
 		if (i != COREID_MASTER)
+		{
 			core_start(i, test_core_slave_entry);
+			break;
+		}
 	}
 
 	/**
-	 * Wait indefinitely for all cores start.
+	 * Wait indefinitely for the slave start.
 	 *
-	 * @note: If for some reason not all cores were started,
+	 * @note: If for some reason the slave core not start,
 	 * the master core will hang forever.
 	 */
 	while (TRUE)
 	{
 		dcache_invalidate();
 
-		if (cores_started == CORES_NUM)
+		if (cores_started == 1)
 			break;
 	}
 }


### PR DESCRIPTION
Description
---------------

In the unit test introduced in a870ec1, the test makes use of all slave cores available. However, this test is primarily intended for test only one core to make sure if the communication between master and slave works. Tests that makes use of multiple cores will be introduced later.

Related Issues
---------------------

- [[hal][test] Unit Tests for Core Interface](https://github.com/nanvix/hal/issues/2)