### PR TITLE
[hal][lib] Unreachable Kernel Builtin Function

### DIFF
--- a/include/nanvix/const.h
+++ b/include/nanvix/const.h
@@ -81,6 +81,12 @@
 	#define PACK __attribute__((packed))
 
 	/**
+	 * @brief Makes code unreachable.
+	 */
+	#define UNREACHABLE() \
+		{ while(TRUE) ; __builtin_unreachable(); }
+
+	/**
 	 * @name Logical Constants
 	 */
 	/**@{*/


### PR DESCRIPTION
Description
----------------

In this commit, I introduce the `UNREACHABLE()` kernel builtin, which signals the compiler that the code that follows is never reached, thereby enabling optimizations.

Related Issues
---------------------

- [[hal][lib] C Compiler Extensions](https://github.com/nanvix/hal/issues/263)