### PR TITLE
[or1k-core] BSS Initialization Is Missing

### DIFF
--- a/build/optimsoc/linker/link.ld
+++ b/build/optimsoc/linker/link.ld
@@ -58,7 +58,6 @@ SECTIONS
 	.data ALIGN(8192) : AT(ADDR(.data))
 	{
 		__DATA_START = .;
-		*boot_data.o
 		*(.rodata)
 		*(.data)
 		__DATA_END = .;
@@ -68,6 +67,7 @@ SECTIONS
 	.bss : AT(ADDR(.bss))
 	{
 		__BSS_START = .;
+		*boot_data.o
 		*(.bss)
 		__BSS_END = .;
 	}

--- a/build/optimsoc/linker/link.ld
+++ b/build/optimsoc/linker/link.ld
@@ -47,7 +47,9 @@ SECTIONS
 	/* Kernel code section. */
 	.text : AT(ADDR(.text))
 	{
+		__TEXT_START = .;
 		*(.text)
+		__TEXT_END = .;
 	}
 
 	KSTART_DATA = ALIGN(8192);
@@ -55,15 +57,19 @@ SECTIONS
 	/* Initialized kernel data section. */
 	.data ALIGN(8192) : AT(ADDR(.data))
 	{
+		__DATA_START = .;
 		*boot_data.o
 		*(.rodata)
 		*(.data)
+		__DATA_END = .;
 	}
 
 	/* Uninitialized kernel data section. */
 	.bss : AT(ADDR(.bss))
 	{
+		__BSS_START = .;
 		*(.bss)
+		__BSS_END = .;
 	}
 
 	. =ALIGN(8192);

--- a/build/qemu-openrisc/linker/link.ld
+++ b/build/qemu-openrisc/linker/link.ld
@@ -58,7 +58,6 @@ SECTIONS
 	.data ALIGN(8192) : AT(ADDR(.data))
 	{
 		__DATA_START = .;
-		*boot_data.o
 		*(.rodata)
 		*(.data)
 		__DATA_END = .;
@@ -68,6 +67,7 @@ SECTIONS
 	.bss : AT(ADDR(.bss))
 	{
 		__BSS_START = .;
+		*boot_data.o
 		*(.bss)
 		__BSS_END = .;
 	}

--- a/build/qemu-openrisc/linker/link.ld
+++ b/build/qemu-openrisc/linker/link.ld
@@ -47,7 +47,9 @@ SECTIONS
 	/* Kernel code section. */
 	.text : AT(ADDR(.text))
 	{
+		__TEXT_START = .;
 		*(.text)
+		__TEXT_END = .;
 	}
 
 	KSTART_DATA = ALIGN(8192);
@@ -55,15 +57,19 @@ SECTIONS
 	/* Initialized kernel data section. */
 	.data ALIGN(8192) : AT(ADDR(.data))
 	{
+		__DATA_START = .;
 		*boot_data.o
 		*(.rodata)
 		*(.data)
+		__DATA_END = .;
 	}
 
 	/* Uninitialized kernel data section. */
 	.bss : AT(ADDR(.bss))
 	{
+		__BSS_START = .;
 		*(.bss)
+		__BSS_END = .;
 	}
 
 	. =ALIGN(8192);

--- a/include/arch/cluster/optimsoc-cluster/memory.h
+++ b/include/arch/cluster/optimsoc-cluster/memory.h
@@ -169,6 +169,18 @@
 
 #ifndef _ASM_FILE_
 
+	/**
+	 * @brief Binary Sections
+	 */
+	/**@{*/
+	EXTERN unsigned char __TEXT_START; /**< Text Start */
+	EXTERN unsigned char __TEXT_END;   /**< Text End   */
+	EXTERN unsigned char __DATA_START; /**< Data Start */
+	EXTERN unsigned char __DATA_END;   /**< Data End   */
+	EXTERN unsigned char __BSS_START;  /**< BSS Start  */
+	EXTERN unsigned char __BSS_END;    /**< BSS End    */
+	/**@}*/
+
 #ifdef __NANVIX_HAL
 
 	/**

--- a/include/arch/cluster/or1k-cluster/memory.h
+++ b/include/arch/cluster/or1k-cluster/memory.h
@@ -122,6 +122,18 @@
 
 #ifndef _ASM_FILE_
 
+	/**
+	 * @brief Binary Sections
+	 */
+	/**@{*/
+	EXTERN unsigned char __TEXT_START; /**< Text Start */
+	EXTERN unsigned char __TEXT_END;   /**< Text End   */
+	EXTERN unsigned char __DATA_START; /**< Data Start */
+	EXTERN unsigned char __DATA_END;   /**< Data End   */
+	EXTERN unsigned char __BSS_START;  /**< BSS Start  */
+	EXTERN unsigned char __BSS_END;    /**< BSS End    */
+	/**@}*/
+
 #ifdef __NANVIX_HAL
 
 	/**

--- a/include/arch/core/or1k/asm.h
+++ b/include/arch/core/or1k/asm.h
@@ -372,7 +372,7 @@
 	 */
 	.macro or1k_core_stack_reset coreid
 
-		OR1K_LOAD_SYMBOL_2_GPR(r1, core.kstack)
+		OR1K_LOAD_SYMBOL_2_GPR(r1, kstacks)
 		l.or   r3, r0, \coreid
 		l.addi r3, r3, 1
 		l.slli r3, r3, OR1K_PAGE_SHIFT

--- a/src/hal/arch/cluster/or1k-cluster/_cluster.S
+++ b/src/hal/arch/cluster/or1k-cluster/_cluster.S
@@ -34,7 +34,7 @@
 
 /* Exported symbols. */
 .global _or1k_cluster_core_reset
-.global core.kstack
+.global kstacks
 
 .section .text
 

--- a/src/hal/arch/cluster/or1k-cluster/boot_code.S
+++ b/src/hal/arch/cluster/or1k-cluster/boot_code.S
@@ -35,7 +35,7 @@
 
 /* Exported symbols. */
 .globl start
-.globl core.kstack
+.globl kstacks
 
 /*============================================================================*
  *                              bootstrap section                             *

--- a/src/hal/arch/cluster/or1k-cluster/boot_data.S
+++ b/src/hal/arch/cluster/or1k-cluster/boot_data.S
@@ -32,16 +32,16 @@
 #endif
 
 /* Exported symbols. */
-.globl core.kstack
+.globl kstacks
 
-.section .data
+.section .bss
 /*----------------------------------------------------------------------------*
- * core.kstack                                                                *
+ * kstacks                                                                    *
  *----------------------------------------------------------------------------*/
 
 /**
  * @brief Kernel stack for all cores.
  */
 .align OR1K_PAGE_SIZE
-core.kstack:
-	.fill (OR1K_PAGE_SIZE/OR1K_PTE_SIZE)*OR1K_CLUSTER_NUM_CORES, OR1K_PTE_SIZE, 0
+kstacks:
+	.skip OR1K_PAGE_SIZE * OR1K_CLUSTER_NUM_CORES

--- a/src/hal/arch/cluster/or1k-cluster/cluster.c
+++ b/src/hal/arch/cluster/or1k-cluster/cluster.c
@@ -105,6 +105,9 @@ PRIVATE void or1k_fence_wait(void)
  */
 PUBLIC NORETURN void or1k_cluster_master_setup(void)
 {
+	/* Clear BSS section. */
+	kmemset(&__BSS_START, 0, &__BSS_END - &__BSS_START);
+
 	/* Core setup. */
 	or1k_cluster_setup();
 

--- a/src/hal/arch/cluster/or1k-cluster/memory.c
+++ b/src/hal/arch/cluster/or1k-cluster/memory.c
@@ -403,6 +403,12 @@ PRIVATE void or1k_cluster_mem_info(void)
 {
 	int i; /* Loop index. */
 
+	kprintf("[hal] text = %d KB data = %d KB bss = %d KB",
+		(&__TEXT_END - &__TEXT_START)/KB,
+		(&__DATA_END - &__DATA_START)/KB,
+		(&__BSS_END  - &__BSS_START)/KB
+	);
+
 	for (i = 0; i < OR1K_CLUSTER_MEM_REGIONS; i++)
 	{
 		kprintf("[hal] %s_base=%x %s_end=%x",


### PR DESCRIPTION
Description
---------------
It's expected that the BSS section is cleared in the startup, otherwise, unexpected behaviors could arise, this PR fixes it.

Related Issues
-------------------
- [[hal] BSS Initialization Is Missing](https://github.com/nanvix/hal/issues/231)