### PR TITLE
[hal][test] Resume Instruction Execution in a Bad Core

### DIFF
--- a/src/hal/core/core.c
+++ b/src/hal/core/core.c
@@ -145,10 +145,6 @@ PUBLIC int core_wakeup(int coreid)
 	if ((coreid < 0) || (coreid > CORES_NUM))
 		return (-EINVAL);
 
-	/* Bad Core. */
-	if (cores[coreid].state == CORE_IDLE)
-		return (-EINVAL);
-
 	spinlock_lock(&cores[coreid].lock);
 	dcache_invalidate();
 

--- a/src/hal/core/core.c
+++ b/src/hal/core/core.c
@@ -145,6 +145,10 @@ PUBLIC int core_wakeup(int coreid)
 	if ((coreid < 0) || (coreid > CORES_NUM))
 		return (-EINVAL);
 
+	/* Bad Core. */
+	if (cores[coreid].state == CORE_IDLE)
+		return (-EINVAL);
+
 	spinlock_lock(&cores[coreid].lock);
 	dcache_invalidate();
 

--- a/src/test/core.c
+++ b/src/test/core.c
@@ -637,6 +637,27 @@ PRIVATE void test_core_resume_invalid(void)
 	KASSERT(core_wakeup(-1) == -EINVAL);
 }
 
+/*----------------------------------------------------------------------------*
+ * Resume Instruction Execution in a Bad Core                                 *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief Fault Injection Tests: Tries to wakeup a valid core in a bad context,
+ * i.e: a core that does exit but is in IDLE.
+ */
+PRIVATE void test_core_resume_bad(void)
+{
+	/* Resume first slave available. */
+	for (int i = 0; i < CORES_NUM; i++)
+	{
+		if (i != COREID_MASTER)
+		{
+			KASSERT(core_wakeup(i) == -EINVAL);
+			break;
+		}
+	}
+}
+
 /*============================================================================*
  * Test Driver                                                                *
  *============================================================================*/
@@ -665,6 +686,7 @@ PRIVATE struct test fault_tests_api[] = {
 	{ test_core_invalid_execution,     "Starts an Invalid Execution Flow"    },
 	{ test_core_stop_execution,        "Stops the Execution in the Master"   },
 	{ test_core_resume_invalid,        "Resume Execution in an Invalid Core" },
+	{ test_core_resume_bad,            "Resume Execution in a Bad Core"      },
 	{ NULL,                            NULL                                  },
 };
 


### PR DESCRIPTION
Description
--------------
This PR introduces the Fault Injection test "Resume Instruction Execution in a Bad Core" present in the Unit Core Tests (#2). This test checks if the HAL is able to refuse a wake up in a bad core.

Pull request Dependency List
--------------------------------------
- [[hal] Bad Core Should Not Resume](https://github.com/nanvix/hal/pull/312)
- [[hal][test] Resume Instruction Execution in an Invalid Core](https://github.com/nanvix/hal/pull/311)

Related Issues
-------------------
[[hal][test] Unit Tests for Core Interface](https://github.com/nanvix/hal/issues/2)