### PR TITLE
[hal] Bug Fix: Optimization Produces Wrong Code

### DIFF
--- a/include/nanvix/cc.h
+++ b/include/nanvix/cc.h
@@ -43,7 +43,7 @@
 	 * @name Aliases for Standard C Extensions
 	 */
 	/**@{*/
-	#ifdef NDEBUG
+	#if defined (NDEBUG) && !defined(__optimsoc__) && !defined(__qemu_openrisc__)
 		#define inline __inline__  __attribute__((always_inline)) /**< Inline Function */
 	#else
 		#define inline __inline__                                 /**< Inline Function */

--- a/src/test/cluster/cores.c
+++ b/src/test/cluster/cores.c
@@ -376,6 +376,8 @@ PRIVATE void test_cluster_core_api_reset_slave(void)
 	int ret;
 	int coreid;
 
+	coreid = 0;
+
 	/* Reset flag. */
 	slave_nstarts = 0;
 	dcache_invalidate();
@@ -431,6 +433,8 @@ PRIVATE void test_cluster_core_api_reset_slave(void)
 PRIVATE void test_cluster_core_api_sleep_wakeup_slave(void)
 {
 	int coreid;
+	
+	coreid = 0;
 
 	/* Start one slave core. */
 	for (int i = 0; i < CORES_NUM; i++)

--- a/src/test/cluster/cores.c
+++ b/src/test/cluster/cores.c
@@ -154,7 +154,7 @@ PRIVATE void slave(void)
 /**
  * @brief Number of starts of slave core.
  */
-PRIVATE int slave_nstarts = 0;
+PRIVATE volatile int slave_nstarts = 0;
 
 /**
  * @brief Reset slave.
@@ -194,7 +194,7 @@ PRIVATE void slave_reset(void)
 /**
  * @brief State of slave core.
  */
-PRIVATE int slave_state = 0;
+PRIVATE volatile int slave_state = 0;
 
 /**
  * @brief Sleep/Wakeup slave.

--- a/src/test/core/interrupt.c
+++ b/src/test/core/interrupt.c
@@ -36,7 +36,7 @@
 /**
  * @brief Counter of handler calls.
  */
-PRIVATE int ncalls = 0;
+PRIVATE volatile int ncalls = 0;
 
 /**
  * @brief Dummy interrupt handler.


### PR DESCRIPTION
Description
---------------
The GCC was producing wrong code if the optimization flags were enabled, because the condition variables were changed in other contexts other than the functions they were in, so the compiler was producing an infinite loop instead of checking the value of the variable at all times.

To fix, the 'volatile' qualifier is needed, to tell the compiler that the variable can be changed in other contexts. In addition, the 'always_inline' attribute was removed since it was producing incorrect code for the OpenRISC architecture.