### PR TITLE
[riscv32-cluster] Extensions for Memory Interface

### DIFF
--- a/include/arch/cluster/riscv32-cluster/memmap.h
+++ b/include/arch/cluster/riscv32-cluster/memmap.h
@@ -1,0 +1,76 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef CLUSTER_RISCV32_CLUSTER_MEMMAP_H_
+#define CLUSTER_RISCV32_CLUSTER_MEMMAP_H_
+
+	#ifndef __NEED_CLUSTER_MEMMAP
+		#error "do not include this file"
+	#endif
+
+	/* Cluster Interface Implementation */
+	#include <arch/cluster/riscv32-cluster/_riscv32-cluster.h>
+
+/**
+ * @addtogroup riscv_cluster-cluster-memmap Memory Map
+ * @ingroup riscv_cluster-cluster
+ *
+ * @brief Physical memory map.
+ */
+/**@{*/
+
+	/**
+	 * @name Physical Memory Layout
+	 */
+	/**@{*/
+	#define RISCV32_CLUSTER_PIC_BASE_PHYS  0x02000000 /**< PIC Base  */
+	#define RISCV32_CLUSTER_PIC_END_PHYS   0x02010000 /**< PIC End   */
+	#define RISCV32_CLUSTER_UART_BASE_PHYS 0x10000000 /**< UART Base */
+	#define RISCV32_CLUSTER_UART_END_PHYS  0x10010000 /**< UART End  */
+	#define RISCV32_CLUSTER_DRAM_BASE_PHYS 0x80000000 /**< DRAM Base */
+	#define RISCV32_CLUSTER_DRAM_END_PHYS  0x88000000 /**< DRAM End  */
+	/**@}*/
+
+	/**
+	 * @brief DRAM brief (in bytes).
+	 */
+	#define RISCV32_CLUSTER_DRAM_SIZE \
+		(RISCV32_CLUSTER_DRAM_END_PHYS - RISCV32_CLUSTER_DRAM_BASE_PHYS)
+
+	/**
+	 * @brief PIC brief (in bytes).
+	 */
+	#define RISCV32_CLUSTER_PIC_MEM_SIZE \
+		(RISCV32_CLUSTER_PIC_END_PHYS - RISCV32_CLUSTER_PIC_BASE_PHYS)
+
+	/**
+	 * @brief UART brief (in bytes).
+	 */
+	#define RISCV32_CLUSTER_UART_MEM_SIZE \
+		(RISCV32_CLUSTER_UART_END_PHYS - RISCV32_CLUSTER_UART_BASE_PHYS)
+
+/**@}*/
+
+#endif /* CLUSTER_RISCV32_CLUSTER_MEMMAP_H_ */
+

--- a/include/arch/cluster/riscv32-cluster/memory.h
+++ b/include/arch/cluster/riscv32-cluster/memory.h
@@ -36,69 +36,68 @@
  */
 /**@{*/
 
+	/* Must come first. */
+	#define __NEED_CLUSTER_MEMMAP
+
 #ifndef _ASM_FILE
 
 	#include <nanvix/const.h>
 
 #endif /* _ASM_FILE_ */
 
-	/**
-	 * @brief DRAM size (in bytes).
-	 */
-	#define RISCV32_CLUSTER_DRAM_SIZE (128*MB)
-
-	/**
-	 * @brief Base DRAM address.
-	 */
-	#define RISCV32_DRAM_BASE 0x80000000
-
-	/**
-	 * @brief End DRAM address.
-	 */
-	#define RISCV32_DRAM_END (RISCV32_DRAM_BASE + RISCV32_CLUSTER_DRAM_SIZE)
-
-	/**
-	 * @brief Memory size (in bytes).
-	 */
-	#define RISCV32_CLUSTER_MEM_SIZE (RISCV32_CLUSTER_DRAM_SIZE)
-
-	/**
-	 * @brief Kernel memory size (in bytes).
-	 */
-	#define RISCV32_CLUSTER_KMEM_SIZE RV32I_PGTAB_SIZE
-
-	/**
-	 * @brief Kernel page pool size (in bytes).
-	 */
-	#define RISCV32_CLUSTER_KPOOL_SIZE RV32I_PGTAB_SIZE
+	#include <arch/cluster/riscv32-cluster/memmap.h>
 
 	/**
 	 * @name Physical Memory Layout
 	 */
 	/**@{*/
-	#define RISCV32_CLUSTER_PIC_PHYS         0x02000000                                             /**< PIC                  */
-	#define RISCV32_CLUSTER_UART_PHYS        0x10000000                                             /**< UART                 */
-	#define RISCV32_CLUSTER_KERNEL_BASE_PHYS RISCV32_DRAM_BASE                                      /**< Kernel Code and Data */
-	#define RISCV32_CLUSTER_KERNEL_END_PHYS  (RISCV32_CLUSTER_KERNEL_BASE_PHYS + RISCV32_CLUSTER_KMEM_SIZE) /**< Kernel End           */
-	#define RISCV32_CLUSTER_KPOOL_BASE_PHYS  0x80400000                                             /**< Kernel Page Pool     */
-	#define RISCV32_CLUSTER_KPOOL_END_PHYS   (RISCV32_CLUSTER_KPOOL_BASE_PHYS + RISCV32_CLUSTER_KPOOL_SIZE) /**< Kernel Pool End      */
-	#define RISCV32_CLUSTER_USER_BASE_PHYS   0x80800000                                             /**< User Base            */
-	#define RISCV32_CLUSTER_USER_END_PHYS    RISCV32_DRAM_END                                       /**< User End             */
+	#define RISCV32_CLUSTER_KERNEL_BASE_PHYS RISCV32_CLUSTER_DRAM_BASE_PHYS                        /**< Kernel Code and Data */
+	#define RISCV32_CLUSTER_KERNEL_END_PHYS  (RISCV32_CLUSTER_KERNEL_BASE_PHYS + RV32I_PGTAB_SIZE) /**< Kernel End           */
+	#define RISCV32_CLUSTER_KPOOL_BASE_PHYS  (RISCV32_CLUSTER_KERNEL_END_PHYS + RV32I_PGTAB_SIZE)  /**< Kernel Page Pool     */
+	#define RISCV32_CLUSTER_KPOOL_END_PHYS   (RISCV32_CLUSTER_KPOOL_BASE_PHYS + RV32I_PGTAB_SIZE)  /**< Kernel Pool End      */
+	#define RISCV32_CLUSTER_USER_BASE_PHYS   RISCV32_CLUSTER_KPOOL_END_PHYS                        /**< User Base            */
+	#define RISCV32_CLUSTER_USER_END_PHYS    RISCV32_CLUSTER_DRAM_END_PHYS                         /**< User End             */
 	/**@}*/
 
 	/**
 	 * @name Virtual Memory Layout
 	 */
 	/**@{*/
-	#define RISCV32_CLUSTER_PIC_VIRT         0x02000000                                             /**< PIC                  */
-	#define RISCV32_CLUSTER_UART_VIRT        0x10000000                                             /**< UART                 */
-	#define RISCV32_CLUSTER_KERNEL_BASE_VIRT 0x80000000                                             /**< Kernel Code and Data */
-	#define RISCV32_CLUSTER_KERNEL_END_VIRT  (RISCV32_CLUSTER_KERNEL_BASE_VIRT + RISCV32_CLUSTER_KMEM_SIZE) /**< Kernel End           */
-	#define RISCV32_CLUSTER_KPOOL_BASE_VIRT  0x80400000                                             /**< Kernel Page Pool     */
-	#define RISCV32_CLUSTER_KPOOL_END_VIRT   (RISCV32_CLUSTER_KPOOL_BASE_VIRT + RISCV32_CLUSTER_KPOOL_SIZE) /**< Kernel Pool End      */
-	#define RISCV32_CLUSTER_USER_BASE_VIRT   0x90000000                                             /**< User Base            */
-	#define RISCV32_CLUSTER_USER_END_VIRT    0xf0000000                                             /**< User End             */
+	#define RISCV32_CLUSTER_PIC_BASE_VIRT    RISCV32_CLUSTER_PIC_BASE_PHYS    /**< PIC Base             */
+	#define RISCV32_CLUSTER_PIC_END_VIRT     RISCV32_CLUSTER_PIC_END_PHYS     /**< PIC End              */
+	#define RISCV32_CLUSTER_UART_BASE_VIRT   RISCV32_CLUSTER_UART_BASE_PHYS   /**< UART Base            */
+	#define RISCV32_CLUSTER_UART_END_VIRT    RISCV32_CLUSTER_UART_END_PHYS    /**< UART End             */
+	#define RISCV32_CLUSTER_KERNEL_BASE_VIRT RISCV32_CLUSTER_KERNEL_BASE_PHYS /**< Kernel Code and Data */
+	#define RISCV32_CLUSTER_KERNEL_END_VIRT  RISCV32_CLUSTER_KERNEL_END_PHYS  /**< Kernel End           */
+	#define RISCV32_CLUSTER_KPOOL_BASE_VIRT  RISCV32_CLUSTER_KPOOL_BASE_PHYS  /**< Kernel Page Pool     */
+	#define RISCV32_CLUSTER_KPOOL_END_VIRT   RISCV32_CLUSTER_KPOOL_END_PHYS   /**< Kernel Pool End      */
+	#define RISCV32_CLUSTER_USER_BASE_VIRT   0x90000000                       /**< User Base            */
+	#define RISCV32_CLUSTER_USER_END_VIRT    0xf0000000                       /**< User End             */
 	/**@}*/
+
+	/**
+	 * @brief Memory size (in bytes).
+	 */
+	#define RISCV32_CLUSTER_MEM_SIZE \
+		RISCV32_CLUSTER_DRAM_SIZE
+
+	/**
+	 * @brief Kernel memory size (in bytes).
+	 */
+	#define RISCV32_CLUSTER_KMEM_SIZE \
+		(RISCV32_CLUSTER_KERNEL_END_VIRT - RISCV32_CLUSTER_KERNEL_BASE_VIRT)
+
+	/**
+	 * @brief Kernel page pool size (in bytes).
+	 */
+	#define RISCV32_CLUSTER_KPOOL_SIZE \
+		(RISCV32_CLUSTER_KPOOL_END_VIRT - RISCV32_CLUSTER_KPOOL_BASE_VIRT)
+
+	/**
+	 * @brief User memory size (in bytes).
+	 */
+	#define RISCV32_CLUSTER_UMEM_SIZE \
+		(RISCV32_CLUSTER_USER_END_VIRT - RISCV32_CLUSTER_USER_BASE_VIRT)
 
 #ifndef _ASM_FILE
 
@@ -129,48 +128,21 @@
  */
 
 	/**
-	 * @brief Memory size (in bytes).
+	 * @name Exported Constants
 	 */
-	#define _MEMORY_SIZE RISCV32_CLUSTER_MEM_SIZE
-
-	/**
-	 * @brief Kernel stack size (in bytes).
-	 */
-	#define _KSTACK_SIZE RISCV32_CLUSTER_PAGE_SIZE
-
-	/**
-	 * @brief Kernel memory size (in bytes).
-	 */
-	#define _KMEM_SIZE RISCV32_CLUSTER_KMEM_SIZE
-
-	/**
-	 * @brief Kernel page pool size (in bytes).
-	 */
-	#define _KPOOL_SIZE RISCV32_CLUSTER_KPOOL_SIZE
-
-	/**
-	 * @brief User memory size (in bytes).
-	 */
-	#define _UMEM_SIZE (RISCV32_CLUSTER_USER_END_PHYS - RISCV32_CLUSTER_USER_BASE_PHYS)
-
-	/**
-	 * @name Virtual Memory Layout
-	 */
-	/**@{*/
-	#define _UBASE_VIRT  RISCV32_CLUSTER_UBASE_VIRT  /**< User Base        */
-	#define _USTACK_ADDR RISCV32_CLUSTER_USTACK_ADDR /**< User Stack       */
-	#define _KBASE_VIRT  RISCV32_CLUSTER_KBASE_VIRT  /**< Kernel Base      */
-	#define _KPOOL_VIRT  RISCV32_CLUSTER_KPOOL_VIRT  /**< Kernel Page Pool */
-	/**@}*/
-
-	/**
-	 * @name Physical Memory Layout
-	 */
-	/**@{*/
-	#define _KBASE_PHYS RISCV32_CLUSTER_KBASE_PHYS /**< Kernel Base      */
-	#define _KPOOL_PHYS RISCV32_CLUSTER_KPOOL_PHYS /**< Kernel Page Pool */
-	#define _UBASE_PHYS RISCV32_CLUSTER_UBASE_PHYS /**< User Base        */
-	#define _UART_ADDR  RISCV32_CLUSTER_UART_PHYS  /**< UART Device      */
+	#define MEMORY_SIZE  RISCV32_CLUSTER_MEM_SIZE          /**< @see RISCV32_CLUSTER_MEM_SIZE         */
+	#define KMEM_SIZE    RISCV32_CLUSTER_KMEM_SIZE         /**< @see RISCV32_CLUSTER_KMEM_SIZE        */
+	#define UMEM_SIZE    RISCV32_CLUSTER_UMEM_SIZE         /**< @see RISCV32_CLUSTER_UMEM_SIZE        */
+	#define KSTACK_SIZE  RISCV32_CLUSTER_KSTACK_SIZE       /**< @see RISCV32_CLUSTER_KSTACK_SIZE      */
+	#define KPOOL_SIZE   RISCV32_CLUSTER_KPOOL_SIZE        /**< @see RISCV32_CLUSTER_KPOOL_SIZE       */
+	#define KBASE_PHYS   RISCV32_CLUSTER_KERNEL_BASE_PHYS  /**< @see RISCV32_CLUSTER_KERNEL_BASE_PHYS */
+	#define KPOOL_PHYS   RISCV32_CLUSTER_KPOOL_BASE_PHYS   /**< @see RISCV32_CLUSTER_KPOOL_BASE_PHYS  */
+	#define UBASE_PHYS   RISCV32_CLUSTER_USER_BASE_PHYS    /**< @see RISCV32_CLUSTER_USER_BASE_PHYS   */
+	#define USTACK_VIRT  RISCV32_CLUSTER_USTACK_BASE_VIRT  /**< @see RISCV32_CLUSTER_USTACK_BASE_VIRT */
+	#define UBASE_VIRT   RISCV32_CLUSTER_USER_BASE_VIRT    /**< @see RISCV32_CLUSTER_USER_BASE_VIRT   */
+	#define KBASE_VIRT   RISCV32_CLUSTER_KERNEL_BASE_VIRT  /**< @see RISCV32_CLUSTER_KERNEL_BASE_VIRT */
+	#define KPOOL_VIRT   RISCV32_CLUSTER_KPOOL_BASE_VIRT   /**< @see RISCV32_CLUSTER_KPOOL_BASE_VIRT  */
+	#define _UART_ADDR  RISCV32_CLUSTER_UART_PHYS          /**< @see UART Device                      */
 	/**@}*/
 
 /**@endcond*/

--- a/include/arch/cluster/riscv32-cluster/memory.h
+++ b/include/arch/cluster/riscv32-cluster/memory.h
@@ -115,6 +115,11 @@
 	EXTERN unsigned char __BSS_END;         /**< BSS End         */
 	/**@}*/
 
+	/**
+	 * @brief Initializes the Memory Interface.
+	 */
+	EXTERN void riscv32_cluster_mem_setup(void);
+
 #endif /* _ASM_FILE_ */
 
 /**@}*/

--- a/include/arch/core/rv32i/mmu.h
+++ b/include/arch/core/rv32i/mmu.h
@@ -205,11 +205,6 @@
 #ifndef _ASM_FILE_
 
 	/**
-	 * @brief Frame number.
-	 */
-	typedef uint32_t frame_t;
-
-	/**
 	 * @brief Page directory entry.
 	 */
 	struct pde

--- a/include/arch/core/rv32i/mmu.h
+++ b/include/arch/core/rv32i/mmu.h
@@ -63,6 +63,33 @@
 	/**@}*/
 
 	/**
+	 * @brief Length of virtual addresses.
+	 *
+	 * Number of bits in a virtual address.
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	#define RV32I_VADDR_LENGTH 32
+
+	/**
+	 * @brief Page Directory length.
+	 *
+	 * Number of Page Directory Entries (PDEs) per Page Directory.
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	#define RV32I_PGDIR_LENGTH (1 << (RV32I_VADDR_LENGTH - RV32I_PGTAB_SHIFT))
+
+	/**
+	 * @brief Page Table length.
+	 *
+	 * Number of Page Table Entries (PTEs) per Page Table.
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	#define RV32I_PGTAB_LENGTH (1 << (RV32I_PGTAB_SHIFT - RV32I_PAGE_SHIFT))
+
+	/**
 	 * @name Page Table Entry Shifts and Masks
 	 */
 	/**@{*/

--- a/include/arch/core/rv32i/mmu.h
+++ b/include/arch/core/rv32i/mmu.h
@@ -179,6 +179,20 @@
 	EXTERN int rv32i_page_map(struct pte *pgtab, paddr_t paddr, vaddr_t vaddr, int w, int x);
 
 	/**
+	 * @brief Maps a huge page.
+	 *
+	 * @param pgtab Target page directory.
+	 * @param paddr Physical address of the target huge page frame.
+	 * @param vaddr Virtual address of the target huge page.
+	 * @param w     Writable huge page?
+	 * @param x     Executable huge page?
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
+	 */
+	EXTERN int rv32i_huge_page_map(struct pte *pgdir, paddr_t paddr, vaddr_t vaddr, int w, int x);
+
+	/**
 	 * @brief Maps a page table.
 	 *
 	 * @param pgdir Target page directory.

--- a/include/arch/core/rv32i/mmu.h
+++ b/include/arch/core/rv32i/mmu.h
@@ -128,6 +128,70 @@
 	#define RV32I_PDE_IDX(x) \
 		((x) >> (RV32I_PGTAB_SHIFT))
 
+#ifndef _ASM_FILE_
+
+	/**
+	 * @brief Page directory entry.
+	 */
+	struct pde
+	{
+		unsigned valid      :  1; /**< Valid?       */
+		unsigned readable   :  1; /**< Readable?    */
+		unsigned writable   :  1; /**< Writable?    */
+		unsigned executable :  1; /**< Executable?  */
+		unsigned            :  1; /**< Reserved     */
+		unsigned global     :  1; /**< Global Page? */
+		unsigned            :  1; /**< Reserved     */
+		unsigned            :  1; /**< Reserved     */
+		unsigned            :  2; /**< Reserved     */
+		unsigned frame      : 22; /**< Frame Number */
+	};
+
+	/**
+	 * @brief Page table entry.
+	 */
+	struct pte
+	{
+		unsigned valid      :  1; /**< Valid?       */
+		unsigned readable   :  1; /**< Readable?    */
+		unsigned writable   :  1; /**< Writable?    */
+		unsigned executable :  1; /**< Executable?  */
+		unsigned user       :  1; /**< User page?   */
+		unsigned global     :  1; /**< Global Page? */
+		unsigned accessed   :  1; /**< Accessed?    */
+		unsigned dirty      :  1; /**< Dirty?       */
+		unsigned            :  2; /**< Reserved     */
+		unsigned frame      : 22; /**< Frame Number */
+	};
+
+	/**
+	 * @brief Maps a page.
+	 *
+	 * @param pgtab Target page table.
+	 * @param paddr Physical address of the target page frame.
+	 * @param vaddr Virtual address of the target page.
+	 * @param w     Writable page?
+	 * @param x     Executable page?
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
+	 */
+	EXTERN int rv32i_page_map(struct pte *pgtab, paddr_t paddr, vaddr_t vaddr, int w, int x);
+
+	/**
+	 * @brief Maps a page table.
+	 *
+	 * @param pgdir Target page directory.
+	 * @param paddr Physical address of the target page table frame.
+	 * @param vaddr Virtual address of the target page table.
+	 *
+	 * @returns Upon successful completion, zero is returned. Upon
+	 * failure, a negative error code is returned instead.
+	 */
+	EXTERN int rv32i_pgtab_map(struct pde *pgdir, paddr_t paddr, vaddr_t vaddr);
+
+#endif /* _ASM_FILE_ */
+
 /**@}*/
 
 /*============================================================================*
@@ -203,40 +267,6 @@
 	/**@}*/
 
 #ifndef _ASM_FILE_
-
-	/**
-	 * @brief Page directory entry.
-	 */
-	struct pde
-	{
-		unsigned valid      :  1; /**< Valid?       */
-		unsigned readable   :  1; /**< Readable?    */
-		unsigned writable   :  1; /**< Writable?    */
-		unsigned executable :  1; /**< Executable?  */
-		unsigned            :  1; /**< Reserved     */
-		unsigned global     :  1; /**< Global Page? */
-		unsigned            :  1; /**< Reserved     */
-		unsigned            :  1; /**< Reserved     */
-		unsigned            :  2; /**< Reserved     */
-		unsigned frame      : 22; /**< Frame Number */
-	};
-
-	/**
-	 * @brief Page table entry.
-	 */
-	struct pte
-	{
-		unsigned valid      :  1; /**< Valid?       */
-		unsigned readable   :  1; /**< Readable?    */
-		unsigned writable   :  1; /**< Writable?    */
-		unsigned executable :  1; /**< Executable?  */
-		unsigned user       :  1; /**< User page?   */
-		unsigned global     :  1; /**< Global Page? */
-		unsigned accessed   :  1; /**< Accessed?    */
-		unsigned dirty      :  1; /**< Dirty?       */
-		unsigned            :  2; /**< Reserved     */
-		unsigned frame      : 22; /**< Frame Number */
-	};
 
 	/**
 	 * @brief Clears a page directory entry.

--- a/include/arch/core/rv32i/types.h
+++ b/include/arch/core/rv32i/types.h
@@ -142,6 +142,11 @@
 		 */
 		typedef uint32_t paddr_t;
 
+		/**
+		 * @brief Frame number.
+		 */
+		typedef uint32_t frame_t;
+
 	#endif
 	#endif
 

--- a/src/hal/arch/cluster/riscv32-cluster/memory.c
+++ b/src/hal/arch/cluster/riscv32-cluster/memory.c
@@ -27,33 +27,6 @@
 #include <nanvix/const.h>
 
 /**
- * @brief Length of virtual addresses.
- *
- * Number of bits in a virtual address.
- *
- * @author Pedro Henrique Penna
- */
-#define RV32I_VADDR_LENGTH 32
-
-/**
- * @brief Page Directory length.
- *
- * Number of Page Directory Entries (PDEs) per Page Directory.
- *
- * @author Pedro Henrique Penna
- */
-#define RV32I_PGDIR_LENGTH (1 << (RV32I_VADDR_LENGTH - RV32I_PGTAB_SHIFT))
-
-/**
- * @brief Page Table length.
- *
- * Number of Page Table Entries (PTEs) per Page Table.
- *
- * @author Pedro Henrique Penna
- */
-#define RV32I_PGTAB_LENGTH (1 << (RV32I_PGTAB_SHIFT - RV32I_PAGE_SHIFT))
-
-/**
  * @brief Root page directory.
  */
 PUBLIC struct pde rv32i_root_pgdir[RV32I_PAGE_SIZE/RV32I_PTE_SIZE] ALIGN(PAGE_SIZE);

--- a/src/hal/arch/cluster/riscv32-cluster/memory.c
+++ b/src/hal/arch/cluster/riscv32-cluster/memory.c
@@ -27,139 +27,251 @@
 #include <nanvix/const.h>
 
 /**
- * @brief Root page directory.
+ * @brief Number of memory regions.
  */
-PUBLIC struct pde rv32i_root_pgdir[RV32I_PAGE_SIZE/RV32I_PTE_SIZE] ALIGN(PAGE_SIZE);
+#define RISCV32_CLUSTER_MEM_REGIONS 4
 
 /**
- * @brief PIC page table.
+ * @brief Memory region.
  */
-PUBLIC struct pte rv32i_pic_pgtab[RV32I_PAGE_SIZE/RV32I_PTE_SIZE] ALIGN(PAGE_SIZE);
+struct memory_region
+{
+	paddr_t pbase;  /**< Base physical address. */
+	vaddr_t vbase;  /**< Base virtual address.  */
+	size_t size;    /**< Size.                  */
+	int writable;   /**< Writable?              */
+	int executable; /**< Executable?            */
+};
+
+/**
+ * @brief Memory layout.
+ */
+PRIVATE struct memory_region riscv32_cluster_mem_layout[RISCV32_CLUSTER_MEM_REGIONS] = {
+	{ RISCV32_CLUSTER_KERNEL_BASE_PHYS, RISCV32_CLUSTER_KERNEL_BASE_VIRT,  RISCV32_CLUSTER_KMEM_SIZE,     TRUE, TRUE  },
+	{ RISCV32_CLUSTER_KPOOL_BASE_PHYS,  RISCV32_CLUSTER_KPOOL_BASE_VIRT,   RISCV32_CLUSTER_KPOOL_SIZE,    TRUE, FALSE },
+	{ RISCV32_CLUSTER_PIC_BASE_PHYS,    RISCV32_CLUSTER_PIC_BASE_VIRT,     RISCV32_CLUSTER_PIC_MEM_SIZE,  TRUE, FALSE },
+	{ RISCV32_CLUSTER_UART_BASE_PHYS,   RISCV32_CLUSTER_UART_BASE_VIRT,    RISCV32_CLUSTER_UART_MEM_SIZE, TRUE, FALSE },
+};
+
+/**
+ * @brief Root page directory.
+ */
+PRIVATE struct pde riscv32_cluster_root_pgdir[RV32I_PGDIR_LENGTH] ALIGN(PAGE_SIZE);
+
+/**
+ * @brief Root page tables.
+ */
+PRIVATE struct pte riscv32_cluster_root_pgtabs[RISCV32_CLUSTER_MEM_REGIONS][RV32I_PGTAB_LENGTH] ALIGN(PAGE_SIZE);
 
 /**
  * Alias to root page directory.
  */
-PUBLIC struct pde *root_pgdir = &rv32i_root_pgdir[0];
+PUBLIC struct pde *root_pgdir = &riscv32_cluster_root_pgdir[0];
 
 /**
  * Alias to kernel page table.
- *
- * @todo FIXME properly initialize this.
  */
-PUBLIC struct pte *kernel_pgtab = NULL;
+PUBLIC struct pte *kernel_pgtab = riscv32_cluster_root_pgtabs[0];
 
 /**
  * Alias to kernel page pool page table.
- *
- * @todo FIXME properly initialize this.
  */
-PUBLIC struct pte *kpool_pgtab = NULL;
+PUBLIC struct pte *kpool_pgtab = riscv32_cluster_root_pgtabs[1];
+
+/*============================================================================*
+ * riscv32_cluster_mem_info()                                                 *
+ *============================================================================*/
 
 /**
- * @brief Assert memory alignment.
+ * @brief Prints information about memory layout.
+ *
+ * The riscv32_cluster_mem_info() prints information about the virtual
+ * memory layout.
+ *
+ * @author Pedro Henrique Penna
  */
-PRIVATE void riscv32_cluster_mmu_check_alignment(void)
+PRIVATE void riscv32_cluster_mem_info(void)
 {
-	if (RISCV32_CLUSTER_KERNEL_BASE_VIRT & (RV32I_PAGE_SIZE - 1))
+	kprintf("[hal] kernel_base=%x kernel_end=%x",
+		RISCV32_CLUSTER_KERNEL_BASE_VIRT,
+		RISCV32_CLUSTER_KERNEL_END_VIRT
+	);
+	kprintf("[hal]  kpool_base=%x  kpool_end=%x",
+		RISCV32_CLUSTER_KPOOL_BASE_VIRT,
+		RISCV32_CLUSTER_KPOOL_END_VIRT
+	);
+	kprintf("[hal]   user_base=%x   user_end=%x",
+		RISCV32_CLUSTER_USER_BASE_VIRT,
+		RISCV32_CLUSTER_USER_END_VIRT
+	);
+	kprintf("[hal]   uart_base=%x   uart_end=%x",
+		RISCV32_CLUSTER_UART_BASE_VIRT,
+		RISCV32_CLUSTER_UART_END_VIRT
+	);
+	kprintf("[hal]    pic_base=%x    pic_end=%x",
+		RISCV32_CLUSTER_PIC_BASE_VIRT,
+		RISCV32_CLUSTER_PIC_END_VIRT
+	);
+	kprintf("[hal] memsize=%d MB kmem=%d KB kpool=%d KB umem=%d KB",
+		RISCV32_CLUSTER_MEM_SIZE/MB,
+		RISCV32_CLUSTER_KMEM_SIZE/KB,
+		RISCV32_CLUSTER_KPOOL_SIZE/KB,
+		RISCV32_CLUSTER_UMEM_SIZE/KB
+	);
+}
+
+/*============================================================================*
+ * riscv32_cluster_mem_check_align()                                          *
+ *============================================================================*/
+
+/**
+ * @brief Asserts the memory alignment.
+ *
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Pedro Henrique Penna
+ */
+PRIVATE void riscv32_cluster_mem_check_align(void)
+{
+	/* These should be aligned at page boundaries. */
+	if (RISCV32_CLUSTER_PIC_BASE_VIRT & (RV32I_PAGE_SIZE - 1))
+		kpanic("pic base address misaligned");
+	if (RISCV32_CLUSTER_PIC_END_VIRT & (RV32I_PAGE_SIZE - 1))
+		kpanic("pic end address misaligned");
+	if (RISCV32_CLUSTER_UART_BASE_VIRT & (RV32I_PAGE_SIZE - 1))
+		kpanic("uart base address misaligned");
+	if (RISCV32_CLUSTER_UART_END_VIRT & (RV32I_PAGE_SIZE - 1))
+		kpanic("uart end address misaligned");
+
+	/* These should be aligned at page table boundaries. */
+	if (RISCV32_CLUSTER_KERNEL_BASE_VIRT & (RV32I_PGTAB_SIZE - 1))
 		kpanic("kernel base address misaligned");
-	if (RISCV32_CLUSTER_KERNEL_END_VIRT & (RV32I_PAGE_SIZE - 1))
+	if (RISCV32_CLUSTER_KERNEL_END_VIRT & (RV32I_PGTAB_SIZE - 1))
 		kpanic("kernel end address misaligned");
-	if (RISCV32_CLUSTER_KPOOL_BASE_VIRT & (RV32I_PAGE_SIZE - 1))
+	if (RISCV32_CLUSTER_KPOOL_BASE_VIRT & (RV32I_PGTAB_SIZE - 1))
 		kpanic("kernel pool base address misaligned");
-	if (RISCV32_CLUSTER_KPOOL_END_VIRT & (RV32I_PAGE_SIZE - 1))
+	if (RISCV32_CLUSTER_KPOOL_END_VIRT & (RV32I_PGTAB_SIZE - 1))
 		kpanic("kernel pool end address misaligned");
-	if (RISCV32_CLUSTER_USER_BASE_VIRT & (RV32I_PAGE_SIZE - 1))
+	if (RISCV32_CLUSTER_USER_BASE_VIRT & (RV32I_PGTAB_SIZE - 1))
 		kpanic("user base address misaligned");
-	if (RISCV32_CLUSTER_USER_END_VIRT & (RV32I_PAGE_SIZE - 1))
+	if (RISCV32_CLUSTER_USER_END_VIRT & (RV32I_PGTAB_SIZE - 1))
 		kpanic("user end address misaligned");
 }
 
+/*============================================================================*
+ * riscv32_cluster_mem_check_layout()                                         *
+ *============================================================================*/
+
 /**
- * @brief The rv32i_mmu_setup() function initializes the Memory
- * Management Unit (MMU) of the underlying rv32i core.
+ * @brief Asserts the memory layout.
+ *
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Pedro Henrique Penna
  */
-PUBLIC void riscv32_mmu_setup(void)
+PRIVATE void riscv32_cluster_mem_check_layout(void)
+{
+	/*
+	 * These should be identity mapped, becasuse the underlying
+	 * hypervisor runs with virtual memory disabled.
+	 */
+	if (RISCV32_CLUSTER_PIC_BASE_VIRT != RISCV32_CLUSTER_PIC_BASE_PHYS)
+		kpanic("pic base address is not identity mapped");
+	if (RISCV32_CLUSTER_PIC_END_VIRT != RISCV32_CLUSTER_PIC_END_PHYS)
+		kpanic("pic end address is not identity mapped");
+	if (RISCV32_CLUSTER_UART_BASE_VIRT != RISCV32_CLUSTER_UART_BASE_PHYS)
+		kpanic("uart base address is not identity mapped");
+	if (RISCV32_CLUSTER_UART_END_VIRT != RISCV32_CLUSTER_UART_END_PHYS)
+		kpanic("uart end address is not identity mapped");
+	if (RISCV32_CLUSTER_KERNEL_BASE_VIRT != RISCV32_CLUSTER_KERNEL_BASE_PHYS)
+		kpanic("kernel base address is not identity mapped");
+	if (RISCV32_CLUSTER_KERNEL_END_VIRT != RISCV32_CLUSTER_KERNEL_END_PHYS)
+		kpanic("kernel end address is not identity mapped");
+	if (RISCV32_CLUSTER_KPOOL_BASE_VIRT != RISCV32_CLUSTER_KPOOL_BASE_PHYS)
+		kpanic("kernel pool base address is not identity mapped");
+	if (RISCV32_CLUSTER_KPOOL_END_VIRT != RISCV32_CLUSTER_KPOOL_END_PHYS)
+		kpanic("kernel pool end address is not identity mapped");
+}
+
+/*============================================================================*
+ * riscv32_cluster_mem_map()                                                  *
+ *============================================================================*/
+
+/**
+ * @brief Builds the memory layout.
+ *
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Pedro Henrique Penna
+ */
+PRIVATE void riscv32_cluster_mem_map(void)
+{
+	/* Clean root page directory. */
+	for (int i = 0; i < RV32I_PGDIR_LENGTH; i++)
+		pde_clear(&riscv32_cluster_root_pgdir[i]);
+
+	/* Build root address space. */
+	for (int i = 0; i < RISCV32_CLUSTER_MEM_REGIONS; i++)
+	{
+		paddr_t j;
+		vaddr_t k;
+		paddr_t pbase = riscv32_cluster_mem_layout[i].pbase;
+		vaddr_t vbase = riscv32_cluster_mem_layout[i].vbase;
+		size_t size = riscv32_cluster_mem_layout[i].size;
+		int w = riscv32_cluster_mem_layout[i].writable;
+		int x = riscv32_cluster_mem_layout[i].executable;
+
+		/* Map underlying pages. */
+		for (j = pbase, k = vbase;
+			 k < (pbase + size);
+			 j += RV32I_PAGE_SIZE, k += RV32I_PAGE_SIZE)
+		{
+			rv32i_page_map(riscv32_cluster_root_pgtabs[i], j, k, w, x);
+		}
+
+		/* Map underlying page table. */
+		rv32i_pgtab_map(
+				riscv32_cluster_root_pgdir,
+				RV32I_PADDR(riscv32_cluster_root_pgtabs[i]),
+				vbase
+		);
+	}
+
+	/* Load virtual address space and enable MMU. */
+	rv32i_tlb_load(RV32I_PADDR(riscv32_cluster_root_pgdir));
+}
+
+/*============================================================================*
+ * riscv32_cluster_mem_setup()                                                *
+ *============================================================================*/
+
+/**
+ * The rv32i_cluster_mem_setup() function initializes the Memory
+ * Interface of the underlying RISC-V 32-Bit Cluster.
+ *
+ * @author Pedro Henrique Penna
+ */
+PUBLIC void riscv32_cluster_mem_setup(void)
 {
 	int coreid;
 
 	coreid = rv32i_core_get_id();
 
-	kprintf("[hal] initializing mmu");
+	kprintf("[hal] initializing memory layout...");
 
-	/*
-	 * Master core builds
-	 * root page directory.
-	 */
+	/* Master core builds root virtual address space. */
 	if (coreid == RISCV32_CLUSTER_COREID_MASTER)
 	{
-		int pde_idx_kernel;
-		int pde_idx_kpool;
-		int pde_idx_uart;
-		int pde_idx_pic;
-
-		kprintf("[hal] kernel_base=%x kernel_end=%x",
-			RISCV32_CLUSTER_KERNEL_BASE_VIRT,
-			RISCV32_CLUSTER_KERNEL_END_VIRT
-		);
-		kprintf("[hal]  kpool_base=%x  kpool_end=%x",
-			RISCV32_CLUSTER_KPOOL_BASE_VIRT,
-			RISCV32_CLUSTER_KPOOL_END_VIRT
-		);
-		kprintf("[hal]   user_base=%x   user_end=%x",
-			RISCV32_CLUSTER_USER_BASE_VIRT,
-			RISCV32_CLUSTER_USER_END_VIRT
-		);
-		kprintf("[hal] memsize=%d MB kmem=%d KB kpool=%d KB umem=%d KB",
-			MEMORY_SIZE/MB,
-			KMEM_SIZE/KB,
-			KPOOL_SIZE/KB,
-			UMEM_SIZE/KB
-		);
+		riscv32_cluster_mem_info();
 
 		/* Check for memory layout. */
-		riscv32_cluster_mmu_check_alignment();
+		riscv32_cluster_mem_check_layout();
+		riscv32_cluster_mem_check_align();
 
-		/* Clean root page directory. */
-		for (int i = 0; i < RV32I_PGDIR_LENGTH; i++)
-			pde_clear(&rv32i_root_pgdir[i]);
-
-		pde_idx_kernel = pde_idx_get(RISCV32_CLUSTER_KERNEL_BASE_VIRT);
-		pde_idx_kpool = pde_idx_get(RISCV32_CLUSTER_KPOOL_BASE_VIRT);
-		pde_idx_uart = pde_idx_get(RISCV32_CLUSTER_UART_BASE_VIRT);
-		pde_idx_pic = pde_idx_get(RISCV32_CLUSTER_PIC_BASE_VIRT);
-
-		/* Map kernel code and data. */
-		rv32i_root_pgdir[pde_idx_kernel].valid = 1;
-		rv32i_root_pgdir[pde_idx_kernel].readable = 1;
-		rv32i_root_pgdir[pde_idx_kernel].writable = 1;
-		rv32i_root_pgdir[pde_idx_kernel].executable = 1;
-		rv32i_root_pgdir[pde_idx_kernel].frame =
-			RV32I_FRAME(RISCV32_CLUSTER_KERNEL_BASE_VIRT >> RV32I_PAGE_SHIFT);
-
-		/* Map kernel pool. */
-		rv32i_root_pgdir[pde_idx_kpool].valid = 1;
-		rv32i_root_pgdir[pde_idx_kpool].readable = 1;
-		rv32i_root_pgdir[pde_idx_kpool].writable = 1;
-		rv32i_root_pgdir[pde_idx_kpool].executable = 0;
-		rv32i_root_pgdir[pde_idx_kpool].frame =
-			RV32I_FRAME(RISCV32_CLUSTER_KPOOL_BASE_VIRT >> RV32I_PAGE_SHIFT);
-
-		/* Map PIC. */
-		rv32i_root_pgdir[pde_idx_pic].valid = 1;
-		rv32i_root_pgdir[pde_idx_pic].readable = 1;
-		rv32i_root_pgdir[pde_idx_pic].writable = 1;
-		rv32i_root_pgdir[pde_idx_pic].executable = 0;
-		rv32i_root_pgdir[pde_idx_pic].frame =
-			RV32I_FRAME(RISCV32_CLUSTER_PIC_BASE_VIRT >> RV32I_PAGE_SHIFT);
-
-		/* Map UART. */
-		rv32i_root_pgdir[pde_idx_uart].valid = 1;
-		rv32i_root_pgdir[pde_idx_uart].readable = 1;
-		rv32i_root_pgdir[pde_idx_uart].writable = 1;
-		rv32i_root_pgdir[pde_idx_uart].executable = 0;
-		rv32i_root_pgdir[pde_idx_uart].frame =
-			RV32I_FRAME(RISCV32_CLUSTER_UART_BASE_VIRT >> RV32I_PAGE_SHIFT);
-
-		rv32i_tlb_load(RV32I_PADDR(rv32i_root_pgdir));
+		riscv32_cluster_mem_map();
 	}
+
+	/*
+	 * TODO: slave cores should warmup the TLB.
+	 */
 }

--- a/src/hal/arch/cluster/riscv32-cluster/memory.c
+++ b/src/hal/arch/cluster/riscv32-cluster/memory.c
@@ -110,10 +110,10 @@ PUBLIC void riscv32_mmu_setup(void)
 			RISCV32_CLUSTER_USER_END_VIRT
 		);
 		kprintf("[hal] memsize=%d MB kmem=%d KB kpool=%d KB umem=%d KB",
-			_MEMORY_SIZE/MB,
-			_KMEM_SIZE/KB,
-			_KPOOL_SIZE/KB,
-			_UMEM_SIZE/KB
+			MEMORY_SIZE/MB,
+			KMEM_SIZE/KB,
+			KPOOL_SIZE/KB,
+			UMEM_SIZE/KB
 		);
 
 		/* Check for memory layout. */
@@ -125,8 +125,8 @@ PUBLIC void riscv32_mmu_setup(void)
 
 		pde_idx_kernel = pde_idx_get(RISCV32_CLUSTER_KERNEL_BASE_VIRT);
 		pde_idx_kpool = pde_idx_get(RISCV32_CLUSTER_KPOOL_BASE_VIRT);
-		pde_idx_uart = pde_idx_get(RISCV32_CLUSTER_UART_VIRT);
-		pde_idx_pic = pde_idx_get(RISCV32_CLUSTER_PIC_VIRT);
+		pde_idx_uart = pde_idx_get(RISCV32_CLUSTER_UART_BASE_VIRT);
+		pde_idx_pic = pde_idx_get(RISCV32_CLUSTER_PIC_BASE_VIRT);
 
 		/* Map kernel code and data. */
 		rv32i_root_pgdir[pde_idx_kernel].valid = 1;
@@ -150,7 +150,7 @@ PUBLIC void riscv32_mmu_setup(void)
 		rv32i_root_pgdir[pde_idx_pic].writable = 1;
 		rv32i_root_pgdir[pde_idx_pic].executable = 0;
 		rv32i_root_pgdir[pde_idx_pic].frame =
-			RV32I_FRAME(RISCV32_CLUSTER_PIC_VIRT >> RV32I_PAGE_SHIFT);
+			RV32I_FRAME(RISCV32_CLUSTER_PIC_BASE_VIRT >> RV32I_PAGE_SHIFT);
 
 		/* Map UART. */
 		rv32i_root_pgdir[pde_idx_uart].valid = 1;
@@ -158,7 +158,7 @@ PUBLIC void riscv32_mmu_setup(void)
 		rv32i_root_pgdir[pde_idx_uart].writable = 1;
 		rv32i_root_pgdir[pde_idx_uart].executable = 0;
 		rv32i_root_pgdir[pde_idx_uart].frame =
-			RV32I_FRAME(RISCV32_CLUSTER_UART_VIRT >> RV32I_PAGE_SHIFT);
+			RV32I_FRAME(RISCV32_CLUSTER_UART_BASE_VIRT >> RV32I_PAGE_SHIFT);
 
 		rv32i_tlb_load(RV32I_PADDR(rv32i_root_pgdir));
 	}

--- a/src/hal/arch/cluster/riscv32-cluster/setup.c
+++ b/src/hal/arch/cluster/riscv32-cluster/setup.c
@@ -22,17 +22,13 @@
  * SOFTWARE.
  */
 
-/* Must come first. */
-#define __NEED_IVT
-
-#include <arch/core/rv32i/ivt.h>
+#include <arch/cluster/riscv32-cluster/memory.h>
 #include <nanvix/const.h>
 #include <nanvix/klib.h>
 
 /* Import definitions. */
 EXTERN NORETURN void kmain(int, const char *[]);
 EXTERN void rv32i_do_strap(void);
-EXTERN void riscv32_mmu_setup(void);
 
 /*============================================================================*
  * rv32i_core_setup()                                                         *
@@ -50,7 +46,7 @@ PUBLIC void rv32i_core_setup(void)
 
 	rv32i_ivt_setup(&rv32i_do_strap);
 
-	riscv32_mmu_setup();
+	riscv32_cluster_mem_setup();
 }
 
 /*============================================================================*

--- a/src/hal/arch/core/rv32i/mmu.c
+++ b/src/hal/arch/core/rv32i/mmu.c
@@ -1,0 +1,76 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <arch/core/rv32i/mmu.h>
+#include <nanvix/const.h>
+#include <errno.h>
+
+/**
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Pedro Henrique Penna
+ */
+PUBLIC int rv32i_page_map(struct pte *pgtab, paddr_t paddr, vaddr_t vaddr, int w, int x)
+{
+	int idx;
+
+	/* Invalid page table. */
+	if (UNLIKELY(pgtab == NULL))
+		return (-EINVAL);
+
+	idx = pte_idx_get(vaddr);
+
+	pgtab[idx].valid = 1;
+	pgtab[idx].readable = 1;
+	pgtab[idx].writable = (w) ? 1 : 0;
+	pgtab[idx].executable = (x) ? 1 : 0;
+	pgtab[idx].frame = RV32I_FRAME(paddr >> RV32I_PAGE_SHIFT);
+
+	return (0);
+}
+
+/**
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Pedro Henrique Penna
+ */
+PUBLIC int rv32i_pgtab_map(struct pde *pgdir, paddr_t paddr, vaddr_t vaddr)
+{
+	int idx;
+
+	/* Invalid page directory. */
+	if (UNLIKELY(pgdir == NULL))
+		return (-EINVAL);
+
+	idx = pde_idx_get(vaddr);
+
+	pgdir[idx].valid = 1;
+	pgdir[idx].readable = 0;
+	pgdir[idx].writable = 0;
+	pgdir[idx].executable = 0;
+	pgdir[idx].frame = RV32I_FRAME(paddr >> RV32I_PAGE_SHIFT);
+
+	return (0);
+}
+

--- a/src/hal/arch/core/rv32i/mmu.c
+++ b/src/hal/arch/core/rv32i/mmu.c
@@ -55,6 +55,30 @@ PUBLIC int rv32i_page_map(struct pte *pgtab, paddr_t paddr, vaddr_t vaddr, int w
  *
  * @author Pedro Henrique Penna
  */
+PUBLIC int rv32i_huge_page_map(struct pte *pgdir, paddr_t paddr, vaddr_t vaddr, int w, int x)
+{
+	int idx;
+
+	/* Invalid page table. */
+	if (UNLIKELY(pgdir == NULL))
+		return (-EINVAL);
+
+	idx = pde_idx_get(vaddr);
+
+	pgdir[idx].valid = 1;
+	pgdir[idx].readable = 1;
+	pgdir[idx].writable = (w) ? 1 : 0;
+	pgdir[idx].executable = (x) ? 1 : 0;
+	pgdir[idx].frame = RV32I_FRAME(paddr >> RV32I_PAGE_SHIFT);
+
+	return (0);
+}
+
+/**
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Pedro Henrique Penna
+ */
 PUBLIC int rv32i_pgtab_map(struct pde *pgdir, paddr_t paddr, vaddr_t vaddr)
 {
 	int idx;

--- a/src/hal/core/core.c
+++ b/src/hal/core/core.c
@@ -142,7 +142,7 @@ PUBLIC void core_sleep(void)
 PUBLIC int core_wakeup(int coreid)
 {
 	/* Invalid core. */
-	if ((coreid < 0) || (coreid > CORES_NUM))
+	if ((coreid < 0) || (coreid >= CORES_NUM))
 		return (-EINVAL);
 
 	spinlock_lock(&cores[coreid].lock);


### PR DESCRIPTION
Description
----------------

In this Pull Request, I the following extensions to the Memroy Interface:

- `cluster_mem_setup()`: initializes the memory interface
- `cluster_mem_info()`: prints information about virtual memory layout
- `cluster_mem_check_layout()`: asserts the layout of the memory
- `cluster_mem_check_align()`: asserts the alignment of the memory
- `cluster_mem_map()`: builds the memory layout

Additionally, I introduce huge page support for the MMU Interface:

- `pgtab_map()`: maps a page table
- `page_map()`: maps a page
- `huge_page_map()`: maps a huge page

Related Issues
---------------------

- [[hal] Extensions for MMU Interface](https://github.com/nanvix/hal/issues/276)
- [[hal] Huge Page Support](https://github.com/nanvix/hal/issues/269)
- [[hal] Extensions for Memory Interface](https://github.com/nanvix/hal/issues/321)

Pull Request Dependency List
-----------------------------------------

- [[test] Bad Check for Core ID](https://github.com/nanvix/hal/pull/314)