### PR TITLE
[hal][test] Start a Bad Execution Flow

### DIFF
--- a/src/test/core.c
+++ b/src/test/core.c
@@ -574,6 +574,26 @@ PRIVATE void test_core_start_master(void)
 	);
 }
 
+/*----------------------------------------------------------------------------*
+ * Start a Bad Execution Flow                                                 *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief Fault Injection Tests: Starts a bad execution flow, i.e: an invalid
+ * function pointer.
+ */
+PRIVATE void test_core_bad_execution(void)
+{
+	int i; /* Slave index. */
+
+	/* First slave available. */
+	for (i = 0; i < CORES_NUM; i++)
+		if (i != COREID_MASTER)
+			break;
+
+	KASSERT(core_start(i, NULL) == -EINVAL);
+}
+
 /*============================================================================*
  * Test Driver                                                                *
  *============================================================================*/
@@ -598,6 +618,7 @@ PRIVATE struct test core_tests_api[] = {
  */
 PRIVATE struct test fault_tests_api[] = {
 	{ test_core_start_master,          "Start Execution in a Master Core" },
+	{ test_core_bad_execution,         "Start a Bad Execution Flow"       },
 	{ NULL,                            NULL                               },
 };
 


### PR DESCRIPTION
Description
--------------
This PR introduces the Fault Injection test "Start a Bad Execution Flow" present in the Unit Core Tests (#2). This test checks if the HAL is able to catch invalid calls to the core_start() function by passing a invalid function pointer.

Pull request Dependency List
-------------------------------------
- [[hal] Bug Fix: Checking Function Pointer Before Start](https://github.com/nanvix/hal/pull/299)

Related Issues
------------------
[[hal][test] Unit Tests for Core Interface](https://github.com/nanvix/hal/issues/2)