### PR TITLE
[optimsoc] Memory Interface

### DIFF
--- a/include/arch/cluster/optimsoc-cluster.h
+++ b/include/arch/cluster/optimsoc-cluster.h
@@ -22,11 +22,38 @@
  * SOFTWARE.
  */
 
-#ifndef _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
-#define _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
+#ifndef CLUSTER_OPTIMSOC_CLUSTER_H_
+#define CLUSTER_OPTIMSOC_CLUSTER_H_
 
-	#undef  __NEED_CLUSTER_OPTIMSOC
-	#define __NEED_CLUSTER_OPTIMSOC
-	#include <arch/cluster/optimsoc-cluster.h>
+	#ifndef __NEED_CLUSTER_OPTIMSOC
+		#error "bad cluster configuration?"
+	#endif
 
-#endif /* _PROCESSOR_OPTIMSOC_OPTIMSOC_H_ */
+	/* Cluster Interface Implementation */
+	#include <arch/cluster/optimsoc-cluster/_optimsoc-cluster.h>
+
+/**
+ * @addtogroup optimsoc-cluster OpenRISC Cluster
+ * @ingroup clusters
+ *
+ * @brief OpenRISC Cluster
+ */
+/**@{*/
+
+	#include <arch/cluster/optimsoc-cluster/clock.h>
+	#include <arch/cluster/optimsoc-cluster/cores.h>
+	#include <arch/cluster/optimsoc-cluster/memory.h>
+
+	/**
+	 * @name Provided Features
+	 */
+	/**@{*/
+	#define CLUSTER_IS_MULTICORE  1 /**< Multicore Cluster */
+	#define CLUSTER_IS_IO         1 /**< I/O Cluster       */
+	#define CLUSTER_IS_COMPUTE    0 /**< Compute Cluster   */
+	#define CLUSTER_HAS_EVENTS    0 /**< Event Support?    */
+	/**@}*/
+
+/**@}*/
+
+#endif /* CLUSTER_OPTIMSOC_CLUSTER_H_ */

--- a/include/arch/cluster/optimsoc-cluster/_optimsoc-cluster.h
+++ b/include/arch/cluster/optimsoc-cluster/_optimsoc-cluster.h
@@ -25,19 +25,9 @@
 #ifndef _CLUSTER_OPTIMSOC_CLUSTER_H_
 #define _CLUSTER_OPTIMSOC_CLUSTER_H_
 
-	#undef  __NEED_CORE_OR1K
-	#define __NEED_CORE_OR1K
+	#undef  __NEED_CORE_MOR1KX
+	#define __NEED_CORE_MOR1KX
 
-#ifndef _ASM_FILE_
-
-	#if (defined(__or1200__))
-		#include <arch/core/or1k.h>
-	#elif (defined(__mor1kx__))
-		#include <arch/core/mor1kx.h>
-	#else
-		#error "unkonwn core"
-	#endif
-
-#endif
+	#include <arch/core/mor1kx.h>
 
 #endif /* _CLUSTER_OPTIMSOC_CLUSTER_H_ */

--- a/include/arch/cluster/optimsoc-cluster/_optimsoc-cluster.h
+++ b/include/arch/cluster/optimsoc-cluster/_optimsoc-cluster.h
@@ -22,11 +22,22 @@
  * SOFTWARE.
  */
 
-#ifndef _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
-#define _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
+#ifndef _CLUSTER_OPTIMSOC_CLUSTER_H_
+#define _CLUSTER_OPTIMSOC_CLUSTER_H_
 
-	#undef  __NEED_CLUSTER_OPTIMSOC
-	#define __NEED_CLUSTER_OPTIMSOC
-	#include <arch/cluster/optimsoc-cluster.h>
+	#undef  __NEED_CORE_OR1K
+	#define __NEED_CORE_OR1K
 
-#endif /* _PROCESSOR_OPTIMSOC_OPTIMSOC_H_ */
+#ifndef _ASM_FILE_
+
+	#if (defined(__or1200__))
+		#include <arch/core/or1k.h>
+	#elif (defined(__mor1kx__))
+		#include <arch/core/mor1kx.h>
+	#else
+		#error "unkonwn core"
+	#endif
+
+#endif
+
+#endif /* _CLUSTER_OPTIMSOC_CLUSTER_H_ */

--- a/include/arch/cluster/optimsoc-cluster/clock.h
+++ b/include/arch/cluster/optimsoc-cluster/clock.h
@@ -22,11 +22,61 @@
  * SOFTWARE.
  */
 
-#ifndef _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
-#define _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
+#ifndef ARCH_CLUSTER_OPTIMSOC_CLUSTER_CLOCK_H_
+#define ARCH_CLUSTER_OPTIMSOC_CLUSTER_CLOCK_H_
 
-	#undef  __NEED_CLUSTER_OPTIMSOC
-	#define __NEED_CLUSTER_OPTIMSOC
-	#include <arch/cluster/optimsoc-cluster.h>
+	#ifndef __optimsoc_cluster__
+		#error "wrong cluter included!"
+	#endif
 
-#endif /* _PROCESSOR_OPTIMSOC_OPTIMSOC_H_ */
+
+	/* Cluster Interface Implementation */
+	#include <arch/cluster/optimsoc-cluster/_optimsoc-cluster.h>
+
+/**
+ * @addtogroup or1k-core-clock Clock
+ * @ingroup or1k-core
+ *
+ * @brief Integrated Clock Device
+ */
+/**@{*/
+
+	#include <nanvix/const.h>
+
+/*============================================================================*
+ * Exported Interface                                                         *
+ *============================================================================*/
+
+/**
+ * @cond or1k
+ */
+
+	/**
+	 * @name Exported Functions
+	 */
+	/**@{*/
+	#define __clock_init_fn  /**< clock_init()  */
+	#define __clock_reset_fn /**< clock_reset() */
+	/**@}*/
+
+	/**
+	 * @see or1k_clock_init().
+	 */
+	static inline void clock_init(unsigned freq)
+	{
+		or1k_clock_init(freq);
+	}
+
+	/**
+	 * @see or1k_clock_reset().
+	 */
+	static inline void clock_reset(void)
+	{
+		or1k_clock_reset();
+	}
+
+/**@endcond*/
+
+/**@}*/
+
+#endif /* ARCH_CLUSTER_OR1K_CLUSTER_CLOCK */

--- a/include/arch/cluster/optimsoc-cluster/clock.h
+++ b/include/arch/cluster/optimsoc-cluster/clock.h
@@ -25,13 +25,12 @@
 #ifndef ARCH_CLUSTER_OPTIMSOC_CLUSTER_CLOCK_H_
 #define ARCH_CLUSTER_OPTIMSOC_CLUSTER_CLOCK_H_
 
-
 	/* Cluster Interface Implementation */
 	#include <arch/cluster/optimsoc-cluster/_optimsoc-cluster.h>
 
 /**
- * @addtogroup or1k-core-clock Clock
- * @ingroup or1k-core
+ * @addtogroup optimsoc-cluster-clock Clock
+ * @ingroup optimsoc-cluster
  *
  * @brief Integrated Clock Device
  */
@@ -39,12 +38,14 @@
 
 	#include <nanvix/const.h>
 
+/**@}*/
+
 /*============================================================================*
  * Exported Interface                                                         *
  *============================================================================*/
 
 /**
- * @cond or1k
+ * @optimsoc_cluster
  */
 
 	/**
@@ -54,6 +55,8 @@
 	#define __clock_init_fn  /**< clock_init()  */
 	#define __clock_reset_fn /**< clock_reset() */
 	/**@}*/
+
+#ifndef _ASM_FILE_
 
 	/**
 	 * @see or1k_clock_init().
@@ -71,8 +74,8 @@
 		or1k_clock_reset();
 	}
 
-/**@endcond*/
+#endif /* !_ASM_FILE_ */
 
-/**@}*/
+/**@endcond*/
 
 #endif /* ARCH_CLUSTER_OR1K_CLUSTER_CLOCK */

--- a/include/arch/cluster/optimsoc-cluster/clock.h
+++ b/include/arch/cluster/optimsoc-cluster/clock.h
@@ -25,10 +25,6 @@
 #ifndef ARCH_CLUSTER_OPTIMSOC_CLUSTER_CLOCK_H_
 #define ARCH_CLUSTER_OPTIMSOC_CLUSTER_CLOCK_H_
 
-	#ifndef __optimsoc_cluster__
-		#error "wrong cluter included!"
-	#endif
-
 
 	/* Cluster Interface Implementation */
 	#include <arch/cluster/optimsoc-cluster/_optimsoc-cluster.h>

--- a/include/arch/cluster/optimsoc-cluster/cores.h
+++ b/include/arch/cluster/optimsoc-cluster/cores.h
@@ -1,0 +1,138 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef ARCH_CLUSTER_OPTIMSOC_CLUSTER_CORES_H_
+#define ARCH_CLUSTER_OPTIMSOC_CLUSTER_CORES_H_
+
+	/* Cluster Interface Implementation */
+	#include <arch/cluster/optimsoc-cluster/_optimsoc-cluster.h>
+
+/**
+ * @addtogroup optimsoc-cluster-cpu Cores
+ * @ingroup optimsoc-cluster
+ *
+ * @brief Cores
+ */
+/**@{*/
+
+	/**
+	 * @brief Number of cores in a cluster.
+	 */
+	#define OPTIMSOC_CLUSTER_NUM_CORES 4
+	#define OR1K_CLUSTER_NUM_CORES OPTIMSOC_CLUSTER_NUM_CORES
+
+	/**
+	 * @brief ID of the master core.
+	 */
+	#define OPTIMSOC_CLUSTER_COREID_MASTER 0
+
+#ifndef _ASM_FILE_
+
+	/**
+	 * @brief Resets the underlying cluster
+	 *
+	 * @param coreid ID of target core.
+	 */
+	EXTERN NORETURN void _optimsoc_cluster_core_reset(int coreid);
+
+	/**
+	 * @brief Initializes the underlying cluster.
+	 */
+	EXTERN void optimsoc_cluster_setup(void);
+
+	/**
+	 * @brief Gets the number of cores.
+	 *
+	 * The optimsoc_cluster_cluster_get_num_cores() gets the number of cores in the
+	 * underlying optimsoc processor.
+	 *
+	 * @returns The the number of cores in the underlying processor.
+	 */
+	static inline int optimsoc_cluster_cluster_get_num_cores(void)
+	{
+		return (OPTIMSOC_CLUSTER_NUM_CORES);
+	}
+
+#endif /* _ASM_FILE_ */
+
+/**@}*/
+
+/*============================================================================*
+ * Exported Interface                                                         *
+ *============================================================================*/
+
+/**
+ * @cond optimsoc_cluster
+ */
+
+	/**
+	 * @name Provided Functions
+	 */
+	/**@{*/
+	#define __core_get_id_fn        /**< core_get_id()           */
+	#define __core_setup_fn         /**< core_setup()            */
+	#define __cluster_get_num_cores /**< cluster_get_num_cores() */
+	/**@}*/
+
+	/**
+	 * @brief Number of cores in a cluster.
+	 */
+	#define CORES_NUM OPTIMSOC_CLUSTER_NUM_CORES
+
+	/**
+	 * @brief ID of the master core.
+	 */
+	#define COREID_MASTER OPTIMSOC_CLUSTER_COREID_MASTER
+
+#ifndef _ASM_FILE_
+
+	/**
+	 * @see _or1k_cluster_core_reset().
+	 */
+	static inline void _core_reset(void)
+	{
+		_optimsoc_cluster_core_reset(or1k_core_get_id());
+	}
+
+	/**
+	 * @see optimsoc_cluster_cluster_get_num_cores()
+	 */
+	static inline int cluster_get_num_cores(void)
+	{
+		return (optimsoc_cluster_cluster_get_num_cores());
+	}
+
+	/**
+	 * @see optimsoc_cluster_setup().
+	 */
+	static inline void core_setup(void)
+	{
+		optimsoc_cluster_setup();
+	}
+
+#endif /* _ASM_FILE_ */
+
+/**@endcond*/
+
+#endif /* ARCH_CLUSTER_OPTIMSOC_CLUSTER_CORES_H_ */

--- a/include/arch/cluster/optimsoc-cluster/cores.h
+++ b/include/arch/cluster/optimsoc-cluster/cores.h
@@ -78,7 +78,7 @@
 		return (OPTIMSOC_CLUSTER_NUM_CORES);
 	}
 
-#endif /* _ASM_FILE_ */
+#endif /* !_ASM_FILE_ */
 
 /**@}*/
 
@@ -135,7 +135,7 @@
 		optimsoc_cluster_setup();
 	}
 
-#endif /* _ASM_FILE_ */
+#endif /* !_ASM_FILE_ */
 
 /**@endcond*/
 

--- a/include/arch/cluster/optimsoc-cluster/cores.h
+++ b/include/arch/cluster/optimsoc-cluster/cores.h
@@ -25,6 +25,10 @@
 #ifndef ARCH_CLUSTER_OPTIMSOC_CLUSTER_CORES_H_
 #define ARCH_CLUSTER_OPTIMSOC_CLUSTER_CORES_H_
 
+	#ifndef __optimsoc_cluster__
+		#error "wrong cluter included!"
+	#endif
+
 	/* Cluster Interface Implementation */
 	#include <arch/cluster/optimsoc-cluster/_optimsoc-cluster.h>
 

--- a/include/arch/cluster/optimsoc-cluster/memmap.h
+++ b/include/arch/cluster/optimsoc-cluster/memmap.h
@@ -22,11 +22,46 @@
  * SOFTWARE.
  */
 
-#ifndef _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
-#define _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
+#ifndef CLUSTER_OPTIMSOC_CLUSTER_MEMMAP_H_
+#define CLUSTER_OPTIMSOC_CLUSTER_MEMMAP_H_
 
-	#undef  __NEED_CLUSTER_OPTIMSOC
-	#define __NEED_CLUSTER_OPTIMSOC
-	#include <arch/cluster/optimsoc-cluster.h>
+	#ifndef __NEED_CLUSTER_MEMMAP
+		#error "do not include this file"
+	#endif
 
-#endif /* _PROCESSOR_OPTIMSOC_OPTIMSOC_H_ */
+	/* Cluster Interface Implementation */
+	#include <arch/cluster/optimsoc-cluster/_optimsoc-cluster.h>
+
+/**
+ * @addtogroup optimsoc_cluster-cluster-memmap Memory Map
+ * @ingroup optimsoc_cluster-cluster
+ *
+ * @brief Physical memory map.
+ */
+/**@{*/
+
+	/**
+	 * @name Physical Memory Layout
+	 */
+	/**@{*/
+	#define OPTIMSOC_CLUSTER_OMPIC_BASE_PHYS 0x98000000 /**< OMPIC Base */
+	#define OPTIMSOC_CLUSTER_OMPIC_END_PHYS  0x98010000 /**< OMPIC End */
+	#define OPTIMSOC_CLUSTER_DRAM_BASE_PHYS  0x00000000 /**< DRAM Base */
+	#define OPTIMSOC_CLUSTER_DRAM_END_PHYS   0x08000000 /**< DRAM End  */
+	/**@}*/
+
+	/**
+	 * @brief DRAM brief (in bytes).
+	 */
+	#define OPTIMSOC_CLUSTER_DRAM_SIZE \
+		(OPTIMSOC_CLUSTER_DRAM_END_PHYS - OPTIMSOC_CLUSTER_DRAM_BASE_PHYS)
+
+	/**
+	 * @brief OMPIC brief (in bytes).
+	 */
+	#define OPTIMSOC_CLUSTER_OMPIC_MEM_SIZE \
+		(OPTIMSOC_CLUSTER_OMPIC_END_PHYS - OPTIMSOC_CLUSTER_OMPIC_BASE_PHYS)
+
+/**@}*/
+
+#endif /* CLUSTER_OPTIMSOC_CLUSTER_MEMMAP_H_ */

--- a/include/arch/cluster/optimsoc-cluster/memmap.h
+++ b/include/arch/cluster/optimsoc-cluster/memmap.h
@@ -22,8 +22,8 @@
  * SOFTWARE.
  */
 
-#ifndef CLUSTER_OPTIMSOC_CLUSTER_MEMMAP_H_
-#define CLUSTER_OPTIMSOC_CLUSTER_MEMMAP_H_
+#ifndef ARCH_CLUSTER_OPTIMSOC_CLUSTER_MEMMAP_H_
+#define ARCH_CLUSTER_OPTIMSOC_CLUSTER_MEMMAP_H_
 
 	#ifndef __NEED_CLUSTER_MEMMAP
 		#error "do not include this file"
@@ -33,10 +33,10 @@
 	#include <arch/cluster/optimsoc-cluster/_optimsoc-cluster.h>
 
 /**
- * @addtogroup optimsoc_cluster-cluster-memmap Memory Map
- * @ingroup optimsoc_cluster-cluster
+ * @addtogroup optimsoc-cluster-memmap Memory Map
+ * @ingroup optimsoc-cluster
  *
- * @brief Physical memory map.
+ * @brief Physical Memory Map
  */
 /**@{*/
 

--- a/include/arch/cluster/optimsoc-cluster/memory.h
+++ b/include/arch/cluster/optimsoc-cluster/memory.h
@@ -1,0 +1,155 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef CLUSTER_OPTIMSOC_CLUSTER_MEMORY_H_
+#define CLUSTER_OPTIMSOC_CLUSTER_MEMORY_H_
+
+	/* Cluster Interface Implementation */
+	#include <arch/cluster/optimsoc-cluster/_optimsoc-cluster.h>
+
+/**
+ * @addtogroup optimsoc-cluster-mem Memory
+ * @ingroup optimsoc-cluster
+ *
+ * @brief Memory System
+ */
+/**@{*/
+
+	/* Must come first. */
+	#define __NEED_CLUSTER_MEMMAP
+
+	#include <nanvix/const.h>
+	#include <arch/cluster/optimsoc-cluster/memmap.h>
+
+	/**
+	 * @name Physical Memory Layout
+	 */
+	/**@{*/
+	#define OPTIMSOC_CLUSTER_KERNEL_BASE_PHYS OPTIMSOC_CLUSTER_DRAM_BASE_PHYS                       /**< Kernel Code and Data */
+	#define OPTIMSOC_CLUSTER_KERNEL_END_PHYS  (OPTIMSOC_CLUSTER_KERNEL_BASE_PHYS + OR1K_PGTAB_SIZE) /**< Kernel End           */
+	#define OPTIMSOC_CLUSTER_KPOOL_BASE_PHYS  (OPTIMSOC_CLUSTER_KERNEL_END_PHYS + OR1K_PGTAB_SIZE)  /**< Kernel Page Pool     */
+	#define OPTIMSOC_CLUSTER_KPOOL_END_PHYS   (OPTIMSOC_CLUSTER_KPOOL_BASE_PHYS + OR1K_PGTAB_SIZE)  /**< Kernel Pool End      */
+	#define OPTIMSOC_CLUSTER_USER_BASE_PHYS   OPTIMSOC_CLUSTER_KPOOL_END_PHYS                       /**< User Base            */
+	#define OPTIMSOC_CLUSTER_USER_END_PHYS    OPTIMSOC_CLUSTER_DRAM_END_PHYS                        /**< User End             */
+	/**@}*/
+
+	/**
+	 * @name Virtual Memory Layout
+	 */
+	/**@{*/
+	#define OPTIMSOC_CLUSTER_OMPIC_BASE_VIRT  OPTIMSOC_CLUSTER_OMPIC_BASE_PHYS  /**< PIC Base             */
+	#define OPTIMSOC_CLUSTER_OMPIC_END_VIRT   OPTIMSOC_CLUSTER_OMPIC_END_PHYS   /**< PIC End              */
+	#define OPTIMSOC_CLUSTER_KERNEL_BASE_VIRT OPTIMSOC_CLUSTER_KERNEL_BASE_PHYS /**< Kernel Code and Data */
+	#define OPTIMSOC_CLUSTER_KERNEL_END_VIRT  OPTIMSOC_CLUSTER_KERNEL_END_PHYS  /**< Kernel End           */
+	#define OPTIMSOC_CLUSTER_KPOOL_BASE_VIRT  OPTIMSOC_CLUSTER_KPOOL_BASE_PHYS  /**< Kernel Page Pool     */
+	#define OPTIMSOC_CLUSTER_KPOOL_END_VIRT   OPTIMSOC_CLUSTER_KPOOL_END_PHYS   /**< Kernel Pool End      */
+	#define OPTIMSOC_CLUSTER_USER_BASE_VIRT   0xa0000000                    /**< User Base            */
+	#define OPTIMSOC_CLUSTER_USER_END_VIRT    0xc0000000                    /**< User End             */
+	#define OPTIMSOC_CLUSTER_USTACK_BASE_VIRT 0xc0000000                    /**< User Stack Base      */
+	#define OPTIMSOC_CLUSTER_USTACK_END_VIRT  0xb0000000                    /**< User Stack End       */
+	/**@}*/
+
+	/**
+	 * @brief Memory size (in bytes).
+	 */
+	#define OPTIMSOC_CLUSTER_MEM_SIZE \
+		OPTIMSOC_CLUSTER_DRAM_SIZE
+
+	/**
+	 * @brief Kernel memory size (in bytes).
+	 */
+	#define OPTIMSOC_CLUSTER_KMEM_SIZE \
+		(OPTIMSOC_CLUSTER_KERNEL_END_VIRT - OPTIMSOC_CLUSTER_KERNEL_BASE_VIRT)
+
+	/**
+	 * @brief Kernel page pool size (in bytes).
+	 */
+	#define OPTIMSOC_CLUSTER_KPOOL_SIZE \
+		(OPTIMSOC_CLUSTER_KPOOL_END_VIRT - OPTIMSOC_CLUSTER_KPOOL_BASE_VIRT)
+
+	/**
+	 * @brief User memory size (in bytes).
+	 */
+	#define OPTIMSOC_CLUSTER_UMEM_SIZE \
+		(OPTIMSOC_CLUSTER_USER_END_VIRT - OPTIMSOC_CLUSTER_USER_BASE_VIRT)
+
+	/**
+	 * @brief Kernel stack size (in bytes).
+	 */
+	#define OPTIMSOC_CLUSTER_KSTACK_SIZE OPTIMSOC_PAGE_SIZE
+
+	/**
+	 * OMPIC Registers and flags.
+	 */
+	/**@{*/
+	#define OPTIMSOC_OMPIC_CPUBYTES	        8
+	#define OPTIMSOC_OMPIC_CTRL(cpu)        (OPTIMSOC_CLUSTER_OMPIC_BASE_VIRT + (0x0 + ((cpu) * OPTIMSOC_OMPIC_CPUBYTES)))
+	#define OPTIMSOC_OMPIC_STAT(cpu)        (OPTIMSOC_CLUSTER_OMPIC_BASE_VIRT + (0x4 + ((cpu) * OPTIMSOC_OMPIC_CPUBYTES)))
+	#define OPTIMSOC_OMPIC_CTRL_IRQ_ACK	    (1 << 31)
+	#define OPTIMSOC_OMPIC_CTRL_IRQ_GEN	    (1 << 30)
+	#define OPTIMSOC_OMPIC_CTRL_DST(cpu)    (((cpu) & 0x3fff) << 16)
+	#define OPTIMSOC_OMPIC_STAT_IRQ_PENDING (1 << 30)
+	#define OPTIMSOC_OMPIC_DATA(x)          ((x) & 0xffff)
+	#define OPTIMSOC_OMPIC_STAT_SRC(x)      (((x) >> 16) & 0x3fff)
+	/**@}*/
+
+#ifndef _ASM_FILE_
+
+	/**
+	 * @brief Initializes the Memory Interface.
+	 */
+	EXTERN void optimsoc_cluster_mem_setup(void);
+
+#endif /* _ASM_FILE_ */
+
+/**@}*/
+
+/*============================================================================*
+ * Exported Interface                                                         *
+ *============================================================================*/
+
+/**
+ * @cond optimsoc_cluster
+ */
+
+	/**
+	 * @name Exported Constants
+	 */
+	#define MEMORY_SIZE  OPTIMSOC_CLUSTER_MEM_SIZE         /**< @see OPTIMSOC_CLUSTER_MEM_SIZE         */
+	#define KMEM_SIZE    OPTIMSOC_CLUSTER_KMEM_SIZE        /**< @see OPTIMSOC_CLUSTER_KMEM_SIZE        */
+	#define UMEM_SIZE    OPTIMSOC_CLUSTER_UMEM_SIZE        /**< @see OPTIMSOC_CLUSTER_UMEM_SIZE        */
+	#define KSTACK_SIZE  OPTIMSOC_CLUSTER_KSTACK_SIZE      /**< @see OPTIMSOC_CLUSTER_KSTACK_SIZE      */
+	#define KPOOL_SIZE   OPTIMSOC_CLUSTER_KPOOL_SIZE       /**< @see OPTIMSOC_CLUSTER_KPOOL_SIZE       */
+	#define KBASE_PHYS   OPTIMSOC_CLUSTER_KERNEL_BASE_PHYS /**< @see OPTIMSOC_CLUSTER_KERNEL_BASE_PHYS */
+	#define KPOOL_PHYS   OPTIMSOC_CLUSTER_KPOOL_BASE_PHYS  /**< @see OPTIMSOC_CLUSTER_KPOOL_BASE_PHYS  */
+	#define UBASE_PHYS   OPTIMSOC_CLUSTER_USER_BASE_PHYS   /**< @see OPTIMSOC_CLUSTER_USER_BASE_PHYS   */
+	#define USTACK_VIRT  OPTIMSOC_CLUSTER_USTACK_BASE_VIRT /**< @see OPTIMSOC_CLUSTER_USTACK_BASE_VIRT */
+	#define UBASE_VIRT   OPTIMSOC_CLUSTER_USER_BASE_VIRT   /**< @see OPTIMSOC_CLUSTER_USER_BASE_VIRT   */
+	#define KBASE_VIRT   OPTIMSOC_CLUSTER_KERNEL_BASE_VIRT /**< @see OPTIMSOC_CLUSTER_KERNEL_BASE_VIRT */
+	#define KPOOL_VIRT   OPTIMSOC_CLUSTER_KPOOL_BASE_VIRT  /**< @see OPTIMSOC_CLUSTER_KPOOL_BASE_VIRT  */
+	/**@}*/
+
+/**@endcond*/
+
+#endif /* CLUSTER_OPTIMSOC_CLUSTER_MEMORY_H_ */

--- a/include/arch/cluster/optimsoc-cluster/memory.h
+++ b/include/arch/cluster/optimsoc-cluster/memory.h
@@ -22,25 +22,25 @@
  * SOFTWARE.
  */
 
-#ifndef CLUSTER_OPTIMSOC_CLUSTER_MEMORY_H_
-#define CLUSTER_OPTIMSOC_CLUSTER_MEMORY_H_
+#ifndef ARCH_CLUSTER_OPTIMSOC_CLUSTER_MEMORY_H_
+#define ARCH_CLUSTER_OPTIMSOC_CLUSTER_MEMORY_H_
 
 	/* Cluster Interface Implementation */
 	#include <arch/cluster/optimsoc-cluster/_optimsoc-cluster.h>
+
+	/* Must come first. */
+	#define __NEED_CLUSTER_MEMMAP
 
 /**
  * @addtogroup optimsoc-cluster-mem Memory
  * @ingroup optimsoc-cluster
  *
- * @brief Memory System
+ * @brief Memory Interface
  */
 /**@{*/
 
-	/* Must come first. */
-	#define __NEED_CLUSTER_MEMMAP
-
-	#include <nanvix/const.h>
 	#include <arch/cluster/optimsoc-cluster/memmap.h>
+	#include <nanvix/const.h>
 
 	/**
 	 * @name Physical Memory Layout
@@ -80,19 +80,19 @@
 	 * @brief Kernel memory size (in bytes).
 	 */
 	#define OPTIMSOC_CLUSTER_KMEM_SIZE \
-		(OPTIMSOC_CLUSTER_KERNEL_END_VIRT - OPTIMSOC_CLUSTER_KERNEL_BASE_VIRT)
+		(OPTIMSOC_CLUSTER_KERNEL_END_PHYS - OPTIMSOC_CLUSTER_KERNEL_BASE_PHYS)
 
 	/**
 	 * @brief Kernel page pool size (in bytes).
 	 */
 	#define OPTIMSOC_CLUSTER_KPOOL_SIZE \
-		(OPTIMSOC_CLUSTER_KPOOL_END_VIRT - OPTIMSOC_CLUSTER_KPOOL_BASE_VIRT)
+		(OPTIMSOC_CLUSTER_KPOOL_END_PHYS - OPTIMSOC_CLUSTER_KPOOL_BASE_PHYS)
 
 	/**
 	 * @brief User memory size (in bytes).
 	 */
 	#define OPTIMSOC_CLUSTER_UMEM_SIZE \
-		(OPTIMSOC_CLUSTER_USER_END_VIRT - OPTIMSOC_CLUSTER_USER_BASE_VIRT)
+		(OPTIMSOC_CLUSTER_USER_END_PHYS - OPTIMSOC_CLUSTER_USER_BASE_PHYS)
 
 	/**
 	 * @brief Kernel stack size (in bytes).
@@ -100,7 +100,7 @@
 	#define OPTIMSOC_CLUSTER_KSTACK_SIZE OPTIMSOC_PAGE_SIZE
 
 	/**
-	 * OMPIC Registers and flags.
+	 * @brief OMPIC Registers and flags.
 	 */
 	/**@{*/
 	#define OPTIMSOC_OMPIC_CPUBYTES	        8
@@ -121,7 +121,7 @@
 	 */
 	EXTERN void optimsoc_cluster_mem_setup(void);
 
-#endif /* _ASM_FILE_ */
+#endif /* !_ASM_FILE_ */
 
 /**@}*/
 

--- a/include/arch/cluster/or1k-cluster/_or1k-cluster.h
+++ b/include/arch/cluster/or1k-cluster/_or1k-cluster.h
@@ -30,6 +30,10 @@
 
 #ifndef _ASM_FILE_
 
+	#ifndef __or1k_cluster__
+		#error "wrong cluter included!"
+	#endif
+
 	#if (defined(__or1200__))
 		#include <arch/core/or1k.h>
 	#elif (defined(__mor1kx__))

--- a/include/arch/cluster/or1k-cluster/_or1k-cluster.h
+++ b/include/arch/cluster/or1k-cluster/_or1k-cluster.h
@@ -28,21 +28,7 @@
 	#undef  __NEED_CORE_OR1K
 	#define __NEED_CORE_OR1K
 
-#ifndef _ASM_FILE_
-
-	#ifndef __or1k_cluster__
-		#error "wrong cluter included!"
-	#endif
-
-	#if (defined(__or1200__))
-		#include <arch/core/or1k.h>
-	#elif (defined(__mor1kx__))
-		#include <arch/core/mor1kx.h>
-	#else
-		#error "unkonwn core"
-	#endif
-
-#endif
+	#include <arch/core/or1k.h>
 
 #endif /* _CLUSTER_OR1K_CLUSTER_H_ */
 

--- a/include/arch/cluster/or1k-cluster/cores.h
+++ b/include/arch/cluster/or1k-cluster/cores.h
@@ -25,6 +25,10 @@
 #ifndef ARCH_CLUSTER_OR1K_CLUSTER_CORES_H_
 #define ARCH_CLUSTER_OR1K_CLUSTER_CORES_H_
 
+	#ifndef __or1k_cluster__
+		#error "wrong cluter included!"
+	#endif
+
 	/* Cluster Interface Implementation */
 	#include <arch/cluster/or1k-cluster/_or1k-cluster.h>
 

--- a/include/arch/cluster/or1k-cluster/memmap.h
+++ b/include/arch/cluster/or1k-cluster/memmap.h
@@ -25,6 +25,10 @@
 #ifndef CLUSTER_OR1K_CLUSTER_MEMMAP_H_
 #define CLUSTER_OR1K_CLUSTER_MEMMAP_H_
 
+	#ifndef __or1k_cluster__
+		#error "wrong cluter included!"
+	#endif
+
 	#ifndef __NEED_CLUSTER_MEMMAP
 		#error "do not include this file"
 	#endif

--- a/include/arch/cluster/or1k-cluster/memory.h
+++ b/include/arch/cluster/or1k-cluster/memory.h
@@ -25,6 +25,10 @@
 #ifndef CLUSTER_OR1K_CLUSTER_MEMORY_H_
 #define CLUSTER_OR1K_CLUSTER_MEMORY_H_
 
+	#ifndef __or1k_cluster__
+		#error "wrong cluter included!"
+	#endif
+
 	/* Cluster Interface Implementation */
 	#include <arch/cluster/or1k-cluster/_or1k-cluster.h>
 

--- a/include/arch/core/mor1kx.h
+++ b/include/arch/core/mor1kx.h
@@ -22,16 +22,16 @@
  * SOFTWARE.
  */
 
-#ifndef CORE_OR1K_H_
-#define CORE_OR1K_H_
+#ifndef ARCH_CORE_MOR1KX_H_
+#define ARCH_CORE_MOR1KX_H_
 
 	/**
 	 * @addtogroup or1k-core OpenRISC Core
 	 * @ingroup cores
 	 */
 
-	#ifndef __NEED_CORE_OR1K
-		#error "or1k core not required"
+	#ifndef __NEED_CORE_MOR1KX
+		#error "mor1kx core not required"
 	#endif
 
 	#include <arch/core/or1k/cache.h>
@@ -47,7 +47,7 @@
 	#include <arch/core/or1k/upcall.h>
 
 /**
- * @cond or1k
+ * @cond mor1kx
  */
 
 	/**
@@ -63,5 +63,5 @@
 
 /**@endcond*/
 
-#endif /* CORE_OR1K_H_ */
+#endif /* ARCH_CORE_MOR1KX_H_ */
 

--- a/include/arch/core/mor1kx/clock.h
+++ b/include/arch/core/mor1kx/clock.h
@@ -40,6 +40,8 @@
 	 */
 	#define OR1K_CPU_FREQUENCY 1666666
 
+#ifndef _ASM_FILE_
+
 	/**
 	 * @brief Initializes the clock driver in the or1k architecture.
 	 *
@@ -51,6 +53,8 @@
 	 * @brief Resets the clock device.
 	 */
 	EXTERN void or1k_clock_reset(void);
+
+#endif /* !_ASM_FILE_ */
 
 /**@}*/
 

--- a/include/arch/core/or1k/cache.h
+++ b/include/arch/core/or1k/cache.h
@@ -25,6 +25,9 @@
 #ifndef ARCH_CORE_OR1K_CACHE_H_
 #define ARCH_CORE_OR1K_CACHE_H_
 
+	/* Must come first. */
+	#define __NEED_OR1K_REGS
+
 /**
  * @addtogroup or1k-core-cache Cache
  * @ingroup or1k-core
@@ -33,12 +36,7 @@
  */
 /**@{*/
 
-#ifndef _ASM_FILE_
-
-	#define __NEED_OR1K_REGS
 	#include <arch/core/or1k/regs.h>
-
-#endif /* _ASM_FILE_ */
 
 	/**
 	 * @brief Cache line size (in bytes).
@@ -46,6 +44,8 @@
 	 * @todo Check this.
 	 */
 	#define OR1K_CACHE_LINE_SIZE 64
+
+#ifndef _ASM_FILE_
 
 	/**
 	 * @brief Invalidates the data cache.
@@ -56,6 +56,8 @@
 	{
 		or1k_mtspr(OR1K_SPR_DCBIR, 0);
 	}
+
+#endif /* _ASM_FILE_ */
 
 /**@}*/
 
@@ -79,6 +81,8 @@
 	 */
 	#define CACHE_LINE_SIZE OR1K_CACHE_LINE_SIZE
 
+#ifndef _ASM_FILE_
+
 	/**
 	 * @see or1k_dcache_inval().
 	 */
@@ -86,6 +90,8 @@
 	{
 		or1k_dcache_inval();
 	}
+
+#endif /* !_ASM_FILE_ */
 
 /**@endcond*/
 

--- a/include/arch/core/or1k/ompic.h
+++ b/include/arch/core/or1k/ompic.h
@@ -25,10 +25,10 @@
 #ifndef ARCH_CORE_OR1K_OMPIC_H_
 #define ARCH_CORE_OR1K_OMPIC_H_
 
-#ifndef _ASM_FILE_
-
 	#include <nanvix/const.h>
 	#include <stdint.h>
+
+#ifndef _ASM_FILE_
 
 	/* External functions. */
 	EXTERN void or1k_ompic_init(void);

--- a/include/arch/core/or1k/regs.h
+++ b/include/arch/core/or1k/regs.h
@@ -488,6 +488,6 @@
 		);
 	}
 
-#endif
+#endif /* !_ASM_FILE_ */
 
 #endif	/* ARCH_CORE_OR1K_REGS_H_ */

--- a/include/arch/core/or1k/tlb.h
+++ b/include/arch/core/or1k/tlb.h
@@ -125,6 +125,8 @@
 	#define OR1K_ITLBE_UXE 2 /**< User Execute Enable       */
 	/**@}*/
 
+#ifndef _ASM_FILE_
+
 	/**
 	 * @brief TLB entry.
 	 */
@@ -236,6 +238,8 @@
 	 */
 	EXTERN void or1k_tlb_init(void);
 
+#endif /* _ASM_FILE_ */
+
 /**@}*/
 
 /*============================================================================*
@@ -275,6 +279,8 @@
 	#define TLB_INSTRUCTION OR1K_TLB_INSTRUCTION /**< Instruction TLB */
 	#define TLB_DATA        OR1K_TLB_DATA        /**< Data TLB        */
 	/**@}*/
+
+#ifndef _ASM_FILE_
 
 	/**
 	 * @see or1k_tlbe_vaddr_get().
@@ -347,6 +353,8 @@
 	{
 		return (or1k_tlb_flush());
 	}
+
+#endif /* _ASM_FILE_ */
 
 /**@endcond*/
 

--- a/include/arch/core/or1k/trap.h
+++ b/include/arch/core/or1k/trap.h
@@ -25,6 +25,9 @@
 #ifndef ARCH_CORE_OR1K_TRAP_H_
 #define ARCH_CORE_OR1K_TRAP_H_
 
+	/* Must come first. */
+	#define __NEED_CORE_TYPES
+
 /**
  * @addtogroup or1k-core-trap Trap
  * @ingroup or1k-core
@@ -33,8 +36,9 @@
  */
 /**@{*/
 
-	#define __NEED_CORE_TYPES
 	#include <arch/core/or1k/types.h>
+
+#ifndef _ASM_FILE_
 
 	/**
 	 * @brief Issues a system call with no arguments.
@@ -238,6 +242,8 @@
 	 */
 	EXTERN void or1k_syscall(void);
 
+#endif /* !_ASM_FILE_ */
+
 /**@}*/
 
 /*============================================================================*
@@ -259,6 +265,8 @@
 	#define __syscall4_fn /**< or1k_syscall4() */
 	#define __syscall5_fn /**< or1k_syscall5() */
 	/**@}*/
+
+#ifndef _ASM_FILE_
 
 	/**
 	 * @see or1k_syscall_0()
@@ -364,6 +372,8 @@
 			)
 		);
 	}
+
+#endif /* !_ASM_FILE_ */
 
 /**@endcond*/
 

--- a/include/nanvix/hal/cluster/_cluster.h
+++ b/include/nanvix/hal/cluster/_cluster.h
@@ -47,6 +47,12 @@
 		#define __NEED_CLUSTER_OR1K
 		#include <arch/cluster/or1k-cluster.h>
 
+	#elif (defined(__optimsoc_cluster__))
+
+		#undef  __NEED_CLUSTER_OPTIMSOC
+		#define __NEED_CLUSTER_OPTIMSOC
+		#include <arch/cluster/optimsoc-cluster.h>
+
 	#elif (defined(__riscv32_cluster__))
 
 		#undef  __NEED_CLUSTER_RISCV32

--- a/include/nanvix/hal/core/_core.h
+++ b/include/nanvix/hal/core/_core.h
@@ -49,8 +49,8 @@
 
 	#elif (defined(__mor1kx__))
 
-		#undef  __NEED_CORE_OR1K
-		#define __NEED_CORE_OR1K
+		#undef  __NEED_CORE_MOR1KX
+		#define __NEED_CORE_MOR1KX
 		#include <arch/core/mor1kx.h>
 
 	#elif (defined(__rv32gc__))

--- a/src/build/processor/makefile.optimsoc
+++ b/src/build/processor/makefile.optimsoc
@@ -24,7 +24,7 @@
 # Target Configuration
 #===============================================================================
 
-export CLUSTER = or1k-cluster
+export CLUSTER = optimsoc-cluster
 export CORE = or1k
 export CORE_VARIANT = mor1kx
 
@@ -33,7 +33,7 @@ export CORE_VARIANT = mor1kx
 #===============================================================================
 
 # Compiler Options
-export CFLAGS += -D __or1k_cluster__ -D__or1k__ -D __mor1kx__
+export CFLAGS += -D __optimsoc_cluster__ -D__or1k__ -D __mor1kx__
 
 #===============================================================================
 

--- a/src/hal/arch/cluster/optimsoc-cluster/_cluster.S
+++ b/src/hal/arch/cluster/optimsoc-cluster/_cluster.S
@@ -24,12 +24,9 @@
 
 /* Must come first. */
 #define _ASM_FILE_
-#define __NEED_OR1K_REGS
-#define __NEED_CORE_TYPES
+#define __NEED_CLUSTER_OPTIMSOC
 
-#include <arch/core/or1k/core.h>
-#include <arch/core/or1k/mmu.h>
-#include <arch/core/or1k/types.h>
+#include <arch/cluster/optimsoc-cluster.h>
 #include <arch/core/or1k/asm.h>
 
 /* Exported symbols. */

--- a/src/hal/arch/cluster/optimsoc-cluster/_cluster.S
+++ b/src/hal/arch/cluster/optimsoc-cluster/_cluster.S
@@ -22,11 +22,42 @@
  * SOFTWARE.
  */
 
-#ifndef _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
-#define _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
+/* Must come first. */
+#define _ASM_FILE_
+#define __NEED_OR1K_REGS
+#define __NEED_CORE_TYPES
 
-	#undef  __NEED_CLUSTER_OPTIMSOC
-	#define __NEED_CLUSTER_OPTIMSOC
-	#include <arch/cluster/optimsoc-cluster.h>
+#include <arch/core/or1k/core.h>
+#include <arch/core/or1k/mmu.h>
+#include <arch/core/or1k/types.h>
+#include <arch/core/or1k/asm.h>
 
-#endif /* _PROCESSOR_OPTIMSOC_OPTIMSOC_H_ */
+/* Exported symbols. */
+.global _optimsoc_cluster_core_reset
+.global core.kstack
+
+.section .text
+
+/*===========================================================================*
+ * _optimsoc_cluster_core_reset()                                            *
+ *===========================================================================*/
+
+/*
+ * Resets the underlying core.
+ */
+_optimsoc_cluster_core_reset:
+
+	/* Save coreid. */
+	OR1K_EXCEPTION_STORE_GPR3
+
+	/* Clear GPRs. */
+	or1k_clear_gprs
+
+	/* Reset stack. */
+	OR1K_EXCEPTION_LOAD_GPR3(r3)
+	or1k_core_stack_reset r3
+
+	/* Restart core. */
+	l.j optimsoc_cluster_slave_setup
+	l.nop
+	halt

--- a/src/hal/arch/cluster/optimsoc-cluster/boot_code.S
+++ b/src/hal/arch/cluster/optimsoc-cluster/boot_code.S
@@ -1,0 +1,96 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * OpenRISC head.S
+ *
+ * Linux architectural port borrowing liberally from similar works of
+ * others.  All original copyrights apply as per the original source
+ * declaration.
+ *
+ * Modifications for the OpenRISC architecture:
+ * Copyright (C) 2003 Matjaz Breskvar <phoenix@bsemi.com>
+ * Copyright (C) 2010-2011 Jonas Bonn <jonas@southpole.se>
+ *
+ *      This program is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU General Public License
+ *      as published by the Free Software Foundation; either version
+ *      2 of the License, or (at your option) any later version.
+ */
+
+/* Must come first. */
+#define _ASM_FILE_
+#define __NEED_OR1K_REGS
+#define __NEED_CORE_TYPES
+
+#include <arch/cluster/or1k-cluster/cores.h>
+#include <arch/core/or1k/mmu.h>
+#include <arch/core/or1k/types.h>
+#include <arch/core/or1k/asm.h>
+
+/* Exported symbols. */
+.globl start
+.globl core.kstack
+
+/*============================================================================*
+ *                              bootstrap section                             *
+ *============================================================================*/
+
+.section .bootstrap,"ax",@progbits
+
+/*----------------------------------------------------------------------------*
+ * start()                                                                    *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * Kernel entry point.
+ */
+start:
+
+	or1k_clear_gprs
+
+	/* Supervisor mode. */
+	l.ori	r1, r0, 0x1
+	l.mtspr	r0, r1, OR1K_SPR_SR
+
+	/* Reset stack. */
+	l.mfspr r3, r0, OR1K_SPR_COREID
+	or1k_core_stack_reset r3
+
+	l.mfspr r3, r0, OR1K_SPR_COREID
+	l.sfeqi r3, 0
+	l.bf start.master
+	l.nop
+
+	/* Slave. */
+	start.slave:
+		l.jal optimsoc_cluster_slave_setup
+		l.nop
+		halt
+
+	/* Master. */
+	start.master:
+		l.jal optimsoc_cluster_master_setup
+		l.nop
+		halt

--- a/src/hal/arch/cluster/optimsoc-cluster/boot_code.S
+++ b/src/hal/arch/cluster/optimsoc-cluster/boot_code.S
@@ -41,12 +41,9 @@
 
 /* Must come first. */
 #define _ASM_FILE_
-#define __NEED_OR1K_REGS
-#define __NEED_CORE_TYPES
+#define __NEED_CLUSTER_OPTIMSOC
 
-#include <arch/cluster/or1k-cluster/cores.h>
-#include <arch/core/or1k/mmu.h>
-#include <arch/core/or1k/types.h>
+#include <arch/cluster/optimsoc-cluster.h>
 #include <arch/core/or1k/asm.h>
 
 /* Exported symbols. */

--- a/src/hal/arch/cluster/optimsoc-cluster/boot_code.S
+++ b/src/hal/arch/cluster/optimsoc-cluster/boot_code.S
@@ -22,23 +22,6 @@
  * SOFTWARE.
  */
 
-/*
- * OpenRISC head.S
- *
- * Linux architectural port borrowing liberally from similar works of
- * others.  All original copyrights apply as per the original source
- * declaration.
- *
- * Modifications for the OpenRISC architecture:
- * Copyright (C) 2003 Matjaz Breskvar <phoenix@bsemi.com>
- * Copyright (C) 2010-2011 Jonas Bonn <jonas@southpole.se>
- *
- *      This program is free software; you can redistribute it and/or
- *      modify it under the terms of the GNU General Public License
- *      as published by the Free Software Foundation; either version
- *      2 of the License, or (at your option) any later version.
- */
-
 /* Must come first. */
 #define _ASM_FILE_
 #define __NEED_CLUSTER_OPTIMSOC

--- a/src/hal/arch/cluster/optimsoc-cluster/boot_data.S
+++ b/src/hal/arch/cluster/optimsoc-cluster/boot_data.S
@@ -24,10 +24,10 @@
 
 /* Must come first. */
 #define _ASM_FILE_
+#define __NEED_CLUSTER_OPTIMSOC
 
-#include <arch/core/or1k/core.h>
-#include <arch/core/or1k/mmu.h>
-#include <arch/cluster/or1k-cluster/cores.h>
+#include <arch/cluster/optimsoc-cluster.h>
+#include <arch/core/or1k/asm.h>
 
 /* Exported symbols. */
 .globl core.kstack

--- a/src/hal/arch/cluster/optimsoc-cluster/boot_data.S
+++ b/src/hal/arch/cluster/optimsoc-cluster/boot_data.S
@@ -22,11 +22,24 @@
  * SOFTWARE.
  */
 
-#ifndef _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
-#define _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
+/* Must come first. */
+#define _ASM_FILE_
 
-	#undef  __NEED_CLUSTER_OPTIMSOC
-	#define __NEED_CLUSTER_OPTIMSOC
-	#include <arch/cluster/optimsoc-cluster.h>
+#include <arch/core/or1k/core.h>
+#include <arch/core/or1k/mmu.h>
+#include <arch/cluster/or1k-cluster/cores.h>
 
-#endif /* _PROCESSOR_OPTIMSOC_OPTIMSOC_H_ */
+/* Exported symbols. */
+.globl core.kstack
+
+.section .data
+/*----------------------------------------------------------------------------*
+ * core.kstack                                                                *
+ *----------------------------------------------------------------------------*/
+
+/**
+ * @brief Kernel stack for all cores.
+ */
+.align OR1K_PAGE_SIZE
+core.kstack:
+	.fill (OR1K_PAGE_SIZE/OR1K_PTE_SIZE)*OR1K_CLUSTER_NUM_CORES, OR1K_PTE_SIZE, 0

--- a/src/hal/arch/cluster/optimsoc-cluster/cluster.c
+++ b/src/hal/arch/cluster/optimsoc-cluster/cluster.c
@@ -1,0 +1,185 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* Must come first. */
+#define __NEED_HAL_CLUSTER
+
+#include <arch/core/or1k/ompic.h>
+#include <nanvix/hal/cluster.h>
+#include <nanvix/const.h>
+#include <nanvix/klib.h>
+
+/* Import definitions. */
+EXTERN NORETURN void kmain(int, const char *[]);
+
+/**
+ * @brief Cores table.
+ */
+PUBLIC struct coreinfo  ALIGN(OR1K_CACHE_LINE_SIZE) cores[OPTIMSOC_CLUSTER_NUM_CORES] = {
+	{ TRUE,  CORE_RUNNING,   0, NULL, OR1K_SPINLOCK_LOCKED }, /* Master Core   */
+	{ FALSE, CORE_RESETTING, 0, NULL, OR1K_SPINLOCK_LOCKED }, /* Slave Core 1  */
+	{ FALSE, CORE_RESETTING, 0, NULL, OR1K_SPINLOCK_LOCKED }, /* Slave Core 2  */
+	{ FALSE, CORE_RESETTING, 0, NULL, OR1K_SPINLOCK_LOCKED }, /* Slave Core 3  */
+};
+
+/**
+ * @brief Startup fence.
+ */
+PUBLIC struct fences
+{
+	int master_alive;
+	or1k_spinlock_t lock;
+} fence = { FALSE , OR1K_SPINLOCK_UNLOCKED};
+
+/**
+ * @brief Releases the startup fence.
+ */
+PRIVATE void optimsoc_fence_release(void)
+{
+	or1k_spinlock_lock(&fence.lock);
+		fence.master_alive = TRUE;
+	or1k_spinlock_unlock(&fence.lock);
+}
+
+/**
+ * @brief Waits on the startup fence.
+ */
+PRIVATE void optimsoc_fence_wait(void)
+{
+	while (TRUE)
+	{
+		or1k_spinlock_lock(&fence.lock);
+
+			/* Fence is released. */
+			if (fence.master_alive)
+			{
+				or1k_spinlock_unlock(&fence.lock);
+				break;
+			}
+
+			noop();
+		or1k_spinlock_unlock(&fence.lock);
+	}
+}
+
+/*============================================================================*
+ * optimsoc_cluster_master_setup()                                            *
+ *============================================================================*/
+
+/**
+ * @brief Initializes the master core.
+ *
+ * The optimsoc_master_setup() function initializes the underlying
+ * master core. It setups the stack and then call the kernel
+ * main function.
+ *
+ * @note This function does not return.
+ *
+ * @author Davidson Francis
+ */
+PUBLIC NORETURN void optimsoc_cluster_master_setup(void)
+{
+	/* Core setup. */
+	optimsoc_cluster_setup();
+
+	/* Enable interrupts. */
+	or1k_mtspr(OR1K_SPR_SR, or1k_mfspr(OR1K_SPR_SR) | OR1K_SPR_SR_IEE);
+
+	optimsoc_fence_release();
+
+	/* Kernel main. */
+	kmain(0, NULL);
+}
+
+/*============================================================================*
+ * optimsoc_cluster_slave_setup()                                             *
+ *============================================================================*/
+
+/**
+ * @brief Initializes a slave core.
+ *
+ * The optimsoc_cluster_slave_setup() function initializes the underlying slave
+ * core.  It setups the stack and then call the kernel main function.
+ * Architectural structures are initialized by the master core and
+ * registered later on, when the slave core is started effectively.
+ *
+ * @note This function does not return.
+ *
+ * @see or1k_core_setup() and or1k_master_setup().
+ *
+ * @author Davidson Francis
+ */
+PUBLIC NORETURN void optimsoc_cluster_slave_setup(void)
+{
+	optimsoc_fence_wait();
+
+	/* Initial TLB. */
+	or1k_tlb_init();
+
+	/* Enable MMU. */
+	or1k_enable_mmu();
+
+	/* Enable OMPIC interrupts. */
+	or1k_pic_unmask(OR1K_INT_OMPIC);
+
+	/* Enable interrupts. */
+	or1k_mtspr(OR1K_SPR_SR, or1k_mfspr(OR1K_SPR_SR) | OR1K_SPR_SR_IEE);
+
+	while (TRUE)
+	{
+		core_idle();
+		core_run();
+	}
+}
+
+/*============================================================================*
+ * optimsoc_cluster_setup()                                                   *
+ *============================================================================*/
+
+/**
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Pedro Henrique Penna, Davidson Francis
+ */
+PUBLIC void optimsoc_cluster_setup(void)
+{
+	kprintf("[hal] booting up cluster...");
+
+	/* Configure Memory Layout. */
+	optimsoc_cluster_mem_setup();
+
+	/* Enable MMU. */
+	or1k_mmu_setup();
+
+	/* Configure OMPIC. */
+	or1k_ompic_init();
+
+	/* Enable OMPIC interrupts. */
+	or1k_pic_unmask(OR1K_INT_OMPIC);
+
+	/* Enable interrupts. */
+	or1k_mtspr(OR1K_SPR_SR, or1k_mfspr(OR1K_SPR_SR) | OR1K_SPR_SR_IEE);
+
+	optimsoc_fence_release();
+}

--- a/src/hal/arch/cluster/optimsoc-cluster/event.c
+++ b/src/hal/arch/cluster/optimsoc-cluster/event.c
@@ -22,11 +22,26 @@
  * SOFTWARE.
  */
 
-#ifndef _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
-#define _PROCESSOR_OPTIMSOC_OPTIMSOC_H_
+/* Must come first. */
+#define __NEED_HAL_CLUSTER
 
-	#undef  __NEED_CLUSTER_OPTIMSOC
-	#define __NEED_CLUSTER_OPTIMSOC
-	#include <arch/cluster/optimsoc-cluster.h>
+#include <nanvix/hal/cluster.h>
+#include <nanvix/const.h>
 
-#endif /* _PROCESSOR_OPTIMSOC_OPTIMSOC_H_ */
+/**
+ * @cond or1k_cluster
+ *
+ * Table of events
+ *
+ * @endcond
+ */
+PUBLIC struct
+{
+	unsigned pending;
+	or1k_spinlock_t lock;
+} events[OPTIMSOC_CLUSTER_NUM_CORES] ALIGN(OR1K_CACHE_LINE_SIZE) = {
+	{ 0, OR1K_SPINLOCK_UNLOCKED }, /* Master Core  */
+	{ 0, OR1K_SPINLOCK_UNLOCKED }, /* Slave Core 1 */
+	{ 0, OR1K_SPINLOCK_UNLOCKED }, /* Slave Core 2 */
+	{ 0, OR1K_SPINLOCK_UNLOCKED }, /* Slave Core 3 */
+};

--- a/src/hal/arch/cluster/optimsoc-cluster/memory.c
+++ b/src/hal/arch/cluster/optimsoc-cluster/memory.c
@@ -1,0 +1,356 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <arch/cluster/optimsoc-cluster/memory.h>
+#include <arch/cluster/optimsoc-cluster/cores.h>
+#include <nanvix/hal/core/exception.h>
+#include <nanvix/klib.h>
+#include <nanvix/const.h>
+
+/**
+ * @brief Length of virtual addresses.
+ *
+ * Number of bits in a virtual address.
+ *
+ * @author Davidson Francis
+ */
+#define OR1K_VADDR_LENGTH 32
+
+/**
+ * @brief Number of memory regions.
+ */
+#define OPTIMSOC_CLUSTER_MEM_REGIONS 3
+
+/**
+ * @brief Memory region.
+ */
+struct memory_region
+{
+	paddr_t pbase;  /**< Base physical address. */
+	vaddr_t vbase;  /**< Base virtual address.  */
+	size_t size;    /**< Size.                  */
+	int writable;   /**< Writable?              */
+	int executable; /**< Executable?            */
+};
+
+/**
+ * @brief Memory layout.
+ */
+PRIVATE struct memory_region optimsoc_cluster_mem_layout[OPTIMSOC_CLUSTER_MEM_REGIONS] = {
+	{ OPTIMSOC_CLUSTER_KERNEL_BASE_PHYS, OPTIMSOC_CLUSTER_KERNEL_BASE_VIRT, OPTIMSOC_CLUSTER_KMEM_SIZE,      TRUE, TRUE  },
+	{ OPTIMSOC_CLUSTER_KPOOL_BASE_PHYS,  OPTIMSOC_CLUSTER_KPOOL_BASE_VIRT,  OPTIMSOC_CLUSTER_KPOOL_SIZE,     TRUE, FALSE },
+	{ OPTIMSOC_CLUSTER_OMPIC_BASE_PHYS,  OPTIMSOC_CLUSTER_OMPIC_BASE_VIRT,  OPTIMSOC_CLUSTER_OMPIC_MEM_SIZE, TRUE, FALSE },
+};
+
+/**
+ * @brief Root page directory.
+ */
+PRIVATE struct pde optimsoc_cluster_root_pgdir[OR1K_PGDIR_LENGTH] ALIGN(PAGE_SIZE);
+
+/**
+ * @brief Root page tables.
+ */
+PRIVATE struct pte optimsoc_cluster_root_pgtabs[OPTIMSOC_CLUSTER_MEM_REGIONS][OR1K_PGTAB_LENGTH] ALIGN(PAGE_SIZE);
+
+/**
+ * Alias to root page directory.
+ */
+PUBLIC struct pde *root_pgdir = &optimsoc_cluster_root_pgdir[0];
+
+/**
+ * Alias to kernel page table.
+ */
+PUBLIC struct pte *kernel_pgtab = optimsoc_cluster_root_pgtabs[0];
+
+/**
+ * Alias to kernel page pool page table.
+ */
+PUBLIC struct pte *kpool_pgtab = optimsoc_cluster_root_pgtabs[1];
+
+/**
+ * @brief Handles a TLB fault.
+ *
+ * The optimsoc_do_tlb_fault() function handles a early TLB faults. It
+ * checks the current page directory for a virtual-to-physical address
+ * mapping, and if it finds one, it writes this mapping to the TLB. If
+ * the faulting address is not currently mapped in the current page
+ * directory, it panics the kernel.
+ *
+ * @param excp Exception information.
+ * @param ctx  Interrupted execution context.
+ *
+ * @author Davidson Francis
+ * @author Pedro Henrique Penna
+ */
+PRIVATE void optimsoc_do_tlb_fault(
+	const struct exception *excp,
+	const struct context *ctx
+)
+{
+	int tlb;           /* Target TLB.                     */
+	paddr_t paddr;     /* Physical address.               */
+	vaddr_t vaddr;     /* Faulting address.               */
+	struct pte *pte;   /* Working page table table entry. */
+	struct pde *pde;   /* Working page directory entry.   */
+	struct pte *pgtab; /* Working page table.             */
+
+	/* Get page address of faulting address. */
+	vaddr = or1k_excp_get_addr(excp);
+	vaddr &= OR1K_PAGE_MASK;
+
+	/* Lookup PDE. */
+	pde = pde_get(root_pgdir, vaddr);
+	if (!pde_is_present(pde))
+	{
+		or1k_context_dump(ctx);
+		kpanic("[hal] page fault at %x", exception_get_addr(excp));
+	}
+
+	/* Lookup PTE. */
+	pgtab = (struct pte *)(pde_frame_get(pde) << OR1K_PAGE_SHIFT);
+	pte = pte_get(pgtab, vaddr);
+	if (!pte_is_present(pte))
+	{
+		or1k_context_dump(ctx);
+		kpanic("[hal] page fault at %x", exception_get_addr(excp));
+	}
+
+	/* Writing mapping to TLB. */
+	paddr = pte_frame_get(pte) << OR1K_PAGE_SHIFT;
+	tlb = (excp->num == OR1K_EXCP_ITLB_FAULT) ?
+		OR1K_TLB_INSTRUCTION : OR1K_TLB_DATA;
+	if (or1k_tlb_write(tlb, vaddr, paddr) < 0)
+		kpanic("[hal] cannot write to tlb");
+}
+
+/**
+ * The or1k_mmu_enable() function enables the MMU of the underlying
+ * or1k core.
+ */
+PUBLIC void or1k_enable_mmu(void)
+{
+	or1k_mtspr(OR1K_SPR_SR, or1k_mfspr(OR1K_SPR_SR)
+		| OR1K_SPR_SR_DME | OR1K_SPR_SR_IME);
+}
+
+/**
+ * The or1k_mmu_setup() function initializes the Memory Management Unit
+ * (MMU) of the underlying or1k core.
+ */
+PUBLIC void or1k_mmu_setup(void)
+{
+	/* TLB Handler. */
+	exception_register(EXCEPTION_DTLB_FAULT, optimsoc_do_tlb_fault);
+	exception_register(EXCEPTION_ITLB_FAULT, optimsoc_do_tlb_fault);
+
+	/* Initial TLB. */
+	or1k_tlb_init();
+
+	/* Enable MMU. */
+	or1k_enable_mmu();
+}
+
+/*============================================================================*
+ * optimsoc_cluster_mem_info()                                                *
+ *============================================================================*/
+
+/**
+ * @brief Prints information about memory layout.
+ *
+ * The optimsoc_cluster_mem_info() prints information about the virtual
+ * memory layout.
+ *
+ * @author Davidson Francis
+ */
+PRIVATE void optimsoc_cluster_mem_info(void)
+{
+	kprintf("[hal] kernel_base=%x kernel_end=%x",
+		OPTIMSOC_CLUSTER_KERNEL_BASE_VIRT,
+		OPTIMSOC_CLUSTER_KERNEL_END_VIRT
+	);
+	kprintf("[hal] kpool_base=%x  kpool_end=%x",
+		OPTIMSOC_CLUSTER_KPOOL_BASE_VIRT,
+		OPTIMSOC_CLUSTER_KPOOL_END_VIRT
+	);
+	kprintf("[hal] user_base=%x   user_end=%x",
+		OPTIMSOC_CLUSTER_USER_BASE_VIRT,
+		OPTIMSOC_CLUSTER_USER_END_VIRT
+	);
+	kprintf("[hal] ompic_base=%x  ompic_end=%x",
+		OPTIMSOC_CLUSTER_OMPIC_BASE_VIRT,
+		OPTIMSOC_CLUSTER_OMPIC_END_VIRT
+	);
+	kprintf("[hal] memsize=%d MB kmem=%d KB kpool=%d KB umem=%d KB",
+		OPTIMSOC_CLUSTER_MEM_SIZE/MB,
+		OPTIMSOC_CLUSTER_KMEM_SIZE/KB,
+		OPTIMSOC_CLUSTER_KPOOL_SIZE/KB,
+		OPTIMSOC_CLUSTER_UMEM_SIZE/KB
+	);
+}
+
+/*============================================================================*
+ * optimsoc_cluster_mem_check_align()                                         *
+ *============================================================================*/
+
+/**
+ * @brief Asserts the memory alignment.
+ *
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Davidson Francis
+ */
+PRIVATE void optimsoc_cluster_mem_check_align(void)
+{
+	/* These should be aligned at page boundaries. */
+	if (OPTIMSOC_CLUSTER_OMPIC_BASE_VIRT & (OR1K_PAGE_SIZE - 1))
+		kpanic("ompic base address misaligned");
+	if (OPTIMSOC_CLUSTER_OMPIC_END_VIRT & (OR1K_PAGE_SIZE - 1))
+		kpanic("ompic end address misaligned");
+
+	/* These should be aligned at page table boundaries. */
+	if (OPTIMSOC_CLUSTER_KERNEL_BASE_VIRT & (OR1K_PGTAB_SIZE - 1))
+		kpanic("kernel base address misaligned");
+	if (OPTIMSOC_CLUSTER_KERNEL_END_VIRT & (OR1K_PGTAB_SIZE - 1))
+		kpanic("kernel end address misaligned");
+	if (OPTIMSOC_CLUSTER_KPOOL_BASE_VIRT & (OR1K_PGTAB_SIZE - 1))
+		kpanic("kernel pool base address misaligned");
+	if (OPTIMSOC_CLUSTER_KPOOL_END_VIRT & (OR1K_PGTAB_SIZE - 1))
+		kpanic("kernel pool end address misaligned");
+	if (OPTIMSOC_CLUSTER_USER_BASE_VIRT & (OR1K_PGTAB_SIZE - 1))
+		kpanic("user base address misaligned");
+	if (OPTIMSOC_CLUSTER_USER_END_VIRT & (OR1K_PGTAB_SIZE - 1))
+		kpanic("user end address misaligned");
+
+}
+
+/*============================================================================*
+ * optimsoc_cluster_mem_check_layout()                                        *
+ *============================================================================*/
+
+/**
+ * @brief Asserts the memory layout.
+ *
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Davidson Francis
+ */
+PRIVATE void optimsoc_cluster_mem_check_layout(void)
+{
+	/*
+	 * These should be identity mapped, becasuse the underlying
+	 * hypervisor runs with virtual memory disabled.
+	 */
+	if (OPTIMSOC_CLUSTER_OMPIC_BASE_VIRT != OPTIMSOC_CLUSTER_OMPIC_BASE_PHYS)
+		kpanic("ompic base address is not identity mapped");
+	if (OPTIMSOC_CLUSTER_OMPIC_END_VIRT != OPTIMSOC_CLUSTER_OMPIC_END_PHYS)
+		kpanic("ompic end address is not identity mapped");
+	if (OPTIMSOC_CLUSTER_KERNEL_BASE_VIRT != OPTIMSOC_CLUSTER_KERNEL_BASE_PHYS)
+		kpanic("kernel base address is not identity mapped");
+	if (OPTIMSOC_CLUSTER_KERNEL_END_VIRT != OPTIMSOC_CLUSTER_KERNEL_END_PHYS)
+		kpanic("kernel end address is not identity mapped");
+	if (OPTIMSOC_CLUSTER_KPOOL_BASE_VIRT != OPTIMSOC_CLUSTER_KPOOL_BASE_PHYS)
+		kpanic("kernel pool base address is not identity mapped");
+	if (OPTIMSOC_CLUSTER_KPOOL_END_VIRT != OPTIMSOC_CLUSTER_KPOOL_END_PHYS)
+		kpanic("kernel pool end address is not identity mapped");
+}
+
+/*============================================================================*
+ * optimsoc_cluster_mem_map()                                                 *
+ *============================================================================*/
+
+/**
+ * @brief Builds the memory layout.
+ *
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Davidson Francis
+ */
+PRIVATE void optimsoc_cluster_mem_map(void)
+{
+	/* Clean root page directory. */
+	for (int i = 0; i < OR1K_PGDIR_LENGTH; i++)
+		pde_clear(&optimsoc_cluster_root_pgdir[i]);
+
+	/* Build root address space. */
+	for (int i = 0; i < OPTIMSOC_CLUSTER_MEM_REGIONS; i++)
+	{
+		paddr_t j;
+		vaddr_t k;
+		paddr_t pbase = optimsoc_cluster_mem_layout[i].pbase;
+		vaddr_t vbase = optimsoc_cluster_mem_layout[i].vbase;
+		size_t size = optimsoc_cluster_mem_layout[i].size;
+		int w = optimsoc_cluster_mem_layout[i].writable;
+		int x = optimsoc_cluster_mem_layout[i].executable;
+
+		/* Map underlying pages. */
+		for (j = pbase, k = vbase;
+			 k < (pbase + size);
+			 j += OR1K_PAGE_SIZE, k += OR1K_PAGE_SIZE)
+		{
+			or1k_page_map(optimsoc_cluster_root_pgtabs[i], j, k, w, x);
+		}
+
+		/* Map underlying page table. */
+		or1k_pgtab_map(
+				optimsoc_cluster_root_pgdir,
+				OR1K_PADDR(optimsoc_cluster_root_pgtabs[i]),
+				vbase
+		);
+	}
+}
+
+/*============================================================================*
+ * or1k_cluster_mem_setup()                                                   *
+ *============================================================================*/
+
+/**
+ * The or1k_cluster_mem_setup() function initializes the Memory
+ * Interface of the underlying OpenRISC Cluster.
+ *
+ * @author Davidson Francis
+ */
+PUBLIC void optimsoc_cluster_mem_setup(void)
+{
+	int coreid;
+
+	coreid = or1k_core_get_id();
+
+	kprintf("[hal] initializing memory layout...");
+
+	/* Master core builds root virtual address space. */
+	if (coreid == OPTIMSOC_CLUSTER_COREID_MASTER)
+	{
+		optimsoc_cluster_mem_info();
+
+		/* Check for memory layout. */
+		optimsoc_cluster_mem_check_layout();
+		optimsoc_cluster_mem_check_align();
+
+		optimsoc_cluster_mem_map();
+	}
+
+	/*
+	 * TODO: slave cores should warmup the TLB.
+	 */
+}

--- a/src/hal/arch/cluster/optimsoc-cluster/ompic.c
+++ b/src/hal/arch/cluster/optimsoc-cluster/ompic.c
@@ -1,0 +1,93 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/hal/core/interrupt.h>
+#include <arch/cluster/or1k-cluster/memory.h>
+#include <nanvix/const.h>
+#include <stdint.h>
+
+/*
+ * @brief Reds from a specified OMPIC register.
+ *
+ * @param reg Target register.
+ * @return Register value.
+ */
+PRIVATE inline uint32_t or1k_ompic_readreg(uint32_t reg)
+{
+	return ( *((volatile uint32_t *) (reg)) );
+}
+
+/*
+ * @brief Writes into a specified OMPIC register.
+ *
+ * @param reg Target register.
+ * @param data Data to be written.
+ */
+PRIVATE inline void or1k_ompic_writereg(uint32_t reg, uint32_t data)
+{
+	*((volatile uint32_t *) (reg)) = data;
+}
+
+/*
+ * @brief Sends an Inter-processor Interrupt.
+ *
+ * @param dstcore Destination core to be sent the message.
+ * @param data Data to be sent.
+ */
+PUBLIC void or1k_ompic_send_ipi(uint32_t dstcore, uint16_t data)
+{
+	int coreid; /* Core ID. */
+	coreid = or1k_core_get_id();
+
+	/* Send IPI. */
+	or1k_ompic_writereg(OR1K_OMPIC_CTRL(coreid), OR1K_OMPIC_CTRL_IRQ_GEN |
+		OR1K_OMPIC_CTRL_DST(dstcore)| OR1K_OMPIC_DATA(data));
+}
+
+/*
+ * @brief Handles to Inter-processor Interrupt here.
+ *
+ * @param num Dummy argument.
+ */
+PRIVATE void or1k_ompic_handle_ipi(int num)
+{
+	int coreid; /* Core ID. */
+
+	UNUSED(num);
+
+	/* Current core. */
+	coreid = or1k_core_get_id();
+
+	/* ACK IPI. */
+	or1k_ompic_writereg(OR1K_OMPIC_CTRL(coreid), OR1K_OMPIC_CTRL_IRQ_ACK);
+}
+
+/*
+ * @brief Setup the OMPIC.
+ */
+PUBLIC void or1k_ompic_init(void)
+{
+	/* IPI handler. */
+	interrupt_register(OR1K_INT_OMPIC, or1k_ompic_handle_ipi);
+}

--- a/src/hal/arch/cluster/optimsoc-cluster/ompic.c
+++ b/src/hal/arch/cluster/optimsoc-cluster/ompic.c
@@ -23,7 +23,7 @@
  */
 
 #include <nanvix/hal/core/interrupt.h>
-#include <arch/cluster/or1k-cluster/memory.h>
+#include <arch/cluster/optimsoc-cluster/memory.h>
 #include <nanvix/const.h>
 #include <stdint.h>
 
@@ -61,8 +61,8 @@ PUBLIC void or1k_ompic_send_ipi(uint32_t dstcore, uint16_t data)
 	coreid = or1k_core_get_id();
 
 	/* Send IPI. */
-	or1k_ompic_writereg(OR1K_OMPIC_CTRL(coreid), OR1K_OMPIC_CTRL_IRQ_GEN |
-		OR1K_OMPIC_CTRL_DST(dstcore)| OR1K_OMPIC_DATA(data));
+	or1k_ompic_writereg(OPTIMSOC_OMPIC_CTRL(coreid), OPTIMSOC_OMPIC_CTRL_IRQ_GEN |
+		OPTIMSOC_OMPIC_CTRL_DST(dstcore)| OPTIMSOC_OMPIC_DATA(data));
 }
 
 /*
@@ -80,7 +80,7 @@ PRIVATE void or1k_ompic_handle_ipi(int num)
 	coreid = or1k_core_get_id();
 
 	/* ACK IPI. */
-	or1k_ompic_writereg(OR1K_OMPIC_CTRL(coreid), OR1K_OMPIC_CTRL_IRQ_ACK);
+	or1k_ompic_writereg(OPTIMSOC_OMPIC_CTRL(coreid), OPTIMSOC_OMPIC_CTRL_IRQ_ACK);
 }
 
 /*

--- a/src/hal/arch/cluster/or1k-cluster/boot_code.S
+++ b/src/hal/arch/cluster/or1k-cluster/boot_code.S
@@ -22,23 +22,6 @@
  * SOFTWARE.
  */
 
-/*
- * OpenRISC head.S
- *
- * Linux architectural port borrowing liberally from similar works of
- * others.  All original copyrights apply as per the original source
- * declaration.
- *
- * Modifications for the OpenRISC architecture:
- * Copyright (C) 2003 Matjaz Breskvar <phoenix@bsemi.com>
- * Copyright (C) 2010-2011 Jonas Bonn <jonas@southpole.se>
- *
- *      This program is free software; you can redistribute it and/or
- *      modify it under the terms of the GNU General Public License
- *      as published by the Free Software Foundation; either version
- *      2 of the License, or (at your option) any later version.
- */
-
 /* Must come first. */
 #define _ASM_FILE_
 #define __NEED_OR1K_REGS

--- a/src/hal/arch/core/or1k/tlb.c
+++ b/src/hal/arch/core/or1k/tlb.c
@@ -22,8 +22,7 @@
  * SOFTWARE.
  */
 
-#include <arch/cluster/or1k-cluster/cores.h>
-#include <arch/cluster/or1k-cluster/memory.h>
+#include <nanvix/hal/hal.h>
 #include <nanvix/const.h>
 
 /**
@@ -370,12 +369,10 @@ PUBLIC int or1k_tlb_write(int tlb_type, vaddr_t vaddr, paddr_t paddr)
  */
 PUBLIC int or1k_tlb_inval(int tlb_type, vaddr_t vaddr)
 {
-	struct tlbe_value tlbev; /* TLB Entry value. */
-	int idx;                 /* TLB Index.       */
-	int coreid;              /* Core ID.         */
+	int idx;     /* TLB Index.       */
+	int coreid;  /* Core ID.         */
 
 	idx = (vaddr >> PAGE_SHIFT) & (OR1K_TLB_LENGTH - 1);
-	tlbev.u.value = 0;
 	coreid = or1k_core_get_id();
 
 	/*
@@ -384,14 +381,14 @@ PUBLIC int or1k_tlb_inval(int tlb_type, vaddr_t vaddr)
 	 */
 	if (tlb_type == OR1K_TLB_INSTRUCTION)
 	{
-		kmemcpy(&tlb[coreid].itlb[idx], &tlbev.u.tlbe, OR1K_TLBE_SIZE);
+		kmemset(&tlb[coreid].itlb[idx], 0, OR1K_TLBE_SIZE);
 		or1k_mtspr(OR1K_SPR_ITLBMR_BASE(0) | idx, 0);
 	}
 
 	/* Data. */
 	else
 	{
-		kmemcpy(&tlb[coreid].dtlb[idx], &tlbev.u.tlbe, OR1K_TLBE_SIZE);
+		kmemset(&tlb[coreid].dtlb[idx], 0, OR1K_TLBE_SIZE);
 		or1k_mtspr(OR1K_SPR_DTLBMR_BASE(0) | idx, 0);
 	}
 


### PR DESCRIPTION
Description
---------------
Although the OpTiMSoC and qemu-openrisc shares a great amount of things, it's important to keep separate each cluster for a couple of reasons, like memory map, devices and so on. Keeping things apart also gives us greater freedom to make individual modifications to each cluster without changing the other. Although there are repeated files, they constitute the smallest part of the system, since the main part is defined in the core, not in the cluster.

Therefore, this PR creates a cluster for the OpTiMSoC target, in order to make things more organized and simple.

Related Issues
--------------------
- [[optimsoc-cluster] Memory Interface](https://github.com/nanvix/hal/issues/286)