### PR TITLE
[hal] Enhancement: Independent TLB implemention

### DIFF
--- a/include/arch/cluster/k1b-cluster/memory.h
+++ b/include/arch/cluster/k1b-cluster/memory.h
@@ -146,7 +146,7 @@
 		#define K1B_CLUSTER_HYPER_HIGH_BASE_VIRT 0x001f8000       /**< High Hypervisor Base */
 		#define K1B_CLUSTER_HYPER_HIGH_END_VIRT  0x00200000       /**< High Hypervisor End  */
 	#endif
-	#define K1B_CLUSTER_USTACK_BASE_VIRT K1B_CLUSTER_HYPER_HIGH_BASE_VIRT /**< User Stack */
+	#define K1B_CLUSTER_USTACK_BASE_VIRT K1B_CLUSTER_HYPER_HIGH_BASE_VIRT /**< User Stack   */
 #ifndef _ASM_FILE_
 	EXTERN const vaddr_t K1B_CLUSTER_KERNEL_BASE_VIRT;            /**< Kernel Base          */
 	EXTERN const vaddr_t K1B_CLUSTER_KERNEL_END_VIRT;             /**< Kernel End           */
@@ -172,64 +172,45 @@
 #endif /* __NANVIX_HAL */
 
 	/**
-	 * @brief Writes a TLB entry.
-	 *
-	 * @param vaddr      Target virtual address.
-	 * @param paddr      Target physical address.
-	 * @param shift      Page shift.
-	 * @param way        Target set-associative way.
-	 * @param protection Protection attributes.
+	 * @brief TLB lookup address mask.
 	 */
-	EXTERN int k1b_tlb_write(
-			vaddr_t vaddr,
-			paddr_t paddr,
-			unsigned shift,
-			unsigned way,
-			unsigned protection
-	);
+	#define K1B_TLB_VADDR_MASK (~0)
 
 	/**
-	 * @brief Invalidates a TLB entry.
+	 * @brief Gets the underlying TLB entries.
 	 *
-	 * @param vaddr Target virtual address.
-	 * @param shift Page shift.
-	 * @param way   Target set-associative way.
+	 * The k1b_cluster_tlb_get_utlb() function returns the architectural
+	 * TLB entries.
+	 *
+	 * @returns Initial position of the specific underlying tlb entries.
 	 */
-	EXTERN int k1b_tlb_inval(vaddr_t vaddr, unsigned shift, unsigned way);
+	EXTERN struct tlbe *k1b_cluster_tlb_get_utlb();
 
 	/**
-	 * @brief Lookups a TLB entry by virtual address.
+	 * @brief Gets the configuration of a TLB Entry.
 	 *
 	 * @param vaddr Target virtual address.
 	 *
-	 * @returns Upon successful completion, a pointer to the TLB entry
-	 * that matches the virtual address @p vaddr is returned. If no
-	 * entry that meets this criteria is found, @p NULL is returned.
+	 * @return K1B TLB entry does not need configuration.
 	 */
-	EXTERN const struct tlbe *k1b_tlb_lookup_vaddr(vaddr_t vaddr);
+	static inline int k1b_cluster_tlb_get_vaddr_info(vaddr_t vaddr)
+	{
+		UNUSED(vaddr);
 
-	/**
-	 * @brief Lookups a TLB entry by physical address.
-	 *
-	 * @param paddr Target physical address.
-	 *
-	 * @returns Upon successful completion, a pointer to the TLB entry
-	 * that matches the physical address @p paddr is returned. If no
-	 * entry that meets this criteria is found, @p NULL is returned.
-	 */
-	EXTERN const struct tlbe *k1b_tlb_lookup_paddr(paddr_t paddr);
+		return (0);
+	}
 
 	/**
 	 * @brief Flushes the TLB.
 	 */
-	EXTERN int k1b_tlb_flush(void);
+	EXTERN int k1b_cluster_tlb_flush(void);
 
 	/**
 	 * @brief Dumps a TLB entry.
 	 *
 	 * @param idx Index of target entry in the TLB.
 	 */
-	EXTERN void k1b_tlbe_dump(int idx);
+	EXTERN void k1b_cluster_tlbe_dump(int idx);
 
 #endif /* _ASM_FILE_ */
 
@@ -240,24 +221,25 @@
  *============================================================================*/
 
 /**
- * @cond k1b_cluster
+ * @cond k1b_cluster_cluster
  */
 
 	/**
 	 * @name Exported Constants
 	 */
-	#define MEMORY_SIZE  K1B_CLUSTER_MEM_SIZE         /**< @see K1B_CLUSTER_MEM_SIZE          */
-	#define KMEM_SIZE    K1B_CLUSTER_KMEM_SIZE        /**< @see K1B_CLUSTER_KMEM_SIZE         */
-	#define UMEM_SIZE    K1B_CLUSTER_UMEM_SIZE        /**< @see K1B_CLUSTER_UMEM_SIZE         */
-	#define KSTACK_SIZE  K1B_CLUSTER_KSTACK_SIZE      /**< @see K1B_CLUSTER_KSTACK_SIZE       */
-	#define KPOOL_SIZE   K1B_CLUSTER_KPOOL_SIZE       /**< @see K1B_CLUSTER_KPOOL_SIZE        */
-	#define KBASE_PHYS   K1B_CLUSTER_KERNEL_BASE_PHYS /**< @see K1B_CLUSTER_KERNEL_BASE_PHYS  */
-	#define KPOOL_PHYS   K1B_CLUSTER_KPOOL_BASE_PHYS  /**< @see K1B_CLUSTER_KPOOL_BASE_PHYS   */
-	#define UBASE_PHYS   K1B_CLUSTER_USER_BASE_PHYS   /**< @see K1B_CLUSTER_USER_BASE_PHYS    */
-	#define USTACK_VIRT  K1B_CLUSTER_USTACK_BASE_VIRT /**< @see K1B_CLUSTER_USTACK_BASE_VIRT  */
-	#define UBASE_VIRT   K1B_CLUSTER_USER_BASE_VIRT   /**< @see K1B_CLUSTER_USER_BASE_VIRT    */
-	#define KBASE_VIRT   K1B_CLUSTER_KERNEL_BASE_VIRT /**< @see K1B_CLUSTER_KERNEL_BASE_VIRT  */
-	#define KPOOL_VIRT   K1B_CLUSTER_KPOOL_BASE_VIRT  /**< @see K1B_CLUSTER_KPOOL_BASE_VIRT   */
+	#define MEMORY_SIZE    K1B_CLUSTER_MEM_SIZE         /**< @see K1B_CLUSTER_MEM_SIZE          */
+	#define KMEM_SIZE      K1B_CLUSTER_KMEM_SIZE        /**< @see K1B_CLUSTER_KMEM_SIZE         */
+	#define UMEM_SIZE      K1B_CLUSTER_UMEM_SIZE        /**< @see K1B_CLUSTER_UMEM_SIZE         */
+	#define KSTACK_SIZE    K1B_CLUSTER_KSTACK_SIZE      /**< @see K1B_CLUSTER_KSTACK_SIZE       */
+	#define KPOOL_SIZE     K1B_CLUSTER_KPOOL_SIZE       /**< @see K1B_CLUSTER_KPOOL_SIZE        */
+	#define KBASE_PHYS     K1B_CLUSTER_KERNEL_BASE_PHYS /**< @see K1B_CLUSTER_KERNEL_BASE_PHYS  */
+	#define KPOOL_PHYS     K1B_CLUSTER_KPOOL_BASE_PHYS  /**< @see K1B_CLUSTER_KPOOL_BASE_PHYS   */
+	#define UBASE_PHYS     K1B_CLUSTER_USER_BASE_PHYS   /**< @see K1B_CLUSTER_USER_BASE_PHYS    */
+	#define USTACK_VIRT    K1B_CLUSTER_USTACK_BASE_VIRT /**< @see K1B_CLUSTER_USTACK_BASE_VIRT  */
+	#define UBASE_VIRT     K1B_CLUSTER_USER_BASE_VIRT   /**< @see K1B_CLUSTER_USER_BASE_VIRT    */
+	#define KBASE_VIRT     K1B_CLUSTER_KERNEL_BASE_VIRT /**< @see K1B_CLUSTER_KERNEL_BASE_VIRT  */
+	#define KPOOL_VIRT     K1B_CLUSTER_KPOOL_BASE_VIRT  /**< @see K1B_CLUSTER_KPOOL_BASE_VIRT   */
+	#define TLB_VADDR_MASK K1B_TLB_VADDR_MASK           /**< @see K1B_TLB_VADDR_MASK            */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -266,67 +248,37 @@
 	 * @brief Provided Interface
 	 */
 	/**@{*/
-	#define __tlb_lookup_vaddr_fn /**< tlbe_lookup_vaddr() */
-	#define __tlb_lookup_paddr_fn /**< tlbe_lookup()       */
-	#define __tlb_write_fn        /**< tlb_write()         */
-	#define __tlb_inval_fn        /**< tlb_inval()         */
-	#define __tlb_flush_fn        /**< tlb_flush()         */
+	#define __tlb_flush_fn          /**< tlb_flush()          */
+	#define __tlb_get_vaddr_info_fn /**< tlb_get_vaddr_info() */
+	#define __tlb_get_utlb_fn       /**< tlb_get_utlb()       */
 	/**@}*/
 
 	/**
-	 * @see k1b_tlb_lookup_vaddr().
-	 */
-	static inline const struct tlbe *tlb_lookup_vaddr(int tlb_type, vaddr_t vaddr)
-	{
-		/* Invalid TLB type. */
-		if ((tlb_type != K1B_TLB_INSTRUCTION) && (tlb_type != K1B_TLB_DATA))
-			return (NULL);
-
-		return (k1b_tlb_lookup_vaddr(vaddr));
-	}
-
-	/**
-	 * @see k1b_tlb_lookup_paddr().
-	 */
-	static inline const struct tlbe *tlb_lookup_paddr(int tlb_type, paddr_t paddr)
-	{
-		/* Invalid TLB type. */
-		if ((tlb_type != K1B_TLB_INSTRUCTION) && (tlb_type != K1B_TLB_DATA))
-			return (NULL);
-
-		return (k1b_tlb_lookup_paddr(paddr));
-	}
-
-	/**
-	 * @see k1b_tlb_write()
-	 */
-	static inline int tlb_write(int tlb_type, vaddr_t vaddr, paddr_t paddr)
-	{
-		/* Invalid TLB type. */
-		if ((tlb_type != K1B_TLB_INSTRUCTION) && (tlb_type != K1B_TLB_DATA))
-			return (-EINVAL);
-
-		return (k1b_tlb_write(vaddr, paddr, 12, 0, K1B_TLBE_PROT_RW));
-	}
-
-	/**
-	 * @see k1b_tlb_inval()
-	 */
-	static inline int tlb_inval(int tlb_type, vaddr_t vaddr)
-	{
-		/* Invalid TLB type. */
-		if ((tlb_type != K1B_TLB_INSTRUCTION) && (tlb_type != K1B_TLB_DATA))
-			return (-EINVAL);
-
-		return (k1b_tlb_inval(vaddr, 12, 0));
-	}
-
-	/**
-	 * @see k1b_tlb_flush().
+	 * @see k1b_cluster_tlb_flush().
 	 */
 	static inline int tlb_flush(void)
 	{
-		return (k1b_tlb_flush());
+		return (k1b_cluster_tlb_flush());
+	}
+
+	/**
+	 * @see k1b_cluster_tlb_get_vaddr_info().
+	 */
+	static inline int tlb_get_vaddr_info(vaddr_t vaddr)
+	{
+		return (k1b_cluster_tlb_get_vaddr_info(vaddr));
+	}
+
+	/**
+	 * @see k1b_cluster_tlb_lookup_paddr().
+	 */
+	static inline struct tlbe *tlb_get_utlb(int tlb_type)
+	{
+		/* Invalid TLB type. */
+		if ((tlb_type != K1B_TLB_INSTRUCTION) && (tlb_type != K1B_TLB_DATA))
+			return (NULL);
+
+		return (k1b_cluster_tlb_get_utlb());
 	}
 
 #endif /* _ASM_FILE_ */

--- a/include/arch/cluster/or1k-cluster/memory.h
+++ b/include/arch/cluster/or1k-cluster/memory.h
@@ -132,45 +132,31 @@
 #endif /* __NANVIX_HAL */
 
 	/**
-	 * @brief Lookups a TLB entry by virtual address.
-	 *
-	 * @param tlb_type Target TLB.
-	 * @param vaddr    Target virtual address.
-	 *
-	 * @returns Upon successful completion, a pointer to the TLB entry
-	 * that matches the virtual address @p vaddr is returned. If no
-	 * entry that meets this criteria is found, @p NULL is returned.
+	 * @brief TLB lookup address mask.
 	 */
-	EXTERN const struct tlbe *or1k_cluster_tlb_lookup_vaddr(int tlb_type, vaddr_t vaddr);
+	#define OR1K_TLB_VADDR_MASK PAGE_MASK
 
 	/**
-	 * @brief Lookups a TLB entry by physical address.
+	 * @brief Gets the underlying TLB entries.
 	 *
-	 * @param tlb_type Target TLB.
-	 * @param paddr    Target physical address.
+	 * @param _tlb     The TLB of a core.
+	 * @param tlb_type Type of the underlying TLB entries that we want get.
 	 *
-	 * @returns Upon successful completion, a pointer to the TLB entry
-	 * that matches the physical address @p paddr is returned. If no
-	 * entry that meets this criteria is found, @p NULL is returned.
+	 * The or1k_cluster_tlb_get_utlb() function returns the architectural 
+	 * TLB entries of a specific TLB type.
+	 *
+	 * @returns Initial position of the specific underlying tlb entries.
 	 */
-	EXTERN const struct tlbe *or1k_cluster_tlb_lookup_paddr(int tlb_type, paddr_t paddr);
+	EXTERN struct tlbe *or1k_cluster_tlb_get_utlb(int tlb_type);
 
 	/**
-	 * @brief Writes a TLB entry.
+	 * @brief Gets the configuration of a TLB Entry.
+	 * 
+	 * @param vaddr Target virtual address.
 	 *
-	 * @param tlb_type Target TLB.
-	 * @param vaddr    Target virtual address.
-	 * @param paddr    Target physical address.
+	 * @return K1B TLB entry does not need configuration.
 	 */
-	EXTERN int or1k_cluster_tlb_write(int tlb_type, vaddr_t vaddr, paddr_t paddr);
-
-	/**
-	 * @brief Invalidates a TLB entry.
-	 *
-	 * @param tlb_type Target TLB.
-	 * @param vaddr    Target virtual address.
-	 */
-	EXTERN int or1k_cluster_tlb_inval(int tlb_type, vaddr_t vaddr);
+	EXTERN int or1k_cluster_tlb_get_vaddr_info(vaddr_t vaddr);
 
 	/**
 	 * @brief Flushes the TLB.
@@ -197,19 +183,20 @@
 	/**
 	 * @name Exported Constants
 	 */
-	#define MEMORY_SIZE  OR1K_CLUSTER_MEM_SIZE         /**< @see OR1K_CLUSTER_MEM_SIZE         */
-	#define KMEM_SIZE    OR1K_CLUSTER_KMEM_SIZE        /**< @see OR1K_CLUSTER_KMEM_SIZE        */
-	#define UMEM_SIZE    OR1K_CLUSTER_UMEM_SIZE        /**< @see OR1K_CLUSTER_UMEM_SIZE        */
-	#define KSTACK_SIZE  OR1K_CLUSTER_KSTACK_SIZE      /**< @see OR1K_CLUSTER_KSTACK_SIZE      */
-	#define KPOOL_SIZE   OR1K_CLUSTER_KPOOL_SIZE       /**< @see OR1K_CLUSTER_KPOOL_SIZE       */
-	#define KBASE_PHYS   OR1K_CLUSTER_KERNEL_BASE_PHYS /**< @see OR1K_CLUSTER_KERNEL_BASE_PHYS */
-	#define KPOOL_PHYS   OR1K_CLUSTER_KPOOL_BASE_PHYS  /**< @see OR1K_CLUSTER_KPOOL_BASE_PHYS  */
-	#define UBASE_PHYS   OR1K_CLUSTER_USER_BASE_PHYS   /**< @see OR1K_CLUSTER_USER_BASE_PHYS   */
-	#define USTACK_VIRT  OR1K_CLUSTER_USTACK_BASE_VIRT /**< @see OR1K_CLUSTER_USTACK_BASE_VIRT */
-	#define UBASE_VIRT   OR1K_CLUSTER_USER_BASE_VIRT   /**< @see OR1K_CLUSTER_USER_BASE_VIRT   */
-	#define KBASE_VIRT   OR1K_CLUSTER_KERNEL_BASE_VIRT /**< @see OR1K_CLUSTER_KERNEL_BASE_VIRT */
-	#define KPOOL_VIRT   OR1K_CLUSTER_KPOOL_BASE_VIRT  /**< @see OR1K_CLUSTER_KPOOL_BASE_VIRT  */
-	#define _UART_ADDR   OR1K_CLUSTER_UART_BASE_PHYS   /**< @see OR1K_CLUSTER_UART_BASE_PHYS   */
+	#define MEMORY_SIZE    OR1K_CLUSTER_MEM_SIZE         /**< @see OR1K_CLUSTER_MEM_SIZE         */
+	#define KMEM_SIZE      OR1K_CLUSTER_KMEM_SIZE        /**< @see OR1K_CLUSTER_KMEM_SIZE        */
+	#define UMEM_SIZE      OR1K_CLUSTER_UMEM_SIZE        /**< @see OR1K_CLUSTER_UMEM_SIZE        */
+	#define KSTACK_SIZE    OR1K_CLUSTER_KSTACK_SIZE      /**< @see OR1K_CLUSTER_KSTACK_SIZE      */
+	#define KPOOL_SIZE     OR1K_CLUSTER_KPOOL_SIZE       /**< @see OR1K_CLUSTER_KPOOL_SIZE       */
+	#define KBASE_PHYS     OR1K_CLUSTER_KERNEL_BASE_PHYS /**< @see OR1K_CLUSTER_KERNEL_BASE_PHYS */
+	#define KPOOL_PHYS     OR1K_CLUSTER_KPOOL_BASE_PHYS  /**< @see OR1K_CLUSTER_KPOOL_BASE_PHYS  */
+	#define UBASE_PHYS     OR1K_CLUSTER_USER_BASE_PHYS   /**< @see OR1K_CLUSTER_USER_BASE_PHYS   */
+	#define USTACK_VIRT    OR1K_CLUSTER_USTACK_BASE_VIRT /**< @see OR1K_CLUSTER_USTACK_BASE_VIRT */
+	#define UBASE_VIRT     OR1K_CLUSTER_USER_BASE_VIRT   /**< @see OR1K_CLUSTER_USER_BASE_VIRT   */
+	#define KBASE_VIRT     OR1K_CLUSTER_KERNEL_BASE_VIRT /**< @see OR1K_CLUSTER_KERNEL_BASE_VIRT */
+	#define KPOOL_VIRT     OR1K_CLUSTER_KPOOL_BASE_VIRT  /**< @see OR1K_CLUSTER_KPOOL_BASE_VIRT  */
+	#define _UART_ADDR     OR1K_CLUSTER_UART_BASE_PHYS   /**< @see OR1K_CLUSTER_UART_BASE_PHYS   */
+	#define TLB_VADDR_MASK OR1K_TLB_VADDR_MASK           /**< @see OR1K_TLB_VADDR_MASK           */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -218,60 +205,10 @@
 	 * @name Provided Interface
 	 */
 	/**@{*/
-	#define __tlb_lookup_vaddr_fn /**< tlbe_lookup_vaddr() */
-	#define __tlb_lookup_paddr_fn /**< tlbe_lookup()       */
-	#define __tlb_write_fn        /**< tlb_write()         */
-	#define __tlb_inval_fn        /**< tlb_inval()         */
-	#define __tlb_flush_fn        /**< tlb_flush()         */
+	#define __tlb_flush_fn          /**< tlb_flush()          */
+	#define __tlb_get_vaddr_info_fn /**< tlb_get_vaddr_info() */
+	#define __tlb_get_utlb_fn       /**< tlb_get_utlb()       */
 	/**@}*/
-
-	/**
-	 * @see or1k_cluster_tlb_lookup_vaddr().
-	 */
-	static inline const struct tlbe *tlb_lookup_vaddr(int tlb_type, vaddr_t vaddr)
-	{
-		/* Invalid TLB type. */
-		if ((tlb_type != OR1K_TLB_INSTRUCTION) && (tlb_type != OR1K_TLB_DATA))
-			return (NULL);
-
-		return (or1k_cluster_tlb_lookup_vaddr(tlb_type, vaddr));
-	}
-
-	/**
-	 * @see or1k_cluster_tlb_lookup_paddr().
-	 */
-	static inline const struct tlbe *tlb_lookup_paddr(int tlb_type, paddr_t paddr)
-	{
-		/* Invalid TLB type. */
-		if ((tlb_type != OR1K_TLB_INSTRUCTION) && (tlb_type != OR1K_TLB_DATA))
-			return (NULL);
-
-		return (or1k_cluster_tlb_lookup_paddr(tlb_type, paddr));
-	}
-
-	/**
-	 * @see or1k_cluster_tlb_write()
-	 */
-	static inline int tlb_write(int tlb_type, vaddr_t vaddr, paddr_t paddr)
-	{
-		/* Invalid TLB type. */
-		if ((tlb_type != OR1K_TLB_INSTRUCTION) && (tlb_type != OR1K_TLB_DATA))
-			return (-EINVAL);
-
-		return (or1k_cluster_tlb_write(tlb_type, vaddr, paddr));
-	}
-
-	/**
-	 * @see or1k_cluster_tlb_inval()
-	 */
-	static inline int tlb_inval(int tlb_type, vaddr_t vaddr)
-	{
-		/* Invalid TLB type. */
-		if ((tlb_type != OR1K_TLB_INSTRUCTION) && (tlb_type != OR1K_TLB_DATA))
-			return (-EINVAL);
-
-		return (or1k_cluster_tlb_inval(tlb_type, vaddr));
-	}
 
 	/**
 	 * @see or1k_cluster_tlb_flush().
@@ -279,6 +216,26 @@
 	static inline int tlb_flush(void)
 	{
 		return (or1k_cluster_tlb_flush());
+	}
+
+	/**
+	 * @see or1k_cluster_tlb_get_vaddr_info().
+	 */
+	static inline int tlb_get_vaddr_info(vaddr_t vaddr)
+	{
+		return (or1k_cluster_tlb_get_vaddr_info(vaddr));
+	}
+
+	/**
+	 * @see or1k_cluster_tlb_get_utlb().
+	 */
+	static inline struct tlbe *tlb_get_utlb(int tlb_type)
+	{
+		/* Invalid TLB type. */
+		if ((tlb_type != OR1K_TLB_INSTRUCTION) && (tlb_type != OR1K_TLB_DATA))
+			return (NULL);
+
+		return (or1k_cluster_tlb_get_utlb(tlb_type));
 	}
 
 #endif /* _ASM_FILE_ */

--- a/include/nanvix/hal/cluster/memory.h
+++ b/include/nanvix/hal/cluster/memory.h
@@ -74,6 +74,14 @@
 	 */
 	#if (!CORE_HAS_TLB_HW)
 
+		/* Constants. */
+		#ifndef TLB_VADDR_MASK
+			#error "TLB_VADDR_MASK not defined?"
+		#endif
+		#ifndef LOOKUP_TLB_LENGTH
+			#error "LOOKUP_TLB_LENGTH not defined?"
+		#endif
+
 		/*
 		* Required interface for software- and hardware-managed TLBs.
 		*/
@@ -82,17 +90,11 @@
 		#endif
 
 		/* Functions */
-		#ifndef __tlb_lookup_vaddr_fn
-			#error "tlb_lookup_vaddr() not defined?"
+		#ifndef __tlb_get_utlb_fn
+			#error "tlb_get_utlb() not defined?"
 		#endif
-		#ifndef __tlb_lookup_paddr_fn
-			#error "tlb_lookup_paddr() not defined?"
-		#endif
-		#ifndef __tlb_write_fn
-			#error "tlb_write() not defined?"
-		#endif
-		#ifndef __tlb_inval_fn
-			#error "tlb_inval() not defined?"
+		#ifndef __tlb_get_vaddr_info_fn
+			#error "tlb_get_vaddr_info() not defined?"
 		#endif
 
 	#endif

--- a/include/nanvix/hal/core/tlb.h
+++ b/include/nanvix/hal/core/tlb.h
@@ -59,6 +59,18 @@
 		#ifndef __tlbe_paddr_get_fn
 			#error "tlb_paddr_get() not defined?"
 		#endif
+		#ifndef __tlbe_get_index_fn
+			#error "tlbe_get_index() not defined?"
+		#endif
+		#ifndef __tlbe_is_valid_fn
+			#error "tlbe_is_valid() not defined?"
+		#endif
+		#ifndef __tlbe_write_fn
+			#error "tlb_write() not defined?"
+		#endif
+		#ifndef __tlbe_inval_fn
+			#error "tlb_inval() not defined?"
+		#endif
 
 	#endif
 
@@ -130,6 +142,59 @@
 	 * to by @p tlbe.
 	 */
 	EXTERN paddr_t tlbe_paddr_get(const struct tlbe *tlbe);
+
+	/**
+	 * @brief Assesses if a TLB entry is valid
+	 *
+	 * @param tlbe Target TLB entry.
+	 *
+	 * The tlbe_is_valid() function assess if a TLB entry
+	 * has the status bit valid.
+	 *
+	 * @return Non zero if is the TLB entry is valid, zero otherwise.
+	 */
+	EXTERN int tlbe_is_valid(const struct tlbe *tlbe);
+
+	/**
+	 * @brief Gets the tlbe entry index in TLB.
+	 * 
+	 * @param vaddr Target virtual address.
+	 *
+	 * @return Index of target entry in the TLB.
+	 */
+	EXTERN unsigned tlbe_get_index(vaddr_t vaddr);
+
+	/**
+	 * @brief Writes a TLB entry.
+	 *
+	 * @param tlbe       The updated value of target TLB entry.
+	 * @param tlb_type   Target TLB.
+	 * @param vaddr      Target virtual address.
+	 * @param paddr      Target physical address.
+	 * @param vaddr_info Virtual address information flags.
+	 * 
+	 * @return Zero if successfully writes a TLB entry,
+	 * non zero otherwise.
+	 */
+	EXTERN int tlbe_write(
+		struct tlbe *tlbe,
+		int tlb_type,
+		vaddr_t vaddr,
+		paddr_t paddr,
+		int vadd_info
+	);
+
+	/**
+	 * @brief Invalidates a TLB entry.
+	 *
+	 * @param tlbe  The updated value of target TLB entry.
+	 * @param tlb_type Target TLB.
+	 * @param vaddr Target virtual address.
+	 * 
+	 * @return Zero if successfully writes a TLB entry,
+	 * non zero otherwise.
+	 */
+	EXTERN int tlbe_inval(struct tlbe *tlbe, int tlb_type, vaddr_t vaddr);
 
 #endif /* __NANVIX_HAL */
 

--- a/src/hal/cluster/memory.c
+++ b/src/hal/cluster/memory.c
@@ -1,0 +1,179 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* Must come first. */
+#define __NEED_HAL_CLUSTER
+
+#include <nanvix/hal/cluster.h>
+#include <nanvix/const.h>
+#include <nanvix/klib.h>
+
+#if (!CORE_HAS_TLB_HW)
+
+/*============================================================================*
+ * tlb_lookup_vaddr()                                                         *
+ *============================================================================*/
+
+/**
+ * The tlb_lookup_vaddr() function searches the architectural TLB
+ * for an entry that matches the virtual address @p vaddr.
+ * type should be used.
+ *
+ * @author Davidson Francis
+ */
+PUBLIC const struct tlbe *tlb_lookup_vaddr(int tlb_type, vaddr_t vaddr)
+{
+	vaddr_t addr;            /* Aligned address.   */
+	struct tlbe *utlb;       /* Underlying TLB.    */
+	const struct tlbe *tlbe; /* TLB Entry Pointer. */
+
+	/* Invalid TLB type. */
+	if ((tlb_type != TLB_INSTRUCTION) && (tlb_type != TLB_DATA))
+		return (NULL);
+
+	addr   = vaddr & TLB_VADDR_MASK;
+	utlb   = tlb_get_utlb(tlb_type);
+
+	for (int i = 0; i < LOOKUP_TLB_LENGTH; i++)
+	{
+		tlbe = &utlb[i];
+
+		/* Found */
+		if (tlbe_vaddr_get(tlbe) == addr)
+		{
+			if (tlbe_is_valid(tlbe))
+				return (tlbe);
+		}
+	}
+
+	return (NULL);
+}
+
+/*============================================================================*
+ * tlb_lookup_paddr()                                                         *
+ *============================================================================*/
+
+/**
+ * The or1k_tlb_lookup_paddr() function searches the architectural TLB
+ * for an entry that matches the physical address @p paddr.
+ *
+ * @returns Upon successful completion, the matching TLB
+ * entry for the address @p vaddr is returned. If none
+ * is found, @p NULL is returned.
+ *
+ * @author Davidson Francis
+ */
+PUBLIC const struct tlbe *tlb_lookup_paddr(int tlb_type, paddr_t paddr)
+{
+	paddr_t addr;            /* Aligned address.   */
+	struct tlbe *utlb;       /* Underlying TLB.    */
+	const struct tlbe *tlbe; /* TLB Entry Pointer. */
+
+	/* Invalid TLB type. */
+	if ((tlb_type != TLB_INSTRUCTION) && (tlb_type != TLB_DATA))
+		return (NULL);
+
+	addr   = paddr & TLB_VADDR_MASK;
+	utlb   = tlb_get_utlb(tlb_type);
+
+	for (int i = 0; i < LOOKUP_TLB_LENGTH; i++)
+	{
+		tlbe = &utlb[i];
+
+		/* Found */
+		if (tlbe_paddr_get(tlbe) == addr)
+		{
+			if (tlbe_is_valid(tlbe))
+				return (tlbe);
+		}
+	}
+
+	return (NULL);
+}
+
+/*============================================================================*
+ * tlb_write()                                                                *
+ *============================================================================*/
+
+/**
+ * The or1k_cluster_tlb_write() function writes an entry into the architectural
+ * TLB. If the new entry conflicts to an old one, the old one is
+ * overwritten.
+ *
+ * @note Although the OpenRISC specification states that the TLB can
+ * have up to 4-ways, there is no known implementation that uses more
+ * than 1-way, i.e: direct mapping. Therefore, this function will use
+ * only 1-way at the moment.
+ *
+ * @author Davidson Francis
+ */
+PUBLIC int tlb_write(int tlb_type, vaddr_t vaddr, paddr_t paddr)
+{
+	int config;        /* Configuration flag. */
+	unsigned idx;      /* TLB Index.          */
+	struct tlbe *utlb; /* Underlying TLB.     */
+
+	/* Invalid TLB type. */
+	if ((tlb_type != TLB_INSTRUCTION) && (tlb_type != TLB_DATA))
+		return (-EINVAL);
+
+	utlb   = tlb_get_utlb(tlb_type);
+	idx    = tlbe_get_index(vaddr);
+	config = tlb_get_vaddr_info(vaddr);
+
+	if (tlbe_write(&utlb[idx], tlb_type, vaddr, paddr, config) != 0)
+		return (-EAGAIN);
+
+	return (0);
+}
+
+/*============================================================================*
+ * or1k_cluster_tlb_inval()                                                   *
+ *============================================================================*/
+
+/**
+ * The or1k_cluster_tlb_inval() function invalidates the TLB entry that
+ * encodes the virtual address @p vaddr.
+ *
+ * @author Davidson Francis
+ */
+PUBLIC int tlb_inval(int tlb_type, vaddr_t vaddr)
+{
+	int idx;           /* TLB Index.      */
+	struct tlbe *utlb; /* Underlying TLB. */
+
+	/* Invalid TLB type. */
+	if ((tlb_type != TLB_INSTRUCTION) && (tlb_type != TLB_DATA))
+		return (-EINVAL);
+
+	idx  = tlbe_get_index(vaddr);
+	utlb = tlb_get_utlb(tlb_type);
+
+	if (tlbe_inval(&utlb[idx], tlb_type, vaddr) != 0)
+		return (-EAGAIN);
+
+	return (0);
+}
+
+#endif /* !CORE_HAS_TLB_HW */


### PR DESCRIPTION
Description
-----------------

In this PR, I remove the responsibility of architecture to deal with some common functions that operate on the TLB by abstracting them to the abstraction level of the Cluster.

The following functions have been abstracted:

- `tlb_lookup_vaddr()`
- `tlb_lookup_paddr()`
- `tlb_write()`
- `tlb_inval()`

However, note that for supporting the abstractions I needed to create some auxiliary functions, both in the AL Cluster and in the Core AL. Because of this, assess whether I abstract some parts correctly.

Related Issues
---------------------

- [[hal] Plataform Independent TLB Management](https://github.com/nanvix/hal/issues/378)