### PR TITLE
[x86-qemu] Disabling Unit Tests for Core Interface

### DIFF
--- a/include/arch/cluster/x86-cluster.h
+++ b/include/arch/cluster/x86-cluster.h
@@ -51,7 +51,7 @@
 	 * @name Provided Features
 	 */
 	/**@{*/
-	#define CLUSTER_IS_MULTICORE  1 /**< Multicore Cluster */
+	#define CLUSTER_IS_MULTICORE  0 /**< Multicore Cluster */
 	#define CLUSTER_IS_IO         1 /**< I/O Cluster       */
 	#define CLUSTER_IS_COMPUTE    0 /**< Compute Cluster   */
 	/**@}*/

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -69,7 +69,9 @@ PUBLIC void kmain(int argc, const char *argv[])
 	test_trap();
 	test_tlb();
 	test_mmu();
+#if (CLUSTER_IS_MULTICORE)
 	test_core();
+#endif
 	test_upcall();
 
 #endif


### PR DESCRIPTION
Description
---------------

The x86-qemu target does not have multiple cores inside the cluster, thus, the Core Tests will not work in it. Due that, this PR disables the Core Tests for architectures that does not features more than one core/cluster.

Related Issues
--------------------
[[qemu-x86] Disable Unit Tests for Core Interface](https://github.com/nanvix/hal/issues/293)