### PR TITLE
[qemu-riscv32] Use Lib GCC for Math

### DIFF
--- a/build/qemu-riscv32/make/makefile
+++ b/build/qemu-riscv32/make/makefile
@@ -60,4 +60,4 @@ export LDFLAGS  += -nostdlib -nostdinc -Wl,--nmagic -Wl,--gc-sections
 
 # Libraries
 export LIBKERNEL = libhal-$(TARGET).a
-export LIBS = $(LIBDIR)/$(LIBKERNEL)
+export LIBS = $(LIBDIR)/$(LIBKERNEL) -lgcc

--- a/src/hal/build/makefile.qemu-riscv32
+++ b/src/hal/build/makefile.qemu-riscv32
@@ -36,6 +36,9 @@ ASM_SRC = $(wildcard arch/core/$(CORE)/*.S)       \
 # C Source Files
 C_SRC += $(wildcard stdout/16550a.c)
 
+# Filter C Source List
+C_SRC := $(filter-out klib/math.c, $(C_SRC))
+
 # Object Files
 OBJ = $(ASM_SRC:.S=.o) \
 	  $(C_SRC:.c=.o)


### PR DESCRIPTION
Description
----------------

In this commit I fall back to the use of LibGCC for math stuff. Lib GCC for this target is safe.