### PR TITLE
[riscv32] Bad Import Symbols

### DIFF
--- a/include/arch/cluster/riscv32-cluster.h
+++ b/include/arch/cluster/riscv32-cluster.h
@@ -25,7 +25,7 @@
 #ifndef CLUSTER_RISCV32_CLUSTER_H_
 #define CLUSTER_RISCV32_CLUSTER_H_
 
-	#ifndef __NEED_RISCV32_CLUSTER
+	#ifndef __NEED_CLUSTER_RISCV32
 		#error "bad cluster configuration?"
 	#endif
 

--- a/include/arch/processor/riscv32/_riscv32.h
+++ b/include/arch/processor/riscv32/_riscv32.h
@@ -25,8 +25,8 @@
 #ifndef _PROCESSOR_RISCV32_H_
 #define _PROCESSOR_RISCV32_H_
 
-	#undef  __NEED_RISCV32_CLUSTER
-	#define __NEED_RISCV32_CLUSTER
+	#undef  __NEED_CLUSTER_RISCV32
+	#define __NEED_CLUSTER_RISCV32
 	#include <arch/cluster/riscv32-cluster.h>
 
 #endif /* _PROCESSOR_RISCV32_H_ */

--- a/include/nanvix/hal/cluster/_cluster.h
+++ b/include/nanvix/hal/cluster/_cluster.h
@@ -49,8 +49,8 @@
 
 	#elif (defined(__riscv32_cluster__))
 
-		#undef  __NEED_CLUSTER_RISCV32_CLUSTER
-		#define __NEED_CLUSTER_RISCV32_CLUSTER
+		#undef  __NEED_CLUSTER_RISCV32
+		#define __NEED_CLUSTER_RISCV32
 		#include <arch/cluster/riscv32-cluster.h>
 
 	#else


### PR DESCRIPTION
Description
---------------

Previously, we were using bad import symbols for the RISC-V 32-Bit processor. In this commit, I fix this problem.