### PR TITLE
[rv32gc] Re-Enabling Trap Interface

### DIFF
--- a/include/arch/core/rv32gc/asm.h
+++ b/include/arch/core/rv32gc/asm.h
@@ -63,6 +63,93 @@
  *============================================================================*/
 
 	/**
+	 * @brief Number of scratch registers.
+	 */
+	#define RV32GC_SCRATCH_REGS_NUM 17
+
+	/**
+	 * @brief Caller stack frame size.
+	 */
+	#define RV32GC_CALLER_FRAME_SIZE \
+		(RV32GC_SCRATCH_REGS_NUM*RV32GC_WORD_SIZE)
+
+	/**
+	 * @brief Offsets to Caller Stack Frame
+	 */
+	/**@{*/
+	#define RV32GC_CALLER_FRAME_RA   0*RV32GC_WORD_SIZE /**< Scratch Register  0 */
+	#define RV32GC_CALLER_FRAME_GP   1*RV32GC_WORD_SIZE /**< Scratch Register  1 */
+	#define RV32GC_CALLER_FRAME_TP   2*RV32GC_WORD_SIZE /**< Scratch Register  2 */
+	#define RV32GC_CALLER_FRAME_T0   3*RV32GC_WORD_SIZE /**< Scratch Register  3 */
+	#define RV32GC_CALLER_FRAME_T1   4*RV32GC_WORD_SIZE /**< Scratch Register  4 */
+	#define RV32GC_CALLER_FRAME_T2   5*RV32GC_WORD_SIZE /**< Scratch Register  5 */
+	#define RV32GC_CALLER_FRAME_T3   6*RV32GC_WORD_SIZE /**< Scratch Register  6 */
+	#define RV32GC_CALLER_FRAME_T4   7*RV32GC_WORD_SIZE /**< Scratch Register  7 */
+	#define RV32GC_CALLER_FRAME_T5   8*RV32GC_WORD_SIZE /**< Scratch Register  8 */
+	#define RV32GC_CALLER_FRAME_T6   9*RV32GC_WORD_SIZE /**< Scratch Register  9 */
+	#define RV32GC_CALLER_FRAME_A1  10*RV32GC_WORD_SIZE /**< Scratch Register 10 */
+	#define RV32GC_CALLER_FRAME_A2  11*RV32GC_WORD_SIZE /**< Scratch Register 11 */
+	#define RV32GC_CALLER_FRAME_A3  12*RV32GC_WORD_SIZE /**< Scratch Register 12 */
+	#define RV32GC_CALLER_FRAME_A4  13*RV32GC_WORD_SIZE /**< Scratch Register 13 */
+	#define RV32GC_CALLER_FRAME_A5  14*RV32GC_WORD_SIZE /**< Scratch Register 14 */
+	#define RV32GC_CALLER_FRAME_A6  15*RV32GC_WORD_SIZE /**< Scratch Register 15 */
+	#define RV32GC_CALLER_FRAME_A7  16*RV32GC_WORD_SIZE /**< Scratch Register 16 */
+	/**@}*/
+
+	.macro rv32gc_do_fn_call_save function
+		add  sp, sp, -RV32GC_CALLER_FRAME_SIZE
+
+		sw  ra, RV32GC_CALLER_FRAME_RA(sp)
+		sw  gp, RV32GC_CALLER_FRAME_GP(sp)
+		sw  tp, RV32GC_CALLER_FRAME_TP(sp)
+		sw  t0, RV32GC_CALLER_FRAME_T0(sp)
+		sw  t1, RV32GC_CALLER_FRAME_T1(sp)
+		sw  t2, RV32GC_CALLER_FRAME_T2(sp)
+		sw  t3, RV32GC_CALLER_FRAME_T3(sp)
+		sw  t4, RV32GC_CALLER_FRAME_T4(sp)
+		sw  t5, RV32GC_CALLER_FRAME_T5(sp)
+		sw  t6, RV32GC_CALLER_FRAME_T6(sp)
+		sw  a1, RV32GC_CALLER_FRAME_A1(sp)
+		sw  a2, RV32GC_CALLER_FRAME_A2(sp)
+		sw  a3, RV32GC_CALLER_FRAME_A3(sp)
+		sw  a4, RV32GC_CALLER_FRAME_A4(sp)
+		sw  a5, RV32GC_CALLER_FRAME_A5(sp)
+		sw  a6, RV32GC_CALLER_FRAME_A6(sp)
+		sw  a7, RV32GC_CALLER_FRAME_A7(sp)
+	.endm
+
+	.macro rv32gc_do_fn_call_restore function
+
+		lw  ra, RV32GC_CALLER_FRAME_RA(sp)
+		lw  gp, RV32GC_CALLER_FRAME_GP(sp)
+		lw  tp, RV32GC_CALLER_FRAME_TP(sp)
+		lw  t0, RV32GC_CALLER_FRAME_T0(sp)
+		lw  t1, RV32GC_CALLER_FRAME_T1(sp)
+		lw  t2, RV32GC_CALLER_FRAME_T2(sp)
+		lw  t3, RV32GC_CALLER_FRAME_T3(sp)
+		lw  t4, RV32GC_CALLER_FRAME_T4(sp)
+		lw  t5, RV32GC_CALLER_FRAME_T5(sp)
+		lw  t6, RV32GC_CALLER_FRAME_T6(sp)
+		lw  a1, RV32GC_CALLER_FRAME_A1(sp)
+		lw  a2, RV32GC_CALLER_FRAME_A2(sp)
+		lw  a3, RV32GC_CALLER_FRAME_A3(sp)
+		lw  a4, RV32GC_CALLER_FRAME_A4(sp)
+		lw  a5, RV32GC_CALLER_FRAME_A5(sp)
+		lw  a6, RV32GC_CALLER_FRAME_A6(sp)
+		lw  a7, RV32GC_CALLER_FRAME_A7(sp)
+
+		add  sp, sp, RV32GC_CALLER_FRAME_SIZE
+	.endm
+
+	.macro rv32gc_do_fn_call function
+		rv32gc_do_fn_call_save
+
+		call \function
+
+		rv32gc_do_fn_call_restore
+	.endm
+
+	/**
 	 * @brief Number of saved registers.
 	 */
 	#define RV32GC_SAVED_REGS_NUM 12

--- a/include/arch/core/rv32gc/asm.h
+++ b/include/arch/core/rv32gc/asm.h
@@ -63,55 +63,55 @@
  *============================================================================*/
 
 	/**
-	 * @brief Number of preserved registers.
+	 * @brief Number of saved registers.
 	 */
-	#define RV32GC_PRESERVED_REGS_NUM 12
+	#define RV32GC_SAVED_REGS_NUM 12
 
 	/**
-	 * @brief Stack frame size for slow call.
+	 * @brief Callee stack frame size.
 	 */
-	#define RV32GC_SLOW_CALL_FRAME_SIZE \
-		(RV32GC_PRESERVED_REGS_NUM*RV32GC_WORD_SIZE)
+	#define RV32GC_CALLEE_FRAME_SIZE \
+		(RV32GC_SAVED_REGS_NUM*RV32GC_WORD_SIZE)
 
 	/**
-	* @brief Offsets to Stack Frame
-	*/
+	 * @brief Offsets to Callee Stack Frame
+	 */
 	/**@{*/
-	#define RV32GC_FRAME_FP   0*RV32GC_WORD_SIZE /**< Frame Pointer Register */
-	#define RV32GC_FRAME_S1   1*RV32GC_WORD_SIZE /**< Saved Register  1      */
-	#define RV32GC_FRAME_S2   2*RV32GC_WORD_SIZE /**< Saved Register  2      */
-	#define RV32GC_FRAME_S3   3*RV32GC_WORD_SIZE /**< Saved Register  3      */
-	#define RV32GC_FRAME_S4   4*RV32GC_WORD_SIZE /**< Saved Register  4      */
-	#define RV32GC_FRAME_S5   5*RV32GC_WORD_SIZE /**< Saved Register  5      */
-	#define RV32GC_FRAME_S6   6*RV32GC_WORD_SIZE /**< Saved Register  6      */
-	#define RV32GC_FRAME_S7   7*RV32GC_WORD_SIZE /**< Saved Register  7      */
-	#define RV32GC_FRAME_S8   8*RV32GC_WORD_SIZE /**< Saved Register  8      */
-	#define RV32GC_FRAME_S9   9*RV32GC_WORD_SIZE /**< Saved Register  9      */
-	#define RV32GC_FRAME_S10 10*RV32GC_WORD_SIZE /**< Saved Register 10      */
-	#define RV32GC_FRAME_S11 11*RV32GC_WORD_SIZE /**< Saved Register 11      */
+	#define RV32GC_CALLE_FRAME_FP   0*RV32GC_WORD_SIZE /**< Saved Register  0 */
+	#define RV32GC_CALLE_FRAME_S1   1*RV32GC_WORD_SIZE /**< Saved Register  1 */
+	#define RV32GC_CALLE_FRAME_S2   2*RV32GC_WORD_SIZE /**< Saved Register  2 */
+	#define RV32GC_CALLE_FRAME_S3   3*RV32GC_WORD_SIZE /**< Saved Register  3 */
+	#define RV32GC_CALLE_FRAME_S4   4*RV32GC_WORD_SIZE /**< Saved Register  4 */
+	#define RV32GC_CALLE_FRAME_S5   5*RV32GC_WORD_SIZE /**< Saved Register  5 */
+	#define RV32GC_CALLE_FRAME_S6   6*RV32GC_WORD_SIZE /**< Saved Register  6 */
+	#define RV32GC_CALLE_FRAME_S7   7*RV32GC_WORD_SIZE /**< Saved Register  7 */
+	#define RV32GC_CALLE_FRAME_S8   8*RV32GC_WORD_SIZE /**< Saved Register  8 */
+	#define RV32GC_CALLE_FRAME_S9   9*RV32GC_WORD_SIZE /**< Saved Register  9 */
+	#define RV32GC_CALLE_FRAME_S10 10*RV32GC_WORD_SIZE /**< Saved Register 10 */
+	#define RV32GC_CALLE_FRAME_S11 11*RV32GC_WORD_SIZE /**< Saved Register 11 */
 	/**@}*/
 
 	/*
-	 * @brief Saves preserved registers in the stack.
+	 * @brief Saves saved registers in the stack.
 	 */
-	.macro rv32gc_do_prologue_slow
+	.macro rv32gc_do_prologue
 
 		/* Allocate stack frame. */
-		addi sp, sp, -RV32GC_SLOW_CALL_FRAME_SIZE
+		addi sp, sp, -RV32GC_CALLEE_FRAME_SIZE
 
-		/* Save preserved registers. */
-		sw fp,  RV32GC_FRAME_FP(sp)
-		sw s1,  RV32GC_FRAME_S1(sp)
-		sw s2,  RV32GC_FRAME_S2(sp)
-		sw s3,  RV32GC_FRAME_S3(sp)
-		sw s4,  RV32GC_FRAME_S4(sp)
-		sw s5,  RV32GC_FRAME_S5(sp)
-		sw s6,  RV32GC_FRAME_S6(sp)
-		sw s7,  RV32GC_FRAME_S7(sp)
-		sw s8,  RV32GC_FRAME_S8(sp)
-		sw s9,  RV32GC_FRAME_S9(sp)
-		sw s10, RV32GC_FRAME_S10(sp)
-		sw s11, RV32GC_FRAME_S11(sp)
+		/* Save saved registers. */
+		sw fp,  RV32GC_CALLE_FRAME_FP(sp)
+		sw s1,  RV32GC_CALLE_FRAME_S1(sp)
+		sw s2,  RV32GC_CALLE_FRAME_S2(sp)
+		sw s3,  RV32GC_CALLE_FRAME_S3(sp)
+		sw s4,  RV32GC_CALLE_FRAME_S4(sp)
+		sw s5,  RV32GC_CALLE_FRAME_S5(sp)
+		sw s6,  RV32GC_CALLE_FRAME_S6(sp)
+		sw s7,  RV32GC_CALLE_FRAME_S7(sp)
+		sw s8,  RV32GC_CALLE_FRAME_S8(sp)
+		sw s9,  RV32GC_CALLE_FRAME_S9(sp)
+		sw s10, RV32GC_CALLE_FRAME_S10(sp)
+		sw s11, RV32GC_CALLE_FRAME_S11(sp)
 
 		/* Save stack frame. */
 		mv fp, sp
@@ -119,29 +119,29 @@
 	.endm
 
 	/*
-	 * @brief Restores preserved registers from the stack.
+	 * @brief Restores saved registers from the stack.
 	 */
-	.macro rv32gc_do_epilogue_slow
+	.macro rv32gc_do_epilogue
 
 		/* Restore stack frame. */
 		mv sp, fp
 
-		/* Restore preserved registers. */
-		lw fp,  RV32GC_FRAME_FP(sp)
-		lw s1,  RV32GC_FRAME_S1(sp)
-		lw s2,  RV32GC_FRAME_S2(sp)
-		lw s3,  RV32GC_FRAME_S3(sp)
-		lw s4,  RV32GC_FRAME_S4(sp)
-		lw s5,  RV32GC_FRAME_S5(sp)
-		lw s6,  RV32GC_FRAME_S6(sp)
-		lw s7,  RV32GC_FRAME_S7(sp)
-		lw s8,  RV32GC_FRAME_S8(sp)
-		lw s9,  RV32GC_FRAME_S9(sp)
-		lw s10, RV32GC_FRAME_S10(sp)
-		lw s11, RV32GC_FRAME_S11(sp)
+		/* Restore saved registers. */
+		lw fp,  RV32GC_CALLE_FRAME_FP(sp)
+		lw s1,  RV32GC_CALLE_FRAME_S1(sp)
+		lw s2,  RV32GC_CALLE_FRAME_S2(sp)
+		lw s3,  RV32GC_CALLE_FRAME_S3(sp)
+		lw s4,  RV32GC_CALLE_FRAME_S4(sp)
+		lw s5,  RV32GC_CALLE_FRAME_S5(sp)
+		lw s6,  RV32GC_CALLE_FRAME_S6(sp)
+		lw s7,  RV32GC_CALLE_FRAME_S7(sp)
+		lw s8,  RV32GC_CALLE_FRAME_S8(sp)
+		lw s9,  RV32GC_CALLE_FRAME_S9(sp)
+		lw s10, RV32GC_CALLE_FRAME_S10(sp)
+		lw s11, RV32GC_CALLE_FRAME_S11(sp)
 
 		/* Wipe out stack frame. */
-		addi sp, sp, RV32GC_SLOW_CALL_FRAME_SIZE
+		addi sp, sp, RV32GC_CALLEE_FRAME_SIZE
 
 	.endm
 
@@ -219,7 +219,7 @@
 	#endif
 
 		/*
-		 * Save all GPRs, but the
+		 * Restore all GPRs, but the
 		 * Stack Pointer (SP).
 		 */
 		lw  x1, RV32GC_CONTEXT_RA(sp)

--- a/include/arch/core/rv32gc/trap.h
+++ b/include/arch/core/rv32gc/trap.h
@@ -25,6 +25,9 @@
 #ifndef ARCH_CORE_RV32GC_TRAP_H_
 #define ARCH_CORE_RV32GC_TRAP_H_
 
+	/* Must come first. */
+	#define __NEED_CORE_TYPES
+
 /**
  * @addtogroup rv32gc-core-trap Trap
  * @ingroup rv32gc-core
@@ -33,7 +36,6 @@
  */
 /**@{*/
 
-	#define __NEED_CORE_TYPES
 	#include <arch/core/rv32gc/types.h>
 
 #ifndef _ASM_FILE_
@@ -45,20 +47,7 @@
 	 *
 	 * @returns The system call return value.
 	 */
-	static inline rv32gc_word_t rv32gc_syscall0(rv32gc_word_t syscall_nr)
-	{
-		register rv32gc_word_t _syscall_nr asm("a0") = syscall_nr;
-		register rv32gc_word_t ret asm ("a0");
-
-		asm volatile (
-			"ecall"
-			: "=r" (ret)
-			: "r"  (_syscall_nr)
-			: "memory", "cc"
-		);
-
-		return (ret);
-	}
+	EXTERN rv32gc_word_t rv32gc_kcall0(rv32gc_word_t syscall_nr);
 
 	/**
 	 * @brief Issues a system call with one argument.
@@ -68,24 +57,9 @@
 	 *
 	 * @returns The system call return value.
 	 */
-	static inline rv32gc_word_t rv32gc_syscall1(
+	EXTERN rv32gc_word_t rv32gc_kcall1(
 		rv32gc_word_t syscall_nr,
-		rv32gc_word_t arg0)
-	{
-		register rv32gc_word_t _syscall_nr asm("a0") = syscall_nr;
-		register rv32gc_word_t _arg0 asm("a1") = arg0;
-		register rv32gc_word_t ret asm ("a0");
-
-		asm volatile (
-			"ecall"
-			: "=r" (ret)
-			: "r"  (_syscall_nr),
-			  "r"  (_arg0)
-			: "memory", "cc"
-		);
-
-		return (ret);
-	}
+		rv32gc_word_t arg0);
 
 	/**
 	 * @brief Issues a system call with two arguments.
@@ -96,27 +70,10 @@
 	 *
 	 * @returns The system call return value.
 	 */
-	static inline rv32gc_word_t rv32gc_syscall2(
+	EXTERN rv32gc_word_t rv32gc_kcall2(
 		rv32gc_word_t syscall_nr,
 		rv32gc_word_t arg0,
-		rv32gc_word_t arg1)
-	{
-		register rv32gc_word_t _syscall_nr asm("a0") = syscall_nr;
-		register rv32gc_word_t _arg0 asm("a1") = arg0;
-		register rv32gc_word_t _arg1 asm("a2") = arg1;
-		register rv32gc_word_t ret asm ("a0");
-
-		asm volatile (
-			"ecall"
-			: "=r" (ret)
-			: "r"  (_syscall_nr),
-			  "r"  (_arg0),
-			  "r"  (_arg1)
-			: "memory", "cc"
-		);
-
-		return (ret);
-	}
+		rv32gc_word_t arg1);
 
 	/**
 	 * @brief Issues a system call with three arguments.
@@ -128,30 +85,11 @@
 	 *
 	 * @returns The system call return value.
 	 */
-	static inline rv32gc_word_t rv32gc_syscall3(
+	EXTERN rv32gc_word_t rv32gc_kcall3(
 		rv32gc_word_t syscall_nr,
 		rv32gc_word_t arg0,
 		rv32gc_word_t arg1,
-		rv32gc_word_t arg2)
-	{
-		register rv32gc_word_t _syscall_nr asm("a0") = syscall_nr;
-		register rv32gc_word_t _arg0 asm("a1") = arg0;
-		register rv32gc_word_t _arg1 asm("a2") = arg1;
-		register rv32gc_word_t _arg2 asm("a3") = arg2;
-		register rv32gc_word_t ret asm ("a0");
-
-		asm volatile (
-			"ecall"
-			: "=r" (ret)
-			: "r"  (_syscall_nr),
-			  "r"  (_arg0),
-			  "r"  (_arg1),
-			  "r"  (_arg2)
-			: "memory", "cc"
-		);
-
-		return (ret);
-	}
+		rv32gc_word_t arg2);
 
 	/**
 	 * @brief Issues a system call with four arguments.
@@ -164,33 +102,12 @@
 	 *
 	 * @returns The system call return value.
 	 */
-	static inline rv32gc_word_t rv32gc_syscall4(
+	EXTERN rv32gc_word_t rv32gc_kcall4(
 		rv32gc_word_t syscall_nr,
 		rv32gc_word_t arg0,
 		rv32gc_word_t arg1,
 		rv32gc_word_t arg2,
-		rv32gc_word_t arg3)
-	{
-		register rv32gc_word_t _syscall_nr asm("a0") = syscall_nr;
-		register rv32gc_word_t _arg0 asm("a1") = arg0;
-		register rv32gc_word_t _arg1 asm("a2") = arg1;
-		register rv32gc_word_t _arg2 asm("a3") = arg2;
-		register rv32gc_word_t _arg3 asm("a4") = arg3;
-		register rv32gc_word_t ret asm ("a0");
-
-		asm volatile (
-			"ecall"
-			: "=r" (ret)
-			: "r"  (_syscall_nr),
-			  "r"  (_arg0),
-			  "r"  (_arg1),
-			  "r"  (_arg2),
-			  "r"  (_arg3)
-			: "memory", "cc"
-		);
-
-		return (ret);
-	}
+		rv32gc_word_t arg3);
 
 	/**
 	 * @brief Issues a system call with five arguments.
@@ -204,41 +121,13 @@
 	 *
 	 * @returns The system call return value.
 	 */
-	static inline rv32gc_word_t rv32gc_syscall5(
+	EXTERN rv32gc_word_t rv32gc_kcall5(
 		rv32gc_word_t syscall_nr,
 		rv32gc_word_t arg0,
 		rv32gc_word_t arg1,
 		rv32gc_word_t arg2,
 		rv32gc_word_t arg3,
-		rv32gc_word_t arg4)
-	{
-		register rv32gc_word_t _syscall_nr asm("a0") = syscall_nr;
-		register rv32gc_word_t _arg0 asm("a1") = arg0;
-		register rv32gc_word_t _arg1 asm("a2") = arg1;
-		register rv32gc_word_t _arg2 asm("a3") = arg2;
-		register rv32gc_word_t _arg3 asm("a4") = arg3;
-		register rv32gc_word_t _arg4 asm("a5") = arg4;
-		register rv32gc_word_t ret asm ("a0");
-
-		asm volatile (
-			"ecall"
-			: "=r" (ret)
-			: "r"  (_syscall_nr),
-			  "r"  (_arg0),
-			  "r"  (_arg1),
-			  "r"  (_arg2),
-			  "r"  (_arg3),
-			  "r"  (_arg4)
-			: "memory", "cc"
-		);
-
-		return (ret);
-	}
-
-	/**
-	 * @brief System Call Hook
-	 */
-	EXTERN void rv32gc_syscall(void);
+		rv32gc_word_t arg4);
 
 #endif
 
@@ -256,35 +145,35 @@
 	 * @name Exported Functions
 	 */
 	/**@{*/
-	#define __syscall0_fn /**< rv32gc_syscall0() */
-	#define __syscall1_fn /**< rv32gc_syscall1() */
-	#define __syscall2_fn /**< rv32gc_syscall2() */
-	#define __syscall3_fn /**< rv32gc_syscall3() */
-	#define __syscall4_fn /**< rv32gc_syscall4() */
-	#define __syscall5_fn /**< rv32gc_syscall5() */
+	#define __syscall0_fn /**< rv32gc_kcall0() */
+	#define __syscall1_fn /**< rv32gc_kcall1() */
+	#define __syscall2_fn /**< rv32gc_kcall2() */
+	#define __syscall3_fn /**< rv32gc_kcall3() */
+	#define __syscall4_fn /**< rv32gc_kcall4() */
+	#define __syscall5_fn /**< rv32gc_kcall5() */
 	/**@}*/
 
 #ifndef _ASM_FILE_
 
 	/**
-	 * @see rv32gc_syscall0()
+	 * @see rv32gc_kcall0()
 	 */
 	static inline rv32gc_word_t syscall0(rv32gc_word_t syscall_nr)
 	{
 		return (
-			rv32gc_syscall0(syscall_nr)
+			rv32gc_kcall0(syscall_nr)
 		);
 	}
 
 	/**
-	 * @see rv32gc_syscall1()
+	 * @see rv32gc_kcall1()
 	 */
 	static inline rv32gc_word_t syscall1(
 		rv32gc_word_t syscall_nr,
 		rv32gc_word_t arg0)
 	{
 		return (
-			rv32gc_syscall1(
+			rv32gc_kcall1(
 				syscall_nr,
 				arg0
 			)
@@ -292,7 +181,7 @@
 	}
 
 	/**
-	 * @see rv32gc_syscall2()
+	 * @see rv32gc_kcall2()
 	 */
 	static inline rv32gc_word_t syscall2(
 		rv32gc_word_t syscall_nr,
@@ -300,7 +189,7 @@
 		rv32gc_word_t arg1)
 	{
 		return (
-			rv32gc_syscall2(
+			rv32gc_kcall2(
 				syscall_nr,
 				arg0,
 				arg1
@@ -309,7 +198,7 @@
 	}
 
 	/**
-	 * @see rv32gc_syscall3()
+	 * @see rv32gc_kcall3()
 	 */
 	static inline rv32gc_word_t syscall3(
 		rv32gc_word_t syscall_nr,
@@ -318,7 +207,7 @@
 		rv32gc_word_t arg2)
 	{
 		return (
-			rv32gc_syscall3(
+			rv32gc_kcall3(
 				syscall_nr,
 				arg0,
 				arg1,
@@ -328,7 +217,7 @@
 	}
 
 	/**
-	 * @see rv32gc_syscall4()
+	 * @see rv32gc_kcall4()
 	 */
 	static inline rv32gc_word_t syscall4(
 		rv32gc_word_t syscall_nr,
@@ -338,7 +227,7 @@
 		rv32gc_word_t arg3)
 	{
 		return (
-			rv32gc_syscall4(
+			rv32gc_kcall4(
 				syscall_nr,
 				arg0,
 				arg1,
@@ -349,7 +238,7 @@
 	}
 
 	/**
-	 * @see rv32gc_syscall5()
+	 * @see rv32gc_kcall5()
 	 */
 	static inline rv32gc_word_t syscall5(
 		rv32gc_word_t syscall_nr,
@@ -360,7 +249,7 @@
 		rv32gc_word_t arg4)
 	{
 		return (
-			rv32gc_syscall5(
+			rv32gc_kcall5(
 				syscall_nr,
 				arg0,
 				arg1,

--- a/src/hal/arch/core/rv32gc/hooks.S
+++ b/src/hal/arch/core/rv32gc/hooks.S
@@ -33,6 +33,12 @@
 #include <arch/core/rv32gc/types.h>
 #include <arch/core/rv32gc/regs.h>
 
+.global rv32gc_kcall0
+.global rv32gc_kcall1
+.global rv32gc_kcall2
+.global rv32gc_kcall3
+.global rv32gc_kcall4
+.global rv32gc_kcall5
 .global rv32gc_do_strap
 
 .section .text,"ax",@progbits
@@ -164,3 +170,70 @@ rv32gc_do_strap:
 
 		/* Return from event. */
 		sret
+
+/*----------------------------------------------------------------------------*
+ * _rv32gc_do_kcall                                                           *
+ *----------------------------------------------------------------------------*/
+
+#ifndef HAS_USER_MODE
+
+//
+// Kernel call hook.
+//
+.macro rv32gc_kcall, num
+	.align RV32GC_WORD_SIZE
+	rv32gc_kcall\()\num:
+		rv32gc_do_fn_call _rv32gc_do_kcall
+		ret
+.endm
+
+rv32gc_kcall 0 // Kernel call with no arguments.
+rv32gc_kcall 1 // Kernel call with one argument.
+rv32gc_kcall 2 // Kernel call with two arguments.
+rv32gc_kcall 3 // Kernel call with three arguments.
+rv32gc_kcall 4 // Kernel call with four arguments.
+rv32gc_kcall 5 // Kernel call with five arguments.
+
+//
+// Low-level kernel call dispatcher.
+//
+.align RV32GC_WORD_SIZE
+_rv32gc_do_kcall:
+
+	// User mode is not supported, then
+	// simulate an ECALL instruction
+	// by push the value of RA onto
+	// the stack.
+	addi  sp, sp, -RV32GC_WORD_SIZE
+	sw    ra, 0(sp)
+
+	// Save the execution context
+	// in the current stack.
+	rv32gc_context_save
+
+	// Get kernel call parameters.
+	lw  a5, RV32GC_CONTEXT_A0(sp) /* System Call Number */
+	lw  a0, RV32GC_CONTEXT_A1(sp) /* Argument 0         */
+	lw  a1, RV32GC_CONTEXT_A2(sp) /* Argument 1         */
+	lw  a2, RV32GC_CONTEXT_A3(sp) /* Argument 2         */
+	lw  a3, RV32GC_CONTEXT_A4(sp) /* Argument 3         */
+	lw  a4, RV32GC_CONTEXT_A5(sp) /* Argument 4         */
+
+	// Forward kernel call
+	// to high-level dispatcher.
+	call  do_syscall
+
+	// Copy return value to user stack.
+	sw  a0, RV32GC_CONTEXT_A0(sp)
+
+	// Return from kernel call.
+	_rv32gc_do_kcall.out:
+
+		rv32gc_context_restore
+
+		// Wipe out face ECALL.
+		addi sp, sp, RV32GC_WORD_SIZE
+
+		ret
+
+#endif

--- a/src/hal/arch/core/rv32gc/hooks.S
+++ b/src/hal/arch/core/rv32gc/hooks.S
@@ -111,9 +111,12 @@ rv32gc_do_strap:
 	/* Kernel call. */
 	rv32gc_do_strap.scall:
 
+
+#ifdef RISCV_HAS_UMODE
+
 		/*
 		 * Get system call parameters.
-		 *  Note that the system call
+		 * Note that the system call
 		 * number is the last  paramenter.
 		 */
 		lw a5, RV32GC_CONTEXT_A0(fp) /* System Call Number */
@@ -139,6 +142,8 @@ rv32gc_do_strap:
 		sw t0, RV32GC_CONTEXT_PC(fp)
 
 		j rv32gc_do_strap.ret
+
+#endif
 
 	/* Interrupt. */
 	rv32gc_do_strap.sint:

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -42,8 +42,8 @@ PRIVATE void test_core_al(void)
 	test_interrupt();
 	test_mmu();
 	test_tlb();
-#if !defined(__rv32gc__)
 	test_trap();
+#if !defined(__rv32gc__)
 	test_upcall();
 #endif
 }


### PR DESCRIPTION
Description
----------------

In this Pull Request, I re-enable kernel calls rv32gc cores, by emulating them as normal function calls.

Related Issues
--------------------

- [[rv32gc] Trap Interface](https://github.com/nanvix/hal/issues/227)