### PR TITLE
[hal] Master Core is Not Allowed to Reset

### DIFF
--- a/include/nanvix/hal/core.h
+++ b/include/nanvix/hal/core.h
@@ -159,11 +159,6 @@
 	EXTERN struct coreinfo cores[];
 
 	/**
-	 * @brief Resets the state of the underlying core.
-	 */
-	EXTERN void core_reset(void);
-
-	/**
 	 * @brief Clears the current IPIs pending of the underlying core.
 	 *
 	 * @author Davidson Francis
@@ -197,7 +192,7 @@
 	/**
 	 * @brief Reset the underlying core.
 	 */
-	EXTERN void core_reset(void);
+	EXTERN int core_reset(void);
 
 	/**
 	 * @brief Resumes instruction execution in the underlying core.

--- a/src/hal/core/core.c
+++ b/src/hal/core/core.c
@@ -255,15 +255,24 @@ PUBLIC void core_run(void)
  * the underlying core by reseting the kernel stack to its initial
  * location and relaunching the slave_setup() function.
  *
- * @note This function does not return.
+ * @return Upon successful completion, this function shall not return.
+ * Upon failure, a negative error code is returned instead.
  *
  * @see slave_setup()
  *
  * @author Pedro Henrique Penna and Davidson Francis
  */
-PUBLIC void core_reset(void)
+PUBLIC int core_reset(void)
 {
 	int coreid = core_get_id();
+
+	/*
+	 * The Master core is not allowed to reset, thus
+	 * this function will return an error code. If
+	 * invoked by a slave, no value will be returned.
+	 */
+	if (coreid == COREID_MASTER)
+		return (-EINVAL);
 
 	spinlock_lock(&cores[coreid].lock);
 	dcache_invalidate();
@@ -279,6 +288,10 @@ PUBLIC void core_reset(void)
 		 * be released when resetting
 		 * is completed, in core_idle().
 		 */
+
+	/* Never gets here. */
+	UNREACHABLE();
+	return (0);
 }
 
 /*============================================================================*


### PR DESCRIPTION
Description
--------------
The routine core_reset() should not permit that the master core resets. This is the only case that the function will in fact return a value, in all other cases, this function does not returns.

Pull request Dependency List
-------------------------------------
- [[hal] Bug Fix: Checking Core ID Before Start](https://github.com/nanvix/hal/pull/301)
