### PR TITLE
[or1k] Using the Frequency Supplied to Initialize Clock

### DIFF
--- a/include/arch/cluster/optimsoc-cluster/clock.h
+++ b/include/arch/cluster/optimsoc-cluster/clock.h
@@ -49,6 +49,11 @@
  */
 
 	/**
+	 * @brief Estimated CPU frequency (in Hz), 50Mhz.
+	 */
+	#define OR1K_CPU_FREQUENCY 50000000
+
+	/**
 	 * @name Exported Functions
 	 */
 	/**@{*/
@@ -78,4 +83,4 @@
 
 /**@endcond*/
 
-#endif /* ARCH_CLUSTER_OR1K_CLUSTER_CLOCK */
+#endif /* ARCH_CLUSTER_OPTIMSOC_CLUSTER_CLOCK */

--- a/include/arch/cluster/or1k-cluster/clock.h
+++ b/include/arch/cluster/or1k-cluster/clock.h
@@ -47,6 +47,11 @@
  */
 
 	/**
+	 * @brief Estimated CPU frequency (in Hz), 20Mhz.
+	 */
+	#define OR1K_CPU_FREQUENCY 20000000
+
+	/**
 	 * @name Exported Functions
 	 */
 	/**@{*/

--- a/include/arch/core/mor1kx/clock.h
+++ b/include/arch/core/mor1kx/clock.h
@@ -35,11 +35,6 @@
 
 	#include <nanvix/const.h>
 
-	/**
-	 * @brief Estimated CPU frequency (in Hz), 50Mhz/30Hz.
-	 */
-	#define OR1K_CPU_FREQUENCY 1666666
-
 #ifndef _ASM_FILE_
 
 	/**

--- a/include/arch/core/or1k/clock.h
+++ b/include/arch/core/or1k/clock.h
@@ -35,13 +35,6 @@
 
 	#include <nanvix/const.h>
 
-	/**
-	 * @brief Estimated CPU frequency (in Hz), 20Mhz/30Hz.
-	 *
-	 * @todo TODO move this to Cluster AL.
-	 */
-	#define OR1K_CPU_FREQUENCY 666666
-
 #ifndef _ASM_FILE_
 
 	/**

--- a/src/hal/arch/core/or1k/clock.c
+++ b/src/hal/arch/core/or1k/clock.c
@@ -22,8 +22,7 @@
  * SOFTWARE.
  */
 
-#include <arch/core/or1k/core.h>
-#include <arch/core/or1k/clock.h>
+#include <nanvix/hal/hal.h>
 #include <nanvix/const.h>
 #include <nanvix/klib.h>
 
@@ -89,8 +88,6 @@ PUBLIC void or1k_clock_init(unsigned freq)
 {
 	unsigned upr;  /* Unit Present Register. */
 
-	UNUSED(freq);
-
 	/* Nothing to do. */
 	if (initialized)
 		return;
@@ -101,7 +98,7 @@ PUBLIC void or1k_clock_init(unsigned freq)
 		while (1);
 
 	/* Clock rate. */
-	clock_delta = OR1K_CPU_FREQUENCY;
+	clock_delta = (OR1K_CPU_FREQUENCY/freq);
 
 	/*
 	 * Clock calibrate.


### PR DESCRIPTION
Description
---------------
This PR fixes the issue #345 by using the frequency supplied to the `clock_init` and `or1k_clock_init` functions.

Related Issues
-------------------
[[or1k] Clock Interface Ignores Supplied Frequency](https://github.com/nanvix/hal/issues/345)