### PR TITLE
[hal][lib] Missing Assembler Guard for stdint

### DIFF
--- a/include/stdint.h
+++ b/include/stdint.h
@@ -33,6 +33,8 @@
 #ifndef _STDINT_H
 #define _STDINT_H
 
+#ifndef _ASM_FILE_
+
 #include <machine/_default_types.h>
 #include <sys/_intsup.h>
 
@@ -532,4 +534,5 @@ typedef __uintptr_t uintptr_t;
 }
 #endif
 
+#endif /* _ASM_FILE_ */
 #endif /* _STDINT_H */


### PR DESCRIPTION
Description
---------------

Previously we were missing an assembler guard for <stdint.h>. In this commit, I fix this problem.