### PR TITLE
[k1b] Bugfix: TLB initializer

### DIFF
--- a/include/arch/core/k1b/tlb.h
+++ b/include/arch/core/k1b/tlb.h
@@ -125,17 +125,17 @@
 	 * @brief Static initializer for a TLB entry.
 	 *
 	 */
-	#define K1B_TLBE_INITIALIZER(pn,s,g,asn,fn,ae,pa,cp,es) \
-	(                              \
-		(((es)  & 0x3ULL)    <<  0) | \
-		(((cp)  & 0x3ULL)    <<  2) | \
-		(((pa)  & 0xfULL)    <<  4) | \
-		(((ae)  & 0xfULL)    <<  8) | \
-		(((fn)  & 0xffffULL) << 12) | \
-		(((asn) & 0x1ffULL)  << 32) | \
-		(((g)   & 0x1ULL)    << 42) | \
-		(((s)   & 0x1ULL)    << 43) | \
-		(((pn)  & 0xffffULL) << 44)   \
+	#define K1B_TLBE_INITIALIZER(pn, s, g, ans, fn, ae, pa, cp, es) \
+	(                                  \
+		(((es)  & 0x3ULL)     <<  0) | \
+		(((cp)  & 0x3ULL)     <<  2) | \
+		(((pa)  & 0xfULL)     <<  4) | \
+		(((ae)  & 0xfULL)     <<  8) | \
+		(((fn)  & 0xfffffULL) << 12) | \
+		(((ans) & 0x1ffULL)   << 32) | \
+		(((g)   & 0x1ULL)     << 42) | \
+		(((s)   & 0x1ULL)     << 43) | \
+		(((pn)  & 0xfffffULL) << 44)   \
 	)
 
 #ifndef _ASM_FILE_


### PR DESCRIPTION
In this PR, I repair some field masks of TLB initialization macro
where previously they were being done with one less byte compared to
the actual size of the field causing a loss of information.