### PR TITLE
[k1b-core] Trashing Context in Exception

### DIFF
--- a/include/arch/core/k1b/asm.h
+++ b/include/arch/core/k1b/asm.h
@@ -75,14 +75,9 @@
  *============================================================================*/
 
 	/**
-	 * @brief Size of a stack frame (in bytes).
-	 */
-	#define FAST_CALL_STACK_FRAME_SIZE 16
-
-	/**
 	 * @brief Stack frame size for slow call.
 	 */
-	#define SLOW_CALL_STACK_FRAME_SIZE 80
+	#define CALL_STACK_FRAME_SIZE 80
 
 	/**
 	* @brief Offsets to Stack Frame
@@ -103,86 +98,14 @@
 	/**@}*/
 
 	/*
-	 * @brief Enters a procedure.
-	 *
-	 * The _do_prologue() macro allocates a new stack frame for the
-	 * caller procedure and saves the BP and RA registers in it.
-	 *
-	 * @note Preserved registers are intentionally not saved to reduce
-	 * overhead.
-	 */
-	.macro _do_prologue
-
-		/* Allocate a stack frame. */
-		add $sp, $sp, -FAST_CALL_STACK_FRAME_SIZE
-		;;
-
-		/* Save r0 + r1 registers. */
-		sd 8[$sp], $p0
-		;;
-
-		/*
-		 * Save RA + BP registers.
-		 * Note that temporarily we use
-		 * BP as a scratch register.
-		 */
-		sw STACK_FRAME_BP[$sp], $bp
-		;;
-		get $bp, $ra
-		;;
-		sw STACK_FRAME_RA[$sp], $bp
-		;;
-
-		/* Change stack frame. */
-		copy $bp, $sp
-		;;
-
-	.endm
-
-	/*
-	 * @brief Exits a procedure.
-	 *
-	 * The _do_epilogue() macro restores previous values of the BP and
-	 * RA registers and wipes out the current stack frame of the
-	 * caller procedure.
-	 */
-	.macro _do_epilogue
-
-		/* Restore stack frame. */
-		copy $sp, $bp
-		;;
-
-		/*
-		 * Restore BP + RA registers.
-		 * Note  that temporarily we use
-		 * BP as a scratch register.
-		 */
-		lw  $bp, STACK_FRAME_RA[$sp]
-		;;
-		set $ra, $bp
-		;;
-		lw  $bp, STACK_FRAME_BP[$sp]
-		;;
-
-		/* Restore r0 + r1 registers. */
-		ld $p0, 8[$sp]
-		;;
-
-		/* Wipe out stack frame. */
-		add $sp, $sp, FAST_CALL_STACK_FRAME_SIZE
-		;;
-
-	.endm
-
-	/*
 	 * @brief Saves preserved registers.
 	 *
 	 * @param s0 Scratch register to use.
 	 */
-	.macro _do_prologue_slow
+	.macro _do_prologue
 
 		/* Allocate stack frame. */
-		add $sp, $sp, -SLOW_CALL_STACK_FRAME_SIZE
+		add $sp, $sp, -CALL_STACK_FRAME_SIZE
 		;;
 
 		/* Save registers preserved registers. */
@@ -230,7 +153,7 @@
 	 *
 	 * @param s0 Scratch register to use.
 	 */
-	.macro _do_epilogue_slow
+	.macro _do_epilogue
 
 		/* Restore stack frame. */
 		copy $sp, $bp
@@ -271,7 +194,7 @@
 		;;
 
 		/* Wipe out stack frame. */
-		add $sp, $sp, SLOW_CALL_STACK_FRAME_SIZE
+		add $sp, $sp, CALL_STACK_FRAME_SIZE
 		;;
 
 	.endm

--- a/src/hal/arch/core/k1b/hooks.S
+++ b/src/hal/arch/core/k1b/hooks.S
@@ -99,7 +99,7 @@ _k1b_do_syscall:
 	_do_syscall.continue:
 
 		/* Save preserved registers. */
-		_do_prologue_slow
+		_do_prologue
 		;;
 
 		/* mOS supports trap calls with 8 arguments, and thus the trap
@@ -122,7 +122,7 @@ _k1b_do_syscall:
 		;;
 
 		/* Restore preserved registers. */
-		_do_epilogue_slow
+		_do_epilogue
 		;;
 
 	_do_syscall.out:
@@ -141,9 +141,6 @@ _k1b_do_syscall:
  */
 .align 8
 _k1b_do_excp:
-
-	_do_prologue
-	;;
 
 	/*
 	 * Save execution context
@@ -264,9 +261,6 @@ _k1b_do_excp:
 	 * Restore saved execution context.
 	 */
 	k1b_context_restore
-	;;
-
-	_do_epilogue
 	;;
 
 	/* Restore exception context. */

--- a/src/hal/arch/core/k1b/hooks.S
+++ b/src/hal/arch/core/k1b/hooks.S
@@ -151,16 +151,6 @@ _k1b_do_excp:
 	 */
 	k1b_context_save
 	;;
-	ld  $p0 = 8[$bp]            /* r0 + r1 */
-	;;
-	sd  K1B_CONTEXT_R0[$sp], $p0
-	;;
-	ld  $p2 = 0[$bp]            /* ra + bp */
-	;;
-	sw  K1B_CONTEXT_RA[$sp], $r2
-	;;
-	sw  K1B_CONTEXT_R13[$sp], $r3
-	;;
 
 	/*
 	 * Save a reference to execution context

--- a/src/test/core/arch/k1b.S
+++ b/src/test/core/arch/k1b.S
@@ -38,8 +38,8 @@
  */
 .align 8
 _upcall_issue:
-	_do_prologue_slow      # Save all preserved registers since
-	;;                     # they may be used by the HAL.
+	_do_prologue      # Save all preserved registers since
+	;;                # they may be used by the HAL.
 
 	make $r1, saved_sp
 	;;
@@ -64,8 +64,8 @@ _upcall_issue_ret:
 	lw  $bp, 0[$r1]
 	;;
 
-	_do_epilogue_slow     # Restore all preserved
-	;;                    # registers.
+	_do_epilogue     # Restore all preserved
+	;;               # registers.
 
 	ret
 	;;


### PR DESCRIPTION
Description
----------------

Previously, we were trashing the context when handling an exception by saving bad values of r0 and r1 in the context structure, even though they were already correctly saved. In this commit, I fix this bug.