### PR TITLE
[hal] Bad Core Should Not Resume

### DIFF
--- a/src/hal/core/core.c
+++ b/src/hal/core/core.c
@@ -148,6 +148,13 @@ PUBLIC int core_wakeup(int coreid)
 	spinlock_lock(&cores[coreid].lock);
 	dcache_invalidate();
 
+		/* Bad Core. */
+		if (cores[coreid].state == CORE_IDLE)
+		{
+			spinlock_unlock(&cores[coreid].lock);
+			return (-EINVAL);
+		}
+
 		/* Wakeup target core. */
 		cores[coreid].wakeups++;
 		core_notify(coreid);


### PR DESCRIPTION
Description
---------------
The HAL should not allows a wake up in a bad core, which could lead to a unexpected behavior.

Pull request Dependency List
--------------------------------------
- [[hal] Invalid Core Should Not Resume](https://github.com/nanvix/hal/pull/310)