### PR TITLE
[hal] Checking Function Pointer Before Start

### DIFF
--- a/src/hal/core/core.c
+++ b/src/hal/core/core.c
@@ -169,8 +169,12 @@ PUBLIC void core_wakeup(int coreid)
  */
 PUBLIC int core_start(int coreid, void (*start)(void))
 {
-	/* No one core should start itself. */
+	/* Invalid core. */
 	if (coreid == core_get_id())
+		return (-EINVAL);
+
+	/* Bad start routine. */
+	if (start == NULL)
 		return (-EINVAL);
 
 again:


### PR DESCRIPTION
Description
--------------
The routine core_start() was not checking if the function pointer passed by parameter was valid or not, which could lead to a unexpected behavior. Thus, this PR checks if valid before to proceed.