### PR TITLE
[hal][test] Stop Instruction Execution in the Master Core

### DIFF
--- a/src/test/core.c
+++ b/src/test/core.c
@@ -610,6 +610,19 @@ PRIVATE void test_core_invalid_execution(void)
 	);
 }
 
+/*----------------------------------------------------------------------------*
+ * Stop Instruction Execution in the Master Core                              *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief Fault Injection Tests: Tries to stop the execution instruction
+ * in the master core, which should not be allowed.
+ */
+PRIVATE void test_core_stop_execution(void)
+{
+	KASSERT(core_reset() == -EINVAL);
+}
+
 /*============================================================================*
  * Test Driver                                                                *
  *============================================================================*/
@@ -636,6 +649,7 @@ PRIVATE struct test fault_tests_api[] = {
 	{ test_core_start_master,          "Start Execution in a Master Core" },
 	{ test_core_bad_execution,         "Start a Bad Execution Flow"       },
 	{ test_core_invalid_execution,     "Starts an Invalid Execution Flow" },
+	{ test_core_stop_execution,        "Stops the Execution in the Master"},
 	{ NULL,                            NULL                               },
 };
 


### PR DESCRIPTION
Description
---------------
This PR introduces the Fault Injection test "Stop Instruction Execution in the Master Core" present in the Unit Core Tests (#2). This test checks if the HAL is able to refuse the master core from doing reset.

Pull request Dependency List
--------------------------------------
- [[hal] Bug Fix: Master Core is Not Allowed to Reset](https://github.com/nanvix/hal/pull/303)
- [[hal][test] Enhancement: Starts an Invalid Execution Flow](https://github.com/nanvix/hal/pull/302)

Related Issues
-------------------
[[hal][test] Unit Tests for Core Interface](https://github.com/nanvix/hal/issues/2)