### PR TITLE
[rv32i] Memory Barrier of Spinlock Initialization

### DIFF
--- a/include/arch/core/rv32i/spinlock.h
+++ b/include/arch/core/rv32i/spinlock.h
@@ -65,6 +65,7 @@
 	static inline void rv32i_spinlock_init(rv32i_spinlock_t *lock)
 	{
 		*lock = RV32I_SPINLOCK_UNLOCKED;
+		__sync_synchronize();
 	}
 
 	/**


### PR DESCRIPTION
Description
----------------

Previously, upon initialization of a spinlock in rv32i cores we were missing a memory barrier. In this commit, I fix this bug.