### PR TITLE
[or1k-core] Bug Fix: Using Spinlocks Builtins

### DIFF
--- a/include/arch/core/or1k/spinlock.h
+++ b/include/arch/core/or1k/spinlock.h
@@ -56,9 +56,9 @@
 	typedef uint32_t or1k_spinlock_t;
 
 	/**
-	 * @brief Initializes a or1k_spinlock_t.
+	 * @brief Initializes a spinlock.
 	 *
-	 * @param lock Target or1k_spinlock_t.
+	 * @param lock Target spinlock.
 	 */
 	static inline void or1k_spinlock_init(or1k_spinlock_t *lock)
 	{
@@ -67,11 +67,11 @@
 	}
 
 	/**
-	 * @brief Attempts to lock a or1k_spinlock_t.
+	 * @brief Attempts to lock a spinlock.
 	 *
-	 * @param lock Target or1k_spinlock_t.
+	 * @param lock Target spinlock.
 	 *
-	 * @returns Upon successful completion, the or1k_spinlock_t pointed to by
+	 * @returns Upon successful completion, the spinlock pointed to by
 	 * @p lock is locked and zero is returned. Upon failure, non-zero
 	 * is returned instead, and the lock is not acquired by the
 	 * caller.
@@ -88,29 +88,29 @@
 	}
 
 	/**
-	 * @brief Locks a or1k_spinlock_t.
+	 * @brief Locks a spinlock.
 	 *
-	 * @param lock Target or1k_spinlock_t.
+	 * @param lock Target spinlock.
 	 */
 	static inline void or1k_spinlock_lock(or1k_spinlock_t *lock)
 	{
 		while (or1k_spinlock_trylock(lock))
 			/* noop */;
-		
+
 		__sync_synchronize();
 	}
 
 	/**
-	 * @brief Unlocks a or1k_spinlock_t.
+	 * @brief Unlocks a spinlock.
 	 *
-	 * @param lock Target or1k_spinlock_t.
+	 * @param lock Target spinlock.
 	 */
 	static inline void or1k_spinlock_unlock(or1k_spinlock_t *lock)
 	{
 		__sync_synchronize();
 		*lock = OR1K_SPINLOCK_UNLOCKED;
 	}
-	
+
 #endif
 
 /**@}*/

--- a/include/arch/core/rv32i/spinlock.h
+++ b/include/arch/core/rv32i/spinlock.h
@@ -56,9 +56,9 @@
 	typedef uint32_t rv32i_spinlock_t;
 
 	/**
-	 * @brief Initializes a rv32i_spinlock_t.
+	 * @brief Initializes a spinlock.
 	 *
-	 * @param lock Target rv32i_spinlock_t.
+	 * @param lock Target spinlock.
 	 *
 	 * @todo Implement this function.
 	 */
@@ -69,11 +69,11 @@
 	}
 
 	/**
-	 * @brief Attempts to lock a rv32i_spinlock_t.
+	 * @brief Attempts to lock a spinlock.
 	 *
-	 * @param lock Target rv32i_spinlock_t.
+	 * @param lock Target spinlock.
 	 *
-	 * @returns Upon successful completion, the rv32i_spinlock_t pointed to by
+	 * @returns Upon successful completion, the spinlock pointed to by
 	 * @p lock is locked and zero is returned. Upon failure, non-zero
 	 * is returned instead, and the lock is not acquired by the
 	 * caller.
@@ -92,9 +92,9 @@
 	}
 
 	/**
-	 * @brief Locks a rv32i_spinlock_t.
+	 * @brief Locks a spinlock.
 	 *
-	 * @param lock Target rv32i_spinlock_t.
+	 * @param lock Target spinlock.
 	 *
 	 * @todo Implement this function.
 	 */
@@ -102,13 +102,14 @@
 	{
 		while (rv32i_spinlock_trylock(lock))
 			/* noop */;
+
 		__sync_synchronize();
 	}
 
 	/**
-	 * @brief Unlocks a rv32i_spinlock_t.
+	 * @brief Unlocks a spinlock.
 	 *
-	 * @param lock Target rv32i_spinlock_t.
+	 * @param lock Target spinlock.
 	 *
 	 * @todo Implement this function.
 	 */


### PR DESCRIPTION
Description
--------------
Since the OpenRISC GCC supports the builtins for locks and barriers, we should rely on it, instead of writing our version.

Related Issues
--------------------
[[or1k-core] Missing Spinlock Memory Barrier](https://github.com/nanvix/hal/issues/175)