### PR TITLE
[hal][lib] C Compiler Extensions

### DIFF
--- a/include/nanvix/cc.h
+++ b/include/nanvix/cc.h
@@ -1,0 +1,118 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_CC_H_
+#define NANVIX_CC_H_
+
+/**
+ * @addtogroup kernel-constants-cc C Compiler Extensions
+ * @ingroup kernel-consts
+ */
+/**@{*/
+
+/*============================================================================*
+ * Aliases                                                                    *
+ *============================================================================*/
+
+	/**
+	 * @name Aliases for Standard C Extensions
+	 */
+	/**@{*/
+	#define inline __inline__     /**< Inline Function */
+	#define asm    __asm__        /**< Inline Assembly */
+	#define volatile __volatile__ /**< Volatile Symbol */
+	/**@}*/
+
+/*============================================================================*
+ * Function Attributes                                                        *
+ *============================================================================*/
+
+	/**
+	 * @brief Casts a function with no return.
+	 */
+	#define NORETURN __attribute__((noreturn))
+
+	/**
+	 * @brief Places object in a binary section.
+	 *
+	 * @param x Target binary section.
+	 */
+	#define SECTION(x) __attribute__((section(x)))
+
+	/**
+	 * @brief Makes a symbol overwritable.
+	 */
+	#define OVERRIDE __attribute__((weak))
+
+/*============================================================================*
+ * Type Attributes                                                            *
+ *============================================================================*/
+
+	/**
+	 * @brief Aligns an object at a boundary.
+	 *
+	 * @param x Boundary.
+	 */
+	#define ALIGN(x) __attribute__((aligned(x)))
+
+	/**
+	 * @brief Packs a structure
+	 *
+	 * @param x Boundary.
+	 */
+	#define PACK __attribute__((packed))
+
+/*============================================================================*
+ * Builtin Functions                                                          *
+ *============================================================================*/
+
+	/**
+	 * @brief Makes code unreachable.
+	 */
+	#define UNREACHABLE() \
+		{ while(TRUE) ; __builtin_unreachable(); }
+
+	/**
+	 * @brief Declares something to be unused.
+	 *
+	 * @param x Thing.
+	 */
+	#define UNUSED(x) ((void) (x))
+
+	/**
+	 * @brief Hints for branch condition.
+	 *
+	 * @param expr Target expression.
+	 * @param val  Excepted logic value (one or zero).
+	 */
+	#define EXPECT(expr, val) __builtin_expect(expr, val)
+
+	/**
+	 * @brief No operation.
+	 */
+	#define noop() __asm__ __volatile__ ("":::"memory")
+
+/**@}*/
+
+#endif

--- a/include/nanvix/const.h
+++ b/include/nanvix/const.h
@@ -35,6 +35,8 @@
  */
 /**@{*/
 
+	#include <nanvix/cc.h>
+
 	/**
 	 * @name Scope Constants
 	 */
@@ -43,48 +45,6 @@
 	#define PRIVATE static /**< File scope.        */
 	#define EXTERN extern  /**< Defined elsewhere. */
 	/**@}*/
-
-	/**
-	 * @brief Places object in a binary section.
-	 *
-	 * @param x Target binary section.
-	 */
-	#define SECTION(x) __attribute__((section(x)))
-
-	/**
-	 * @brief Overrides a symbol.
-	 */
-	#define OVERRIDE __attribute__((weak))
-
-	/**
-	 * @brief Casts an inline function.
-	 */
-	#define INLINE __atribute__((inline))
-
-	/**
-	 * @brief Casts a function  with no return.
-	 */
-	#define NORETURN __attribute__((noreturn))
-
-	/**
-	 * @brief Aligns an object at a boundary.
-	 *
-	 * @param x Boundary.
-	 */
-	#define ALIGN(x) __attribute__((aligned(x)))
-
-	/**
-	 * @brief Packs a structure
-	 *
-	 * @param x Boundary.
-	 */
-	#define PACK __attribute__((packed))
-
-	/**
-	 * @brief Makes code unreachable.
-	 */
-	#define UNREACHABLE() \
-		{ while(TRUE) ; __builtin_unreachable(); }
 
 	/**
 	 * @name Logical Constants

--- a/include/nanvix/const.h
+++ b/include/nanvix/const.h
@@ -81,6 +81,12 @@
 	#define PACK __attribute__((packed))
 
 	/**
+	 * @brief Makes code unreachable.
+	 */
+	#define UNREACHABLE() \
+		{ while(TRUE) ; __builtin_unreachable(); }
+
+	/**
 	 * @name Logical Constants
 	 */
 	/**@{*/

--- a/include/nanvix/klib.h
+++ b/include/nanvix/klib.h
@@ -192,18 +192,6 @@
 	#define KASSERT(x) kassert(x, "kassert() failed")
 
 	/**
-	 * @brief Declares something to be unused.
-	 *
-	 * @param x Thing.
-	 */
-	#define UNUSED(x) ((void) (x))
-
-	/**
-	 * @brief No operation.
-	 */
-	#define noop() __asm__ __volatile__ ("":::"memory")
-
-	/**
 	 * @brief Asserts if a number is within a range.
 	 *
 	 * @param x Number.


### PR DESCRIPTION
Description
----------------

In this commit, I introduce a header for the following C Compiler extensions:

**Keyword Aliases**

- `inline`: inline function
- `asm`: inline assembly
- `volatile`: volatile symbol

**Function Attributes**

- `NORETURN`: casts a function with no return
- `SECTION()`: places a function in a target binary section
- `OVERRIDE`: makes a symbol overwritable

**Type Attributes**

- `ALIGN` aligns n object at a boundary
- `PACK`: packs a structure

**Builtin Functions**

- `UNREACHABLE()`: makes the code that follows unreachable
- `UNUSED()`: declares something to be unsued
- `EXPECT()`: provides hints for branch condition
- `noop()`: no operation

Related Isssues
-----------------------

- [[hal][lib] C Compiler Extensions](https://github.com/nanvix/hal/issues/263)

Pull Request Dependency List
-----------------------------------------

- [[hal][lib] Unreachable Kernel Builtin Function](https://github.com/nanvix/hal/pull/264)