### PR TITLE
[hal][test] Starts an Invalid Execution Flow

### DIFF
--- a/src/test/core.c
+++ b/src/test/core.c
@@ -594,6 +594,22 @@ PRIVATE void test_core_bad_execution(void)
 	KASSERT(core_start(i, NULL) == -EINVAL);
 }
 
+/*----------------------------------------------------------------------------*
+ * Start a Invalid Execution Flow                                             *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief Fault Injection Tests: Starts an invalid execution flow, i.e: a valid
+ * function pointer in a invalid core.
+ */
+PRIVATE void test_core_invalid_execution(void)
+{
+	KASSERT(
+		core_start(CORES_NUM + 1, test_core_start_master_dummy)
+		== -EINVAL
+	);
+}
+
 /*============================================================================*
  * Test Driver                                                                *
  *============================================================================*/
@@ -619,6 +635,7 @@ PRIVATE struct test core_tests_api[] = {
 PRIVATE struct test fault_tests_api[] = {
 	{ test_core_start_master,          "Start Execution in a Master Core" },
 	{ test_core_bad_execution,         "Start a Bad Execution Flow"       },
+	{ test_core_invalid_execution,     "Starts an Invalid Execution Flow" },
 	{ NULL,                            NULL                               },
 };
 


### PR DESCRIPTION
Description
--------------
This PR introduces the Fault Injection test "Starts an Invalid Execution Flow" present in the Unit Core Tests (#2). This test checks if the HAL is able to catch invalid calls to the core_start() function by passing an invalid coreid.

Pull request Dependency List
-------------------------------------
- [[hal] Bug Fix: Checking Core ID Before Start](https://github.com/nanvix/hal/pull/301)
- [[hal][test] Enhancement: Start a Bad Execution Flow](https://github.com/nanvix/hal/pull/300)

Related Issues
------------------
[[hal][test] Unit Tests for Core Interface](https://github.com/nanvix/hal/issues/2)