### PR TITLE
[or1k-cluster] Blocking Events

### DIFF
--- a/include/arch/cluster/optimsoc-cluster.h
+++ b/include/arch/cluster/optimsoc-cluster.h
@@ -42,6 +42,7 @@
 
 	#include <arch/cluster/optimsoc-cluster/clock.h>
 	#include <arch/cluster/optimsoc-cluster/cores.h>
+	#include <arch/cluster/optimsoc-cluster/event.h>
 	#include <arch/cluster/optimsoc-cluster/memory.h>
 	#include <arch/cluster/optimsoc-cluster/ompic.h>
 
@@ -52,7 +53,7 @@
 	#define CLUSTER_IS_MULTICORE  1 /**< Multicore Cluster */
 	#define CLUSTER_IS_IO         1 /**< I/O Cluster       */
 	#define CLUSTER_IS_COMPUTE    0 /**< Compute Cluster   */
-	#define CLUSTER_HAS_EVENTS    0 /**< Event Support?    */
+	#define CLUSTER_HAS_EVENTS    1 /**< Event Support?    */
 	/**@}*/
 
 /**@}*/

--- a/include/arch/cluster/optimsoc-cluster/event.h
+++ b/include/arch/cluster/optimsoc-cluster/event.h
@@ -52,6 +52,11 @@
 	 */
 	EXTERN int or1k_cluster_event_wait(void);
 
+	/**
+	 * @brief Waits for an event.
+	 */
+	EXTERN void or1k_cluster_event_reset(void);
+
 #endif /* _ASM_FILE_ */
 
 /**@}*/
@@ -91,6 +96,14 @@
 	}
 
 	/**
+	 * @see or1k_cluster_event_reset().
+	 */
+	static inline void optimsoc_cluster_event_reset(void)
+	{
+		or1k_cluster_event_reset();
+	}
+
+	/**
 	 * @see optimsoc_cluster_event_notify()
 	 */
 	static inline void event_notify(int coreid)
@@ -104,6 +117,14 @@
 	static inline void event_wait(void)
 	{
 		optimsoc_cluster_event_wait();
+	}
+
+	/**
+	 * @see optimsoc_cluster_event_reset().
+	 */
+	static inline void event_reset(void)
+	{
+		optimsoc_cluster_event_reset();
 	}
 
 #endif /* _ASM_FILE_ */

--- a/include/arch/cluster/optimsoc-cluster/event.h
+++ b/include/arch/cluster/optimsoc-cluster/event.h
@@ -1,0 +1,113 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef ARCH_CLUSTER_OPTIMSOC_CLUSTER_EVENT_H_
+#define ARCH_CLUSTER_OPTIMSOC_CLUSTER_EVENT_H_
+
+	/* Cluster Interface Implementation */
+	#include <arch/cluster/optimsoc-cluster/_optimsoc-cluster.h>
+
+/**
+ * @addtogroup optimsoc-cluster-event Events
+ * @ingroup optimsoc-cluster
+ *
+ * @brief Events Interface
+ */
+/**@{*/
+
+	#include <nanvix/const.h>
+
+#ifndef _ASM_FILE_
+
+	/**
+	 * @brief Notifies a local core about an event.
+	 *
+	 * @param coreid ID of target core.
+	 */
+	EXTERN int or1k_cluster_event_notify(int coreid);
+
+	/**
+	 * @brief Waits for an event.
+	 */
+	EXTERN int or1k_cluster_event_wait(void);
+
+#endif /* _ASM_FILE_ */
+
+/**@}*/
+
+/*============================================================================*
+ * Exported Interface                                                         *
+ *============================================================================*/
+
+/**
+ * @cond optimsoc_cluster
+ */
+
+	/**
+	 * @name Exported Functions
+	 */
+	/**@{*/
+	#define __event_notify_fn /**< event_notify() */
+	#define __event_wait_fn   /**< event_wait()   */
+	/**@}*/
+
+#ifndef _ASM_FILE_
+
+	/**
+	 * @see or1k_cluster_event_notify()
+	 */
+	static inline void optimsoc_cluster_event_notify(int coreid)
+	{
+		or1k_cluster_event_notify(coreid);
+	}
+
+	/**
+	 * @see or1k_cluster_event_wait().
+	 */
+	static inline void optimsoc_cluster_event_wait(void)
+	{
+		or1k_cluster_event_wait();
+	}
+
+	/**
+	 * @see optimsoc_cluster_event_notify()
+	 */
+	static inline void event_notify(int coreid)
+	{
+		optimsoc_cluster_event_notify(coreid);
+	}
+
+	/**
+	 * @see optimsoc_cluster_event_wait().
+	 */
+	static inline void event_wait(void)
+	{
+		optimsoc_cluster_event_wait();
+	}
+
+#endif /* _ASM_FILE_ */
+
+/**@endcond*/
+
+#endif /* ARCH_CLUSTER_OPTIMSOC_EVENT_H_ */

--- a/include/arch/cluster/optimsoc-cluster/memory.h
+++ b/include/arch/cluster/optimsoc-cluster/memory.h
@@ -142,8 +142,8 @@
 	 */
 	/**@{*/
 	#define OPTIMSOC_OMPIC_CPUBYTES	        8
-	#define OPTIMSOC_OMPIC_CTRL(cpu)        (OPTIMSOC_CLUSTER_OMPIC_BASE_VIRT + (0x0 + ((cpu) * OPTIMSOC_OMPIC_CPUBYTES)))
-	#define OPTIMSOC_OMPIC_STAT(cpu)        (OPTIMSOC_CLUSTER_OMPIC_BASE_VIRT + (0x4 + ((cpu) * OPTIMSOC_OMPIC_CPUBYTES)))
+	#define OPTIMSOC_OMPIC_CTRL(cpu)        ((0x0 + ((cpu) * OPTIMSOC_OMPIC_CPUBYTES)))
+	#define OPTIMSOC_OMPIC_STAT(cpu)        ((0x4 + ((cpu) * OPTIMSOC_OMPIC_CPUBYTES)))
 	#define OPTIMSOC_OMPIC_CTRL_IRQ_ACK	    (1 << 31)
 	#define OPTIMSOC_OMPIC_CTRL_IRQ_GEN	    (1 << 30)
 	#define OPTIMSOC_OMPIC_CTRL_DST(cpu)    (((cpu) & 0x3fff) << 16)
@@ -157,8 +157,8 @@
 	 */
 	/**@{*/
 	#define OR1K_OMPIC_CPUBYTES	        8
-	#define OR1K_OMPIC_CTRL(cpu)        (OR1K_CLUSTER_OMPIC_BASE_VIRT + (0x0 + ((cpu) * OR1K_OMPIC_CPUBYTES)))
-	#define OR1K_OMPIC_STAT(cpu)        (OR1K_CLUSTER_OMPIC_BASE_VIRT + (0x4 + ((cpu) * OR1K_OMPIC_CPUBYTES)))
+	#define OR1K_OMPIC_CTRL(cpu)        ((0x0 + ((cpu) * OR1K_OMPIC_CPUBYTES)))
+	#define OR1K_OMPIC_STAT(cpu)        ((0x4 + ((cpu) * OR1K_OMPIC_CPUBYTES)))
 	#define OR1K_OMPIC_CTRL_IRQ_ACK	    (1 << 31)
 	#define OR1K_OMPIC_CTRL_IRQ_GEN	    (1 << 30)
 	#define OR1K_OMPIC_CTRL_DST(cpu)    (((cpu) & 0x3fff) << 16)

--- a/include/arch/cluster/or1k-cluster/event.h
+++ b/include/arch/cluster/or1k-cluster/event.h
@@ -52,6 +52,11 @@
 	 */
 	EXTERN int or1k_cluster_event_wait(void);
 
+	/**
+	 * @brief Waits for an event.
+	 */
+	EXTERN void or1k_cluster_event_reset(void);
+
 #endif /* _ASM_FILE_ */
 
 /**@}*/
@@ -88,6 +93,14 @@
 	static inline void event_wait(void)
 	{
 		or1k_cluster_event_wait();
+	}
+
+	/**
+	 * @see or1k_cluster_event_reset().
+	 */
+	static inline void event_reset(void)
+	{
+		or1k_cluster_event_reset();
 	}
 
 #endif /* _ASM_FILE_ */

--- a/include/arch/cluster/or1k-cluster/event.h
+++ b/include/arch/cluster/or1k-cluster/event.h
@@ -22,40 +22,76 @@
  * SOFTWARE.
  */
 
-#ifndef CLUSTER_OR1K_CLUSTER_H_
-#define CLUSTER_OR1K_CLUSTER_H_
-
-	#ifndef __NEED_CLUSTER_OR1K
-		#error "bad cluster configuration?"
-	#endif
+#ifndef ARCH_CLUSTER_OR1K_CLUSTER_EVENT_H_
+#define ARCH_CLUSTER_OR1K_CLUSTER_EVENT_H_
 
 	/* Cluster Interface Implementation */
 	#include <arch/cluster/or1k-cluster/_or1k-cluster.h>
 
 /**
- * @addtogroup or1k-cluster OpenRISC Cluster
- * @ingroup clusters
+ * @addtogroup or1k-cluster-event Events
+ * @ingroup or1k-cluster
  *
- * @brief OpenRISC Cluster
+ * @brief Events Interface
  */
 /**@{*/
 
-	#include <arch/cluster/or1k-cluster/clock.h>
-	#include <arch/cluster/or1k-cluster/cores.h>
-	#include <arch/cluster/or1k-cluster/event.h>
-	#include <arch/cluster/or1k-cluster/memory.h>
-	#include <arch/cluster/or1k-cluster/ompic.h>
+	#include <nanvix/const.h>
+
+#ifndef _ASM_FILE_
 
 	/**
-	 * @name Provided Features
+	 * @brief Notifies a local core about an event.
+	 *
+	 * @param coreid ID of target core.
 	 */
-	/**@{*/
-	#define CLUSTER_IS_MULTICORE  1 /**< Multicore Cluster */
-	#define CLUSTER_IS_IO         1 /**< I/O Cluster       */
-	#define CLUSTER_IS_COMPUTE    0 /**< Compute Cluster   */
-	#define CLUSTER_HAS_EVENTS    1 /**< Event Support?    */
-	/**@}*/
+	EXTERN int or1k_cluster_event_notify(int coreid);
+
+	/**
+	 * @brief Waits for an event.
+	 */
+	EXTERN int or1k_cluster_event_wait(void);
+
+#endif /* _ASM_FILE_ */
 
 /**@}*/
 
-#endif /* CLUSTER_OR1K_CLUSTER_H_ */
+/*============================================================================*
+ * Exported Interface                                                         *
+ *============================================================================*/
+
+/**
+ * @cond or1k_cluster
+ */
+
+	/**
+	 * @name Exported Functions
+	 */
+	/**@{*/
+	#define __event_notify_fn /**< event_notify() */
+	#define __event_wait_fn   /**< event_wait()   */
+	/**@}*/
+
+#ifndef _ASM_FILE_
+
+	/**
+	 * @see or1k_cluster_event_notify()
+	 */
+	static inline void event_notify(int coreid)
+	{
+		or1k_cluster_event_notify(coreid);
+	}
+
+	/**
+	 * @see or1k_cluster_event_wait().
+	 */
+	static inline void event_wait(void)
+	{
+		or1k_cluster_event_wait();
+	}
+
+#endif /* _ASM_FILE_ */
+
+/**@endcond*/
+
+#endif /* ARCH_CLUSTER_OR1K_EVENT_H_ */

--- a/include/arch/cluster/or1k-cluster/memory.h
+++ b/include/arch/cluster/or1k-cluster/memory.h
@@ -110,8 +110,8 @@
 	 */
 	/**@{*/
 	#define OR1K_OMPIC_CPUBYTES	        8
-	#define OR1K_OMPIC_CTRL(cpu)        (OR1K_CLUSTER_OMPIC_BASE_VIRT + (0x0 + ((cpu) * OR1K_OMPIC_CPUBYTES)))
-	#define OR1K_OMPIC_STAT(cpu)        (OR1K_CLUSTER_OMPIC_BASE_VIRT + (0x4 + ((cpu) * OR1K_OMPIC_CPUBYTES)))
+	#define OR1K_OMPIC_CTRL(cpu)        ((0x0 + ((cpu) * OR1K_OMPIC_CPUBYTES)))
+	#define OR1K_OMPIC_STAT(cpu)        ((0x4 + ((cpu) * OR1K_OMPIC_CPUBYTES)))
 	#define OR1K_OMPIC_CTRL_IRQ_ACK	    (1 << 31)
 	#define OR1K_OMPIC_CTRL_IRQ_GEN	    (1 << 30)
 	#define OR1K_OMPIC_CTRL_DST(cpu)    (((cpu) & 0x3fff) << 16)

--- a/include/arch/core/or1k/int.h
+++ b/include/arch/core/or1k/int.h
@@ -103,6 +103,15 @@
 		);
 	}
 
+	/**
+	 * @brief Waits for an interrupt.
+	 */
+	static inline void or1k_int_wait(void)
+	{
+		if (or1k_mfspr(OR1K_SPR_UPR) & OR1K_SPR_UPR_PMP)
+			or1k_mtspr(OR1K_SPR_PMR, OR1K_SPR_PMR_DME);
+	}
+
 #endif
 
 /**@}*/

--- a/include/arch/core/or1k/int.h
+++ b/include/arch/core/or1k/int.h
@@ -72,6 +72,12 @@
 	/**@}*/
 
 	/**
+	 * @brief Calls the HAL do_interrupt function
+	 * with the appropriate values.
+	 */
+	EXTERN void or1k_do_interrupt(int num);
+
+	/**
 	 * @brief Enables hardware interrupts.
 	 *
 	 * The or1k_int_enable() function enables all hardware interrupts

--- a/src/hal/arch/cluster/or1k-cluster/event.c
+++ b/src/hal/arch/cluster/or1k-cluster/event.c
@@ -24,15 +24,21 @@
 
 /* Must come first. */
 #define __NEED_HAL_CLUSTER
+#define __NEED_CLUSTER_MEMMAP
 
 #if (defined(__or1k_cluster__))
 	#include <arch/cluster/or1k-cluster/cores.h>
 	#include <arch/cluster/or1k-cluster/ompic.h>
+	#include <arch/cluster/or1k-cluster/memmap.h>
+	#include <arch/cluster/or1k-cluster/memory.h>
 #elif (defined(__optimsoc_cluster__))
 	#include <arch/cluster/optimsoc-cluster/cores.h>
 	#include <arch/cluster/optimsoc-cluster/ompic.h>
+	#include <arch/cluster/optimsoc-cluster/memmap.h>
+	#include <arch/cluster/optimsoc-cluster/memory.h>
 #endif
 
+#include <nanvix/hal/cluster/mmio.h>
 #include <nanvix/const.h>
 
 /**
@@ -57,6 +63,25 @@ PUBLIC struct
 	{ 0, OR1K_SPINLOCK_UNLOCKED }, /* Slave Core 3 */
 #endif
 };
+
+/*============================================================================*
+ * or1k_cluster_event_reset()                                                 *
+ *============================================================================*/
+
+PUBLIC void or1k_cluster_event_reset(void)
+{
+	int coreid;       /* Core ID.       */
+	uint32_t *ompic;  /* OMPIC address. */
+
+	/* Get address of uart. */
+	ompic = mmio_get(OR1K_CLUSTER_OMPIC_BASE_PHYS);
+
+	/* Current core. */
+	coreid = or1k_core_get_id();
+
+	/* ACK IPI. */
+	ompic[OR1K_OMPIC_CTRL(coreid) / OR1K_WORD_SIZE] = OR1K_OMPIC_CTRL_IRQ_ACK;
+}
 
 /*============================================================================*
  * or1k_cluster_event_notify()                                                *

--- a/src/hal/arch/core/or1k/hooks.S
+++ b/src/hal/arch/core/or1k/hooks.S
@@ -216,7 +216,7 @@ _do_hwint:
 	/*
 	 * Call interrupt handler.
 	 */
-	l.jal do_interrupt
+	l.jal or1k_do_interrupt
 	l.nop
 
 	/*

--- a/src/hal/arch/core/or1k/int.c
+++ b/src/hal/arch/core/or1k/int.c
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+#include <nanvix/hal/core/interrupt.h>
 #include <arch/core/or1k/int.h>
 #include <arch/core/or1k/core.h>
 #include <nanvix/const.h>
@@ -34,3 +35,23 @@
 PUBLIC void (*interrupt_handlers[OR1K_INT_NUM])(int) = {
 	NULL, NULL, NULL
 };
+
+/**
+ * @brief Receives an interrupt number, checks if belongs
+ * to a clock interrupt or a external device and
+ * call the generic handler with the appropriate
+ * interrupt number.
+ *
+ * @param num Interrupt type identifier.
+ */
+PUBLIC void or1k_do_interrupt(int num)
+{
+	int interrupt; /* Interrupt to be served. */
+
+	if (num == OR1K_INT_EXTERNAL)
+		interrupt = or1k_pic_next();
+	else
+		interrupt = num;
+
+	do_interrupt(interrupt);
+}


### PR DESCRIPTION
Description
---------------
Until now, the OpenRISC architecture was relying on a busy waiting approach to handling Events. For a more reliable approach, the use of Inter-Processor Interrupts was necessary.

This PR, in turn, introduces the use of OMPIC device for OpenRISC targets, which is, in fact, the appropriate way to handle Events.

Related Issues
-------------------
[[or1k-cluster] Blocking Events](https://github.com/nanvix/hal/issues/376)

Pull Request Dependency List
---------------------------------------
[[hal] Enhancement: Event Handler](https://github.com/nanvix/hal/pull/411)