### PR TITLE
[optimsoc-cluster] Using the Busy-Waiting Approach in the Events

### DIFF
--- a/src/hal/arch/cluster/or1k-cluster/event.c
+++ b/src/hal/arch/cluster/or1k-cluster/event.c
@@ -110,7 +110,10 @@ PUBLIC int or1k_cluster_event_notify(int coreid)
 
 		/* Set the pending IPI flag. */
 		events[coreid].pending |= (1 << mycoreid);
+
+#if (defined(__or1k_cluster__))
 		or1k_cluster_ompic_send_ipi(coreid, 0);
+#endif
 
 	spinlock_unlock(&events[coreid].lock);
 
@@ -139,7 +142,9 @@ PUBLIC int or1k_cluster_event_wait(void)
 
 		or1k_spinlock_unlock(&events[mycoreid].lock);
 
+#if (defined(__or1k_cluster__))
 		or1k_int_wait();
+#endif
 	}
 
 		/* Clear event. */


### PR DESCRIPTION
Description
---------------
In the issue #426 was realized that the optimsoc target does not have the OMPIC device by default, this PR, in turn, selectively uses the OMPIC approach only on or1k-cluster targets, while the optimsoc targets use the busy-waiting approach, as it was before.

While the desirable solution would be introduce the OMPIC support to the OpTiMSoC source tree, while this does not happen, our best option is to have the busy-waiting approach again.

Related Issues
--------------------
[[optimsoc-cluster] OMPIC Not Present in OpTiMSoC](https://github.com/nanvix/hal/issues/426)