### PR TITLE
[hal] Bug Fix: Checking Core ID Before Start

### DIFF
--- a/src/hal/core/core.c
+++ b/src/hal/core/core.c
@@ -170,6 +170,10 @@ PUBLIC void core_wakeup(int coreid)
 PUBLIC int core_start(int coreid, void (*start)(void))
 {
 	/* Invalid core. */
+	if ((coreid < 0) || (coreid > CORES_NUM))
+		return (-EINVAL);
+
+	/* Bad core. */
 	if (coreid == core_get_id())
 		return (-EINVAL);
 


### PR DESCRIPTION
Description
--------------
The routine core_start() was not checking if the parameter coreid was valid or not (out of range), which could lead to an unexpected behavior. Thus, this PR checks if valid before to proceed.

Pull request Dependency List
-------------------------------------
- [[hal] Bug Fix: Checking Function Pointer Before Start](https://github.com/nanvix/hal/pull/299)