### PR TITLE
[optimsoc] Bug Fix: Wrong Cluster Header

### DIFF
--- a/include/arch/processor/optimsoc/_optimsoc.h
+++ b/include/arch/processor/optimsoc/_optimsoc.h
@@ -27,6 +27,6 @@
 
 	#undef  __NEED_CLUSTER_OR1K
 	#define __NEED_CLUSTER_OR1K
-	#include <arch/cluster/or1k.h>
+	#include <arch/cluster/or1k-cluster.h>
 
 #endif /* _PROCESSOR_OR1K_OPTIMSOC_H_ */


### PR DESCRIPTION
Description
---------------
In the commit 3f5841293b83522f9f36c9ffec6c4eb751e7212a the cluster header was changed and the _optimsoc header was not updated accordingly, thus, the OpTiMSoC target was not able to compile.