### PR TITLE
[riscv32-cluster] Support for IPIs

### DIFF
--- a/include/arch/core/rv32i.h
+++ b/include/arch/core/rv32i.h
@@ -44,6 +44,10 @@
 	#include <arch/core/rv32i/tlb.h>
 	#include <arch/core/rv32i/trap.h>
 
+	#ifdef __NEED_CORE_MACHINE
+		#include <arch/core/rv32i/machine.h>
+	#endif
+
 /**
  * @cond rv32i
  */

--- a/include/arch/core/rv32i/asm.h
+++ b/include/arch/core/rv32i/asm.h
@@ -30,7 +30,7 @@
 	#endif
 
 	/* Must come first. */
-	#define __NEED_CONTEXT
+	#define __NEED_CORE_CONTEXT
 
 	#include <arch/core/rv32i/context.h>
 	#include <arch/core/rv32i/mmu.h>

--- a/include/arch/core/rv32i/context.h
+++ b/include/arch/core/rv32i/context.h
@@ -25,9 +25,9 @@
 #ifndef ARCH_CORE_RV32I_CONTEXT_H_
 #define ARCH_CORE_RV32I_CONTEXT_H_
 
-#if (!defined(__NEED_CONTEXT))
-	#error "do not include this file"
-#endif
+	#ifndef __NEED_CORE_CONTEXT
+		#error "do not include this file"
+	#endif
 
 /**
  * @addtogroup rv32i-core-context Context

--- a/include/arch/core/rv32i/excp.h
+++ b/include/arch/core/rv32i/excp.h
@@ -34,8 +34,8 @@
 /**@{*/
 
 	/* Must come first. */
-	#define __NEED_IVT
-	#define __NEED_CONTEXT
+	#define __NEED_CORE_IVT
+	#define __NEED_CORE_CONTEXT
 	#define __NEED_MEMORY_TYPES
 
 	#include <arch/core/rv32i/context.h>

--- a/include/arch/core/rv32i/int.h
+++ b/include/arch/core/rv32i/int.h
@@ -121,6 +121,14 @@
 	}
 
 	/**
+	 * @brief Waits for an interrupt.
+	 */
+	static inline void rv32i_int_wait(void)
+	{
+		asm volatile ("wfi");
+	}
+
+	/**
 	 * @brief Unmasks an interrupt.
 	 *
 	 * @param irqnum Number of target interrupt request.

--- a/include/arch/core/rv32i/int.h
+++ b/include/arch/core/rv32i/int.h
@@ -34,8 +34,8 @@
 /**@{*/
 
 	/* Must come first. */
-	#define __NEED_IVT
-	#define __NEED_CONTEXT
+	#define __NEED_CORE_IVT
+	#define __NEED_CORE_CONTEXT
 	#define __NEED_CORE_REGS
 	#define __NEED_CORE_TYPES
 

--- a/include/arch/core/rv32i/ivt.h
+++ b/include/arch/core/rv32i/ivt.h
@@ -33,7 +33,7 @@
  */
 /**@{*/
 
-	#ifndef __NEED_IVT
+	#ifndef __NEED_CORE_IVT
 		#error "do not include this file"
 	#endif
 

--- a/include/arch/core/rv32i/machine.h
+++ b/include/arch/core/rv32i/machine.h
@@ -1,0 +1,102 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#ifndef ARCH_CORE_RV32I_MACHINE_H_
+#define ARCH_CORE_RV32I_MACHINE_H_
+
+/**
+ * @addtogroup rv32i-core-machine Machine
+ * @ingroup rv32i-core
+ *
+ * @brief Machine Interface
+ */
+/**@{*/
+
+	#ifndef __NEED_CORE_MACHINE
+		#error "do not include this file"
+	#endif
+
+	/* Must come first. */
+	#define __NEED_CORE_CONTEXT
+	#define __NEED_CORE_TYPES
+
+	#include <arch/core/rv32i/context.h>
+	#include <arch/core/rv32i/types.h>
+	#include <nanvix/const.h>
+
+#ifndef _ASM_FILE_
+
+	/**
+	 * @brief Dumps all CSRs.
+	 */
+	EXTERN void rv32i_dump_all_csr(void);
+
+	/**
+	 * @brief Enters supervisor mode.
+	 *
+	 * @param pc Target program counter.
+	 */
+	EXTERN NORETURN void rv32i_supervisor_enter(rv32i_word_t pc);
+
+	/**
+	 * @brief Handles a bad machine exception.
+	 */
+	EXTERN NORETURN void rv32i_do_mbad(const struct context *ctx);
+
+	/**
+	 * @brief Handles machine calls.
+	 *
+	 * @param ctx Interrupted context
+	 */
+	EXTERN void rv32i_do_mcall(struct context *ctx);
+
+	/**
+	 * @brief Handles machine exceptions.
+	 *
+	 * @param ctx Interrupted context
+	 */
+	EXTERN NORETURN void rv32i_do_mexcp(const struct context *ctx);
+
+	/**
+	 * @brief Handles machine interrupts.
+	 *
+	 * @param ctx Interrupted context.
+	 */
+	EXTERN void rv32i_do_mint(const struct context *ctx);
+
+	/**
+	 * @brief Delegates traps to loower-privilege levels.
+	 *
+	 * @bug FIXME check if supervisor mode is supported.
+	 *
+	 * @author Pedro Henrique Penna
+	 */
+	EXTERN void rv32i_machine_delegate_traps(void);
+
+#endif /* _ASM_FILE_ */
+
+/**@}*/
+
+#endif /* ARCH_CORE_RV32I_MACHINE_H_ */

--- a/include/arch/core/rv32i/mcall.h
+++ b/include/arch/core/rv32i/mcall.h
@@ -48,6 +48,7 @@
 	#define RV32I_MCALL_TIMER_ACK      4 /**< rv32i_mcall_timer_ack()   */
 	#define RV32I_MCALL_MINT_ENABLE    5 /**< rv32i_mcall_int_enable()  */
 	#define RV32I_MCALL_MINT_DISABLE   6 /**< rv32i_mcall_int_disable() */
+	#define RV32I_MCALL_IPI_ACK        7 /**< rv32i_mcall_ipi_ack()     */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -189,6 +190,14 @@
 	static inline void rv32i_mcall_timer_ack(void)
 	{
 		rv32i_mcall0(RV32I_MCALL_TIMER_ACK);
+	}
+
+	/**
+	 * @brief Acknowledges an IPI.
+	 */
+	static inline void rv32i_mcall_ipi_ack(void)
+	{
+		rv32i_mcall0(RV32I_MCALL_IPI_ACK);
 	}
 
 #endif /* _ASM_FILE_ */

--- a/src/hal/arch/cluster/riscv32-cluster/boot.S
+++ b/src/hal/arch/cluster/riscv32-cluster/boot.S
@@ -132,8 +132,9 @@ rv32i_do_mtrap:
 			bne   t1, t2, rv32i_do_mtrap.ipi
 			li    t1, RV32I_MIE_MTIE
 			csrc  mie, t1
+			li    t1, RV32I_MIP_MTIP
+			csrc  mip, t1
 			li    t1, RV32I_MIP_STIP
-			csrs  mip, t1
 			csrs  sip, t1
 			j     rv32i_do_mtrap.out
 

--- a/src/hal/arch/cluster/riscv32-cluster/boot.S
+++ b/src/hal/arch/cluster/riscv32-cluster/boot.S
@@ -127,13 +127,26 @@ rv32i_do_mtrap:
 		and   t1, t0, t1             # t1 = cause
 
 		/* Timer interrupt? */
-		li    t2, RV32I_MCAUSE_MTI
-		bne  t1, t2, rv32i_do_mtrap.out
+		rv32i_do_mtrap.timer:
+			li    t2, RV32I_MCAUSE_MTI
+			bne   t1, t2, rv32i_do_mtrap.ipi
 			li    t1, RV32I_MIE_MTIE
 			csrc  mie, t1
 			li    t1, RV32I_MIP_STIP
 			csrs  mip, t1
 			csrs  sip, t1
+			j     rv32i_do_mtrap.out
+
+		/* IPI */
+		rv32i_do_mtrap.ipi:
+			li    t2, RV32I_MCAUSE_MSI
+			bne   t1, t2, rv32i_do_mtrap.mint.bad
+			call  riscv32_cluster_do_ipi
+			j     rv32i_do_mtrap.out
+
+		/* Unkown Interrupt */
+		rv32i_do_mtrap.mint.bad:
+			call  rv32i_do_mint
 
 	/* Return. */
 	rv32i_do_mtrap.out:

--- a/src/hal/arch/cluster/riscv32-cluster/clint.c
+++ b/src/hal/arch/cluster/riscv32-cluster/clint.c
@@ -1,0 +1,36 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* Must come first. */
+#define __NEED_CLUSTER_CLINT
+
+#include <arch/cluster/riscv32-cluster/clint.h>
+#include <nanvix/const.h>
+
+/**
+ * Machine Software Interrupt Pending Register (msip).
+ */
+PUBLIC volatile uint32_t *riscv32_cluster_msip =
+	(volatile uint32_t *) RISCV32_CLUSTER_CLINT_MSIP_BASE;
+

--- a/src/hal/arch/cluster/riscv32-cluster/event.c
+++ b/src/hal/arch/cluster/riscv32-cluster/event.c
@@ -22,6 +22,10 @@
  * SOFTWARE.
  */
 
+/* Must come first. */
+#define __NEED_CLUSTER_CLINT
+
+#include <arch/cluster/riscv32-cluster/clint.h>
 #include <arch/cluster/riscv32-cluster/cores.h>
 #include <nanvix/const.h>
 
@@ -46,6 +50,27 @@ PRIVATE int events[RISCV32_CLUSTER_NUM_CORES] ALIGN(RV32I_CACHE_LINE_SIZE) = {
 	0, /* Slave Core 3 */
 	0, /* Slave Core 4 */
 };
+
+/*============================================================================*
+ * riscv32_cluster_event_send()                                               *
+ *============================================================================*/
+
+/**
+ * @brief Handles IPIs.
+ *
+ * @note This executes in machine mode.
+ */
+PUBLIC void riscv32_cluster_do_ipi(const struct context *ctx)
+{
+	rv32i_word_t mie;
+
+	/* Clear Machine IPI. */
+	mie = rv32i_mie_read();
+	mie = BITS_SET(mie, RV32I_MIE_MSIE, 0);
+	rv32i_mie_write(mie);
+
+	UNUSED(ctx);
+}
 
 /*============================================================================*
  * riscv32_cluster_event_send()                                               *

--- a/src/hal/arch/cluster/riscv32-cluster/machine.c
+++ b/src/hal/arch/cluster/riscv32-cluster/machine.c
@@ -1,0 +1,127 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* Must come first. */
+#define __NEED_CORE_MACHINE
+
+#include <arch/cluster/riscv32-cluster/memory.h>
+#include <arch/cluster/riscv32-cluster/cores.h>
+#include <arch/stdout/16550a.h>
+#include <nanvix/const.h>
+#include <errno.h>
+
+/**
+ * @brief Startup fence.
+ */
+PRIVATE struct
+{
+	int master_alive;
+	rv32i_spinlock_t lock;
+} fence = { FALSE , RV32I_SPINLOCK_UNLOCKED};
+
+/**
+ * @brief Releases the startup fence.
+ */
+PRIVATE void rv32i_fence_release(void)
+{
+	rv32i_spinlock_lock(&fence.lock);
+		fence.master_alive = TRUE;
+	rv32i_spinlock_unlock(&fence.lock);
+}
+
+/**
+ * @brief Waits on the startup fence.
+ */
+PRIVATE void rv32i_fence_wait(void)
+{
+	while (TRUE)
+	{
+		rv32i_spinlock_lock(&fence.lock);
+
+			/* Fence is released. */
+			if (fence.master_alive)
+			{
+				rv32i_spinlock_unlock(&fence.lock);
+				break;
+			}
+
+			noop();
+		rv32i_spinlock_unlock(&fence.lock);
+	}
+}
+
+/**
+ * @brief Initializes machine mode.
+ *
+ * @param pc Target program counter.
+ */
+PUBLIC NORETURN void rv32i_machine_master_setup(rv32i_word_t pc)
+{
+	rv32i_word_t mie;
+
+	/* TODO: do this even earlier. */
+	kmemset(&__BSS_START, 0, &__BSS_END - &__BSS_START);
+
+	/*
+	 * Early initialization of
+	 * UART to help us debugging.
+	 */
+	uart_16550a_init();
+
+	rv32i_fence_release();
+
+	/* Enable machine IRQs. */
+	mie = rv32i_mie_read();
+	mie = BITS_SET(mie, RV32I_MIE_MSIE, 1);
+	mie = BITS_SET(mie, RV32I_MIE_MTIE, 1);
+	mie = BITS_SET(mie, RV32I_MIE_MEIE, 1);
+	rv32i_mie_write(mie);
+
+	rv32i_machine_delegate_traps();
+
+	rv32i_supervisor_enter(pc);
+}
+
+/**
+ * @brief Initializes machine mode.
+ *
+ * @param pc Target program counter.
+ */
+PUBLIC NORETURN void rv32i_machine_slave_setup(rv32i_word_t pc)
+{
+	rv32i_word_t mie;
+
+	/* Enable machine IRQs. */
+	mie = rv32i_mie_read();
+	mie = BITS_SET(mie, RV32I_MIE_MSIE, 0);
+	mie = BITS_SET(mie, RV32I_MIE_MTIE, 0);
+	mie = BITS_SET(mie, RV32I_MIE_MEIE, 0);
+	rv32i_mie_write(mie);
+
+	rv32i_machine_delegate_traps();
+
+	rv32i_fence_wait();
+
+	rv32i_supervisor_enter(pc);
+}

--- a/src/hal/arch/cluster/riscv32-cluster/machine.c
+++ b/src/hal/arch/cluster/riscv32-cluster/machine.c
@@ -114,7 +114,7 @@ PUBLIC NORETURN void rv32i_machine_slave_setup(rv32i_word_t pc)
 
 	/* Enable machine IRQs. */
 	mie = rv32i_mie_read();
-	mie = BITS_SET(mie, RV32I_MIE_MSIE, 0);
+	mie = BITS_SET(mie, RV32I_MIE_MSIE, 1);
 	mie = BITS_SET(mie, RV32I_MIE_MTIE, 0);
 	mie = BITS_SET(mie, RV32I_MIE_MEIE, 0);
 	rv32i_mie_write(mie);

--- a/src/hal/arch/core/rv32i/core.c
+++ b/src/hal/arch/core/rv32i/core.c
@@ -23,7 +23,7 @@
  */
 
 /* Must come first. */
-#define __NEED_IVT
+#define __NEED_CORE_IVT
 
 #include <arch/core/rv32i/ivt.h>
 #include <nanvix/const.h>

--- a/src/hal/arch/core/rv32i/ivt.c
+++ b/src/hal/arch/core/rv32i/ivt.c
@@ -23,7 +23,7 @@
  */
 
 /* Must come first. */
-#define __NEED_IVT
+#define __NEED_CORE_IVT
 #define __NEED_CORE_REGS
 #define __NEED_CORE_TYPES
 

--- a/src/hal/arch/core/rv32i/machine.c
+++ b/src/hal/arch/core/rv32i/machine.c
@@ -242,6 +242,13 @@ PUBLIC void rv32i_do_mcall(struct context *ctx)
 			ctx->a0 = 0;
 			break;
 
+		/* Re-Enable IPIs. */
+		case RV32I_MCALL_IPI_ACK:
+			rv32i_csr_clear(mip, RV32I_MIP_MSIP);
+			rv32i_csr_set(mie, RV32I_MIE_MSIE);
+			ctx->a0 = 0;
+		break;
+
 		/* Write mtimecmp register. */
 		case RV32I_MCALL_TIMER_ACK:
 			rv32i_csr_set(mie, RV32I_MIE_MTIE);

--- a/src/hal/arch/core/rv32i/machine.c
+++ b/src/hal/arch/core/rv32i/machine.c
@@ -134,8 +134,9 @@ PUBLIC void rv32i_dump_all_csr(void)
 		rv32i_scause_read(),
 		rv32i_stval_read()
 	);
-	kprintf("[hal]     mepc=%x",
-		rv32i_mepc_read()
+	kprintf("[hal]     mepc=%x mhartid=%x",
+		rv32i_mepc_read(),
+		rv32i_mhartid_read()
 	);
 	kprintf("[hal]     sepc=%x    satp=%x",
 		rv32i_sepc_read(),

--- a/src/hal/core/interrupt.c
+++ b/src/hal/core/interrupt.c
@@ -55,7 +55,7 @@ PRIVATE void default_handler(int num)
 	UNUSED(num);
 
 	/* Too many spurious interrupts. */
-	if (spurious >= INTERRUPT_SPURIOUS_THRESHOLD)
+	if (++spurious >= INTERRUPT_SPURIOUS_THRESHOLD)
 		kprintf("[hal] spurious interrupt %d", num);
 
 	noop();


### PR DESCRIPTION
Description
----------------

In this Pull Request, I introduce support for Inter-Processor Interrupts (IPIs) in the RISC-V 32-Bit Cluster famility.

Related Issues
---------------------

- [[riscv32-cluster] Event Interface](https://github.com/nanvix/hal/issues/326)