### PR TITLE
[hal] Invalid Core Should Not Resume

### DIFF
--- a/include/nanvix/hal/core.h
+++ b/include/nanvix/hal/core.h
@@ -231,8 +231,11 @@
 	 * @brief Wakes up a core.
 	 *
 	 * @param coreid ID of the target core.
+	 *
+	 * @return Returns 0 if the wakeup was successful and a negative
+	 * number otherwise.
 	 */
-	EXTERN void core_wakeup(int coreid);
+	EXTERN int core_wakeup(int coreid);
 
 /**@}*/
 

--- a/src/hal/core/core.c
+++ b/src/hal/core/core.c
@@ -130,14 +130,21 @@ PUBLIC void core_sleep(void)
  * The core_wakeup() function sends a wakeup signal to the
  * sleeping core whose ID equals to @p coreid.
  *
+ * @return Returns 0 if the wakeup was successful and a negative
+ * number otherwise.
+ *
  * @see core_sleep().
  *
  * @todo Check if the calling core is not the target core.
  *
  * @author Pedro Henrique Penna and Davidson Francis
  */
-PUBLIC void core_wakeup(int coreid)
+PUBLIC int core_wakeup(int coreid)
 {
+	/* Invalid core. */
+	if ((coreid < 0) || (coreid > CORES_NUM))
+		return (-EINVAL);
+
 	spinlock_lock(&cores[coreid].lock);
 	dcache_invalidate();
 
@@ -147,6 +154,7 @@ PUBLIC void core_wakeup(int coreid)
 
 	dcache_invalidate();
 	spinlock_unlock(&cores[coreid].lock);
+	return (0);
 }
 
 /*============================================================================*


### PR DESCRIPTION
Description
---------------
The HAL should not allows a wake up in an invalid core, which could lead to a unexpected behavior.