### PR TITLE
[rv32i] Clock Uses 64-Bit Precision

### DIFF
--- a/include/arch/core/rv32i/clock.h
+++ b/include/arch/core/rv32i/clock.h
@@ -26,8 +26,8 @@
 #define ARCH_CORE_RV32I_CLOCK_H_
 
 /**
- * @addtogroup clock-core-timer Timer
- * @ingroup clock-core
+ * @addtogroup rv32i-clock Timer
+ * @ingroup rv32i
  *
  * @brief Programmable Timer Interface
  */
@@ -75,15 +75,15 @@
 	 *
 	 * @returns The value of the mtime register.
 	 */
-	static inline rv32i_dword_t rv32i_mtime_read(void)
+	static inline uint64_t rv32i_mtime_read(void)
 	{
-		rv32i_word_t lo;
-		rv32i_word_t hi;
+		uint32_t lo;
+		uint32_t hi;
 
 		hi = *(RV32I_WORD_PTR(MTIME_ADDR + RV32I_WORD_SIZE));
 		lo = *(RV32I_WORD_PTR(MTIME_ADDR));
 
-		return (RV32I_MAKE_DWORD(hi, lo));
+		return (((hi & 0xffffffffull) << 32) | (lo & 0xffffffffull));
 	}
 
 	/**
@@ -91,14 +91,15 @@
 	 *
 	 * @returns The value of the mtimecmp register.
 	 */
-	static inline rv32i_dword_t rv32i_mtimecmp_read(void)
+	static inline uint64_t rv32i_mtimecmp_read(void)
 	{
-		rv32i_word_t lo, hi;
+		uint32_t lo;
+		uint32_t hi;
 
 		hi = *(RV32I_WORD_PTR(MTIMECMP_ADDR + RV32I_WORD_SIZE));
 		lo = *(RV32I_WORD_PTR(MTIMECMP_ADDR));
 
-		return (RV32I_MAKE_DWORD(hi, lo));
+		return (((hi & 0xffffffffull) << 32) | (lo & 0xffffffffull));
 	}
 
 	/**
@@ -106,7 +107,7 @@
 	 *
 	 * @param time Value to write.
 	 */
-	static inline void rv32i_mtimecmp_write(rv32i_dword_t time)
+	static inline void rv32i_mtimecmp_write(uint64_t time)
 	{
 		*((rv32i_word_t *)(MTIMECMP_ADDR + RV32I_WORD_SIZE)) = -1;
 		*((rv32i_word_t *)(MTIMECMP_ADDR)) = RV32I_WORD(time & -1);

--- a/include/arch/core/rv32i/mmu.h
+++ b/include/arch/core/rv32i/mmu.h
@@ -139,7 +139,7 @@
 		unsigned readable   :  1; /**< Readable?    */
 		unsigned writable   :  1; /**< Writable?    */
 		unsigned executable :  1; /**< Executable?  */
-		unsigned            :  1; /**< Reserved     */
+		unsigned user       :  1; /**< User page?   */
 		unsigned global     :  1; /**< Global Page? */
 		unsigned            :  1; /**< Reserved     */
 		unsigned            :  1; /**< Reserved     */
@@ -499,6 +499,44 @@
 			return (-EINVAL);
 
 		return (pde->executable);
+	}
+
+	/**
+	 * @brief Sets/clears the user bit of a page.
+	 *
+	 * @param pde Page directory entry of target page.
+	 * @param set Set bit?
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	static inline int pde_user_set(struct pde *pde, int set)
+	{
+		/* Invalid PTE. */
+		if (pde == NULL)
+			return (-EINVAL);
+
+		pde->user = (set) ? 1 : 0;
+
+		return (0);
+	}
+
+	/**
+	 * @brief Asserts if the user bit of a page.
+	 *
+	 * @param pde Page directory entry of target page.
+	 *
+	 * @returns If the user bit of the target page, non zero is
+	 * returned. Otherwise, zero is returned instead.
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	static inline int pde_is_user(struct pde *pde)
+	{
+		/* Invalid PTE. */
+		if (pde == NULL)
+			return (-EINVAL);
+
+		return (pde->user);
 	}
 
 	/**

--- a/src/hal/build/makefile.qemu-riscv32
+++ b/src/hal/build/makefile.qemu-riscv32
@@ -28,6 +28,7 @@ C_SRC = $(wildcard arch/core/$(CORE)/*.c)       \
         $(wildcard arch/cluster/$(CLUSTER)/*.c) \
         $(wildcard klib/*.c)                    \
 		$(wildcard core/interrupt.c)            \
+		$(wildcard core/mmu.c)                  \
         $(wildcard *.c)
 
 ASM_SRC = $(wildcard arch/core/$(CORE)/*.S)       \

--- a/src/test/build/makefile.qemu-riscv32
+++ b/src/test/build/makefile.qemu-riscv32
@@ -27,6 +27,8 @@ export LDFLAGS  += -L $(LINKERDIR)/ -T link.ld
 C_SRC = $(wildcard main.c)      \
         $(wildcard exception.c) \
         $(wildcard interrupt.c) \
+        $(wildcard mmu.c) \
+        $(wildcard tlb.c) \
         $(wildcard syscalls.c)
 
 # Object Files

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -63,12 +63,11 @@ PUBLIC void kmain(int argc, const char *argv[])
 
 	test_exception();
 	test_interrupt();
+	test_mmu();
+	test_tlb();
 
 #if !defined(__rv32i__)
-
 	test_trap();
-	test_tlb();
-	test_mmu();
 #if (CLUSTER_IS_MULTICORE)
 	test_core();
 #endif


### PR DESCRIPTION
Description
----------------

Previously, we were using words in the implementation of the clock interface for rv32i cores. However, the clock in RISC-V architectures has a fixed-width of 64-bits, regardless the size of a word. In this Pull Request, I fix this problem.

Pull Request Dependency List
-----------------------------------------

-[[rv32i] Enabling Unit Tests for TLB and MMU Interfaces](https://github.com/nanvix/hal/pull/331)