### PR TITLE
[hal] Bug Fix: No One Core Should Start Itself

### DIFF
--- a/src/hal/core/core.c
+++ b/src/hal/core/core.c
@@ -169,6 +169,10 @@ PUBLIC void core_wakeup(int coreid)
  */
 PUBLIC int core_start(int coreid, void (*start)(void))
 {
+	/* No one core should start itself. */
+	if (coreid == core_get_id())
+		return (-EINVAL);
+
 again:
 
 	spinlock_lock(&cores[coreid].lock);


### PR DESCRIPTION
Description
----------------
The core_start() routine was allowing a core to start itself, which should not be permitted by the hal, thus, this PR checks if the caller core is different from the target core.