### PR TITLE
[hal][test] Start Instruction Execution in the Master Core

### DIFF
--- a/src/hal/core/core.c
+++ b/src/hal/core/core.c
@@ -169,6 +169,10 @@ PUBLIC void core_wakeup(int coreid)
  */
 PUBLIC int core_start(int coreid, void (*start)(void))
 {
+	/* No one core should start itself. */
+	if (coreid == core_get_id())
+		return (-EINVAL);
+
 again:
 
 	spinlock_lock(&cores[coreid].lock);

--- a/src/test/core.c
+++ b/src/test/core.c
@@ -548,11 +548,38 @@ PRIVATE void test_core_suspend_resume_slave(void)
 }
 
 /*============================================================================*
+ * Fault Injection Tests                                                      *
+ *============================================================================*/
+
+/*----------------------------------------------------------------------------*
+ * Start Instruction Execution in the Master Core                             *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * Fault Injection Tests: Dummy function, does nothing.
+ */
+PRIVATE void test_core_start_master_dummy(void)
+{
+	noop();
+}
+
+/**
+ * @brief Fault Injection Tests: Tries to start the master core again.
+ */
+PRIVATE void test_core_start_master(void)
+{
+	KASSERT(core_start(
+		COREID_MASTER,
+		test_core_start_master_dummy) == -EINVAL
+	);
+}
+
+/*============================================================================*
  * Test Driver                                                                *
  *============================================================================*/
 
 /**
- * @brief Unit tests.
+ * @brief API Tests.
  */
 PRIVATE struct test core_tests_api[] = {
 	{ test_core_get_id,                "Get Core ID"                    },
@@ -564,6 +591,14 @@ PRIVATE struct test core_tests_api[] = {
 	{ test_core_suspend_resume_slave,  "Suspend and Resume from Slave"  },
 #endif
 	{ NULL,                            NULL                             },
+};
+
+/**
+ * @brief Fault Injection Tests.
+ */
+PRIVATE struct test fault_tests_api[] = {
+	{ test_core_start_master,          "Start Execution in a Master Core" },
+	{ NULL,                            NULL                               },
 };
 
 /**
@@ -579,5 +614,12 @@ PUBLIC void test_core(void)
 	{
 		core_tests_api[i].test_fn();
 		kprintf("[test][api][core] %s [passed]", core_tests_api[i].name);
+	}
+
+	/* Fault Tests */
+	for (int i = 0; fault_tests_api[i].test_fn != NULL; i++)
+	{
+		fault_tests_api[i].test_fn();
+		kprintf("[test][fault][core] %s [passed]", fault_tests_api[i].name);
 	}
 }


### PR DESCRIPTION
Description
----------------

This PR introduces the Fault Injection test "Start Instruction Execution in the Master Core" present in the Unit Core Tests (#2).

Pull request Dependency List
----------------------------------------

- [[hal] Bug Fix: No One Core Should Start Itself](https://github.com/nanvix/hal/pull/291)