### PR TITLE
[hal] Enhancement: Event Handler

### DIFF
--- a/include/arch/core/i486/int.h
+++ b/include/arch/core/i486/int.h
@@ -63,6 +63,7 @@
 	#define I486_INT_COPROC  13 /*< FPU, coprocessor or inter-processor.       */
 	#define I486_INT_ATA1    14 /*< Primary ATA hard disk.                     */
 	#define I486_INT_ATA2    15 /*< Secondary ATA hard disk.                   */
+	#define I486_INT_IPI    256 /*< Dummy IPI interrupt.                       */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -129,6 +130,7 @@
 	/**@{*/
 	#define INTERRUPTS_NUM  I486_INT_NUM   /**< @ref I486_INT_NUM   */
 	#define INTERRUPT_CLOCK I486_INT_CLOCK /**< @ref I486_INT_CLOCK */
+	#define INTERRUPT_IPI   I486_INT_IPI   /**< @ref I486_INT_IPI   */
 	/**@}*/
 
 	/**

--- a/include/arch/core/k1b/int.h
+++ b/include/arch/core/k1b/int.h
@@ -65,6 +65,7 @@
 	#define K1B_INT_GIC2      11 /**< GIC 2                */
 	#define K1B_INT_GIC3      12 /**< GIC2                 */
 	#endif
+	#define K1B_INT_IPI      256 /**< Dummy IPI interrupt  */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -128,6 +129,7 @@
 	/**@{*/
 	#define INTERRUPTS_NUM  K1B_INT_NUM    /**< @ref K1b_INT_NUM    */
 	#define INTERRUPT_CLOCK K1B_INT_CLOCK0 /**< @ref K1B_INT_CLOCK0 */
+	#define INTERRUPT_IPI   K1B_INT_IPI    /**< @ref K1B_INT_IPI    */
 	#define HAL_INT_CNOC    K1B_INT_CNOC   /**< @ref K1B_INT_CNOC   */
 	/**@}*/
 

--- a/include/arch/core/or1k/int.h
+++ b/include/arch/core/or1k/int.h
@@ -115,6 +115,7 @@
 	/**@{*/
 	#define INTERRUPTS_NUM  OR1K_INT_NUM   /**< @ref OR1K_INT_NUM   */
 	#define INTERRUPT_CLOCK OR1K_INT_CLOCK /**< @ref OR1K_INT_CLOCK */
+	#define INTERRUPT_IPI   OR1K_INT_OMPIC /**< @ref OR1K_INT_CLOCK */
 	/**@}*/
 
 	/**

--- a/include/arch/core/rv32gc/int.h
+++ b/include/arch/core/rv32gc/int.h
@@ -63,6 +63,7 @@
 	#define RV32GC_INT_EXTERN_USER     RV32GC_IRQ_UEXTERN /**< User External Interrupt       */
 	#define RV32GC_INT_EXTERN_KERNEL   RV32GC_IRQ_SEXTERN /**< Supervisor External Interrupt */
 	#define RV32GC_INT_EXTERN_MACHINE  RV32GC_IRQ_HEXTERN /**< Machine External Interrupt    */
+	#define RV32GC_INT_IPI             RV32GC_IRQ_IPI     /**< Dummy IPI interrupt.          */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -132,6 +133,7 @@
 	/**@{*/
 	#define INTERRUPTS_NUM  RV32GC_INT_NUM          /**< @ref RV32GC_INT_NUM          */
 	#define INTERRUPT_CLOCK RV32GC_INT_TIMER_KERNEL /**< @ref RV32GC_INT_TIMER_KERNEL */
+	#define INTERRUPT_IPI   RV32GC_INT_IPI          /**< @ref RV32GC_INT_IPI          */
 	/**@}*/
 
 	/**

--- a/include/arch/core/rv32gc/lpic.h
+++ b/include/arch/core/rv32gc/lpic.h
@@ -59,6 +59,7 @@
 	#define RV32GC_IRQ_UEXTERN  8 /**< User External       */
 	#define RV32GC_IRQ_SEXTERN  9 /**< Supervisor External */
 	#define RV32GC_IRQ_HEXTERN 11 /**< Hypervisor External */
+	#define RV32GC_IRQ_IPI    256 /**< Dummy IPI irq.      */
 	/**@}*/
 
 #ifndef _ASM_FILE_

--- a/include/nanvix/hal/cluster/event.h
+++ b/include/nanvix/hal/cluster/event.h
@@ -82,6 +82,22 @@
 	}
 #endif
 
+	/**
+	 * @brief Resets the pending IPI interrupt.
+	 *
+	 * If the current architecture have events and have a valid
+	 * interrupt number for the IPI handler, exports the function,
+	 * otherwise, defines a dummy reset function.
+	 */
+#if (CLUSTER_HAS_EVENTS && INTERRUPT_IPI < INTERRUPTS_NUM)
+	EXTERN void event_reset(void);
+#else
+	static inline void event_reset(void)
+	{
+		/* noop. */
+	}
+#endif
+
 /**@}*/
 
 #endif /* NANVIX_HAL_CLUSTER_EVENT_H_ */


### PR DESCRIPTION
Description
---------------
So far, HAL does not have any features that relies on Event Handlers, i.e: IPI Interrupts, in this way, it was not possible to receive generic IPI interrupts nor define a user-space handler for it, as occurs with timer interrupts.

For architectures that supports HW Events but do not have IPI interrupts, I insert a dummy `IPI_INTERRUPT` that does not belong to any valid interrupt (and will not be registered as a valid interrupt), for the rest (OpenRISC), a valid `IPI_INTERRUPT` maps to the OMPIC IRQ which in turn registers a generic pre-handler called `do_event` for such arch, which optionally call a user-space defined event in the function `event_handler`.

In addition, following the same approach as `do_clock`, a function called `event_reset` was defined, which in archs that have IPI interrupts, can define any functionality necessary to prepare the device to receive new interrupts again.