### PR TITLE
[unix64] Feature: Memory cache interface and extensions

### DIFF
--- a/build/unix64/make/makefile
+++ b/build/unix64/make/makefile
@@ -63,4 +63,4 @@ export LDFLAGS =
 # Libraries
 export LIBKERNEL = libhal-$(TARGET).a
 export LIBS = $(LIBDIR)/$(LIBKERNEL)
-export LIB_THEIRS = -lpthread
+export LIB_THEIRS = -lpthread -lm

--- a/include/arch/core/linux64/cache.h
+++ b/include/arch/core/linux64/cache.h
@@ -26,39 +26,235 @@
 #define ARCH_LINUX64_CACHE_H_
 
 /**
- * @addtogroup linux64-core-cache Cache
+ * @addtogroup linux64-core-cache Memory Cache
  * @ingroup linux64-core
  *
- * @brief Memory Cache
+ * @brief Memory Cache Interface
  */
 /**@{*/
 
+	#include <nanvix/klib.h>
+	#include <stdlib.h>
+	#include <stdio.h>
+
 	/**
-	 * @name Provided Interface
+	 * @brief recover the cache line size
+	 */
+	EXTERN size_t linux64_core_dcache_line_size_get(void);
+
+	/**
+	 * @brief recover the cache line size log2
+	 */
+	EXTERN size_t linux64_core_dcache_line_size_log2_get(void);
+
+	/**
+	 * @brief recover the cache line size
+	 */
+	EXTERN size_t linux64_core_dcache_size_get(void);
+
+	/**
+	 * @brief Get the cache line size log2
+	 */
+	EXTERN size_t linux64_core_dcache_size_log2_get(void);
+
+	/**
+	 * @brief Invalidates the data cache of the underlying core.
+	 */
+	EXTERN void linux64_core_dcache_invalidate(void);
+
+	/**
+	 * @brief Flushes changes of the data cache into memory
+	 */
+	EXTERN void linux64_core_dcache_flush(void);
+
+	/**
+	 * @brief Wait for ongoing flush operations in the data cache to finish
+	 */
+	EXTERN void linux64_core_dcache_fence(void);
+
+	/**
+	 * @brief Prefetches a line of the data cache
+	 */
+	EXTERN void linux64_core_dcache_line_prefetch(void);
+
+	/**
+	 * @brief Invalidates a line of the data cache
+	 */
+	EXTERN void linux64_core_dcache_line_invalidate(void);
+
+	/**
+	 * @brief Dump information on data cache.
+	 */
+	EXTERN void linux64_core_dcache_dump_info(void);
+
+	/**
+	 * @brief Dump statistics on data cache.
+	 */
+	EXTERN void linux64_core_dcache_dump_stats(void);
+
+	/**
+	 * @brief Enables the data cache
+	 */
+	EXTERN void linux64_core_dcache_setup(void);
+
+	/**
+	 * @brief Invalidates the instruction cache
+	 */
+	EXTERN void linux64_core_icache_invalidate(void);
+
+	/**
+	 * @brief Prefetches a line of the instruction cache
+	 */
+	EXTERN void linux64_core_icache_line_prefetch(void);
+
+	/**
+	 * @brief Invalidates a line of the instruction cache
+	 */
+	EXTERN void linux64_core_icache_line_invalidate(void);
+
+	/**
+	 * @brief Dump statistics on instruction cache.
+	 */
+	EXTERN void linux64_core_icache_dump_stats(void);
+
+	/**
+	 * @brief Enables the instruction cache
+	 */
+	EXTERN void linux64_core_icache_setup(void);
+
+/**@}*/
+
+/*============================================================================*
+ * Exported Interface                                                         *
+ *============================================================================*/
+
+/**
+ * @cond linux64_core
+ */
+
+	/**
+	 * @name Cache Capabilities
 	 */
 	/**@{*/
-	#define __dcache_invalidate_fn
+	#define CORE_HAS_HW_DCACHE 0 /**< Has Data Cache?        */
+	#define CORE_HAS_HW_ICACHE 0 /**< Has Instruction Cache? */
 	/**@}*/
 
 	/**
-	 * @brief Cache line size (in bytes).
-	 *
-	 * @bug The cache line size of i486 may change.
+	 * @name Provided Functions
 	 */
-	#define LINUX64_CACHE_LINE_SIZE 64
+	/**@{*/
+	#define __dcache_invalidate_fn /**< dcache_invalidate() */
+	/**@}*/
 
 	/**
-	 * @see LINUX64_CACHE_LINE_SIZE
+	 * @see linux64_core_dcache_line_size_log2().
 	 */
-	#define CACHE_LINE_SIZE LINUX64_CACHE_LINE_SIZE
+	#define CACHE_LINE_SIZE_LOG2 linux64_core_dcache_line_size_log2_get()
 
 	/**
-	 * @note The linux64 core features cache coherency.
+	 * @see linux64_core_dcache_line_size().
+	 */
+	#define CACHE_LINE_SIZE linux64_core_dcache_line_size_get()
+
+	/**
+	 * @see linux64_core_dcache_size_log2().
+	 */
+	#define CACHE_SIZE_LOG2 linux64_core_dcache_size_log2_get()
+
+	/**
+	 * @see linux64_core_dcache_size().
+	 */
+	#define CACHE_SIZE linux64_core_dcache_size_get()
+
+	/**
+	 * @see linux_core_dcache_invalidate().
 	 */
 	static inline void dcache_invalidate(void)
 	{
+		linux64_core_dcache_invalidate();
 	}
 
-/**@}*/
+	/**
+	 * @see linux_core_dcache_flush().
+	 */
+	static inline void dcache_flush(void)
+	{
+		linux64_core_dcache_flush();
+	}
+
+	/**
+	 * @see linux_core_dcache_fence().
+	 */
+	static inline void dcache_fence(void)
+	{
+		linux64_core_dcache_fence();
+	}
+
+	/**
+	 * @see linux_core_dcache_prefetch().
+	 */
+	static inline void dcache_line_prefetch(void)
+	{
+		linux64_core_dcache_line_prefetch();
+	}
+
+	/**
+	 * @see linux_core_dcache_invalidate().
+	 */
+	static inline void dcache_line_invalidate(void)
+	{
+		linux64_core_dcache_line_invalidate();
+	}
+
+	/**
+	 * @see linux_core_dcache_dump_info().
+	 */
+	static inline void dcache_dump_info(void)
+	{
+		linux64_core_dcache_dump_info();
+	}
+
+	/**
+	 * @see linux_core_dcache_dump_stats().
+	 */
+	static inline void dcache_dump_stats(void)
+	{
+		linux64_core_dcache_dump_stats();
+	}
+
+	/**
+	 * @see linux_core_icache_invalidate().
+	 */
+	static inline void icache_invalidate(void)
+	{
+		linux64_core_icache_invalidate();
+	}
+
+	/**
+	 * @see linux_core_icache_prefetch().
+	 */
+	static inline void icache_line_prefetch(void)
+	{
+		linux64_core_icache_line_prefetch();
+	}
+
+	/**
+	 * @see linux_core_icache_invalidate().
+	 */
+	static inline void icache_line_invalidate(void)
+	{
+		linux64_core_icache_line_invalidate();
+	}
+
+	/**
+	 * @see linux_core_icache_dump_stats().
+	 */
+	static inline void icache_dump_stats(void)
+	{
+		linux64_core_icache_dump_stats();
+	}
+
+/**@endcond*/
 
 #endif /* ARCH_LINUX64_CACHE_H_ */

--- a/src/hal/arch/cluster/linux64-cluster/boot.c
+++ b/src/hal/arch/cluster/linux64-cluster/boot.c
@@ -23,9 +23,12 @@
  */
 
 #include <arch/core/linux64/core.h>
+#include <arch/core/linux64/cache.h>
+#include <math.h>
 #include <nanvix/const.h>
 #include <nanvix/klib.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 /* Import definitions. */
 EXTERN NORETURN void linux64_cluster_master_setup(void);
@@ -42,6 +45,12 @@ int main(int argc, char **argv)
 	UNUSED(argc);
 	UNUSED(argv);
 
+	linux64_core_dcache_setup();
+	linux64_core_icache_setup();
+
+	/**
+	 * Initialize the lookup table for Threads IDs.
+	 */
 	linux64_cores_tab[0] = pthread_self();
 
 	linux64_cluster_master_setup();

--- a/src/hal/arch/core/linux64-core/cache.c
+++ b/src/hal/arch/core/linux64-core/cache.c
@@ -1,0 +1,231 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/const.h>
+#include <nanvix/klib.h>
+#include <math.h>
+#include <unistd.h>
+#include <stdio.h>
+
+/**
+ * @name Data Cache Dimensions
+ */
+/**@{*/
+PRIVATE size_t linux64_cache_line_size = 0;
+PRIVATE size_t linux64_cache_line_size_log2 = 0;
+PRIVATE size_t linux64_cache_size = 0;
+PRIVATE size_t linux64_cache_size_log2 = 0;
+/**@}*/
+
+/**
+ * @name Data Cache Statistics
+ */
+/**@{*/
+PRIVATE unsigned dcache_invalidate_count = 0;      /**< Number of Invalidates      */
+PRIVATE unsigned dcache_flush_count = 0;           /**< Number of Flushes          */
+PRIVATE unsigned dcache_fence_count = 0;           /**< Number of Fences           */
+PRIVATE unsigned dcache_line_invalidate_count = 0; /**< Number of Line Invalidates */
+PRIVATE unsigned dcache_line_prefetch_count = 0;   /**< Number of Line Prefetches  */
+/**@}*/
+
+/**
+ * @name Instruction Cache Statistics
+ */
+/**@{*/
+PRIVATE unsigned icache_invalidate_count = 0;      /**< Number of Invalidates      */
+PRIVATE unsigned icache_line_prefetch_count = 0;   /**< Number of Line Invalidates */
+PRIVATE unsigned icache_line_invalidate_count = 0; /**< Number of Line Prefetches  */
+/**@{*/
+
+/*============================================================================*
+ * Data Cache                                                                 *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC size_t linux64_core_dcache_line_size_get(void)
+{
+	return linux64_cache_line_size;
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC size_t linux64_core_dcache_line_size_log2_get(void)
+{
+	return linux64_cache_line_size_log2;
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC size_t linux64_core_dcache_size_get(void)
+{
+    return linux64_cache_size;
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC size_t linux64_core_dcache_size_log2_get(void)
+{
+    return linux64_cache_size_log2;
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC void linux64_core_dcache_invalidate(void)
+{
+	dcache_invalidate_count++;
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC void linux64_core_dcache_flush(void)
+{
+	dcache_flush_count++;
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC void linux64_core_dcache_fence(void)
+{
+	dcache_fence_count++;
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC void linux64_core_dcache_prefetch_line(void)
+{
+	dcache_line_prefetch_count++;
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC void linux64_core_dcache_invalidate_line(void)
+{
+	dcache_line_invalidate_count++;
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ * @todo TODO: this should be platform independent.
+ */
+PUBLIC void linux64_core_dcache_dump_info(void)
+{
+	kprintf("dcache_line_size = %d B", linux64_core_dcache_line_size_get());
+	kprintf("dcache_line_size_log2 = %d B", linux64_core_dcache_line_size_log2_get());
+	kprintf("dcache_size = %d B", linux64_core_dcache_size_get());
+	kprintf("dcache_size_log2 = %d B", linux64_core_dcache_size_log2_get());
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ * @todo TODO: this should be platform independent.
+ */
+PUBLIC void linux64_core_dcache_dump_stats(void)
+{
+	kprintf("dcache_invalidate = %d", dcache_invalidate_count);
+	kprintf("dcache_flush = %d", dcache_flush_count);
+	kprintf("dcache_fence = %d", dcache_fence_count);
+	kprintf("dcache_line_prefetch = %d", dcache_line_prefetch_count);
+	kprintf("dcache_line_invalidate = %d", dcache_line_invalidate_count);
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC void linux64_core_dcache_setup(void)
+{
+	/*
+	 * Retrieve dimension of cache line size. Note that we
+	 * intentionally truncate the line size to a of power 2, because
+	 * that may not be true in some archs.
+	 */
+	linux64_cache_line_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
+	linux64_cache_line_size_log2 = log2(linux64_cache_line_size);
+	linux64_cache_line_size = pow(2, linux64_cache_line_size_log2);
+
+	/*
+	 * Retrieve dimension of cache. Note that we intentionally
+	 * truncate the line size to a of power 2, because that may not be
+	 * true in some archs.
+	 */
+	linux64_cache_size = sysconf(_SC_LEVEL1_DCACHE_SIZE);
+	linux64_cache_size_log2 = log2(linux64_cache_size);
+	linux64_cache_size = pow(2, linux64_cache_size_log2);
+}
+
+/*============================================================================*
+ * Instruction Cache                                                          *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC void linux64_core_icache_invalidate(void)
+{
+	icache_invalidate_count++;
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC void linux64_core_icache_line_prefetch(void)
+{
+	icache_line_prefetch_count++;
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC void linux64_core_icache_line_invalidate(void)
+{
+	icache_line_invalidate_count++;
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ * @todo TODO: implement this function.
+ */
+PUBLIC void linux64_core_icache_setup(void)
+{
+}
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ * @todo TODO: this should be platform independent.
+ */
+PUBLIC void linux64_core_icache_dump_stats(void)
+{
+	kprintf("icache_invalidate = %d", icache_invalidate_count);
+	kprintf("icache_line_prefetch = %d", icache_line_prefetch_count);
+	kprintf("icache_line_invalidate = %d", icache_line_invalidate_count);
+}

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -26,6 +26,7 @@
 #include <nanvix/const.h>
 #include <nanvix/klib.h>
 #include <nanvix/const.h>
+#include <nanvix/hal/core/cache.h>
 #include "test.h"
 
 #ifndef __unix64__


### PR DESCRIPTION
Description
---------------

In this PR we introduce the Memory Cache Interface for the UNIX 64-bit target.

Related Issues
---------------------

- [[linux64-core] Memory Cache Interface](https://github.com/nanvix/hal/issues/444)
- [[hal] Extensions for Memory Cache Interface](https://github.com/nanvix/hal/issues/232)