### PR TITLE
[qemu-riscv32] Overriding LDFLAGS

### DIFF
--- a/build/qemu-riscv32/make/makefile
+++ b/build/qemu-riscv32/make/makefile
@@ -51,8 +51,8 @@ export CFAGS  += -march=rv32imac -mabi=ilp32
 export CFLAGS += -mcmodel=medany
 
 # Linker Options
-export LDFLAGS  = -march=rv32imac -mabi=ilp32 -mcmodel=medany
-export LDFLAGS  = -nostdlib -nostdinc -Wl,--nmagic -Wl,--gc-sections
+export LDFLAGS   = -march=rv32imac -mabi=ilp32 -mcmodel=medany
+export LDFLAGS  += -nostdlib -nostdinc -Wl,--nmagic -Wl,--gc-sections
 
 #===============================================================================
 # Libraries and Binaries


### PR DESCRIPTION
Description
---------------

Previously, we were overriding LDFLAGS in the build. In this commit, I fix this problem.