### PR TITLE
[rv32i] Enabling Unit Tests for TLB and MMU Interfaces

### DIFF
--- a/include/arch/core/rv32i/mmu.h
+++ b/include/arch/core/rv32i/mmu.h
@@ -139,7 +139,7 @@
 		unsigned readable   :  1; /**< Readable?    */
 		unsigned writable   :  1; /**< Writable?    */
 		unsigned executable :  1; /**< Executable?  */
-		unsigned            :  1; /**< Reserved     */
+		unsigned user       :  1; /**< User page?   */
 		unsigned global     :  1; /**< Global Page? */
 		unsigned            :  1; /**< Reserved     */
 		unsigned            :  1; /**< Reserved     */
@@ -499,6 +499,44 @@
 			return (-EINVAL);
 
 		return (pde->executable);
+	}
+
+	/**
+	 * @brief Sets/clears the user bit of a page.
+	 *
+	 * @param pde Page directory entry of target page.
+	 * @param set Set bit?
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	static inline int pde_user_set(struct pde *pde, int set)
+	{
+		/* Invalid PTE. */
+		if (pde == NULL)
+			return (-EINVAL);
+
+		pde->user = (set) ? 1 : 0;
+
+		return (0);
+	}
+
+	/**
+	 * @brief Asserts if the user bit of a page.
+	 *
+	 * @param pde Page directory entry of target page.
+	 *
+	 * @returns If the user bit of the target page, non zero is
+	 * returned. Otherwise, zero is returned instead.
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	static inline int pde_is_user(struct pde *pde)
+	{
+		/* Invalid PTE. */
+		if (pde == NULL)
+			return (-EINVAL);
+
+		return (pde->user);
 	}
 
 	/**

--- a/src/hal/build/makefile.qemu-riscv32
+++ b/src/hal/build/makefile.qemu-riscv32
@@ -28,6 +28,7 @@ C_SRC = $(wildcard arch/core/$(CORE)/*.c)       \
         $(wildcard arch/cluster/$(CLUSTER)/*.c) \
         $(wildcard klib/*.c)                    \
 		$(wildcard core/interrupt.c)            \
+		$(wildcard core/mmu.c)                  \
         $(wildcard *.c)
 
 ASM_SRC = $(wildcard arch/core/$(CORE)/*.S)       \

--- a/src/test/build/makefile.qemu-riscv32
+++ b/src/test/build/makefile.qemu-riscv32
@@ -27,6 +27,8 @@ export LDFLAGS  += -L $(LINKERDIR)/ -T link.ld
 C_SRC = $(wildcard main.c)      \
         $(wildcard exception.c) \
         $(wildcard interrupt.c) \
+        $(wildcard mmu.c) \
+        $(wildcard tlb.c) \
         $(wildcard syscalls.c)
 
 # Object Files

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -63,12 +63,11 @@ PUBLIC void kmain(int argc, const char *argv[])
 
 	test_exception();
 	test_interrupt();
+	test_mmu();
+	test_tlb();
 
 #if !defined(__rv32i__)
-
 	test_trap();
-	test_tlb();
-	test_mmu();
 #if (CLUSTER_IS_MULTICORE)
 	test_core();
 #endif


### PR DESCRIPTION
Description
----------------

In this Pull Request, I enable unit tests for TLB and MMU Interfaces in rv32i cores.

Related Issues
--------------------

- [[rv32i] Enable Unit Tests for MMU Interface](https://github.com/nanvix/hal/issues/296)
- [[rv32i] Enable Unit Tests for TLB Interface](https://github.com/nanvix/hal/issues/295)