### PR TITLE
[hal] Return Value for Core Start

### DIFF
--- a/include/nanvix/hal/core.h
+++ b/include/nanvix/hal/core.h
@@ -221,8 +221,11 @@
 	 *
 	 * @param coreid ID of the target core.
 	 * @param start  Starting routine to execute.
+	 *
+	 * @return Returns 0 if the core start was successful and, otherwise,
+	 * non-zero value.
 	 */
-	EXTERN void core_start(int coreid, void (*start)(void));
+	EXTERN int core_start(int coreid, void (*start)(void));
 
 	/**
 	 * @brief Wait and clears the current IPIs pending of the underlying core.

--- a/src/hal/core/core.c
+++ b/src/hal/core/core.c
@@ -158,13 +158,16 @@ PUBLIC void core_wakeup(int coreid)
  * sleeping core whose ID equals to @p coreid to @p start and sends a
  * wakeup signal to this core.
  *
+ * @return Returns 0 if the core start was successful and, otherwise,
+ * non-zero value.
+ *
  * @see core_idle(), core_run().
  *
  * @todo Check if the calling core is not the target core.
  *
  * @author Pedro Henrique Penna and Davidson Francis
  */
-PUBLIC void core_start(int coreid, void (*start)(void))
+PUBLIC int core_start(int coreid, void (*start)(void))
 {
 again:
 
@@ -187,9 +190,13 @@ again:
 		dcache_invalidate();
 
 		core_notify(coreid);
+
+		spinlock_unlock(&cores[coreid].lock);
+		return (0);
 	}
 
 	spinlock_unlock(&cores[coreid].lock);
+	return (-EBUSY);
 }
 
 /*============================================================================*


### PR DESCRIPTION
Description
----------------

Since the core table should not be used outside from the core interface, it's necessary a reliable way to check whether the core was started or not, which is indeed useful for the core tests. In order to do that, the function `core_start` was slightly changed so the current state could be returned.

Related Issues
---------------------
- [[hal] Return Value for Core Start](https://github.com/nanvix/hal/issues/262)