### PR TITLE
[openrisc] Enhancement: Cache Setup

### DIFF
--- a/include/arch/core/or1k/cache.h
+++ b/include/arch/core/or1k/cache.h
@@ -57,6 +57,16 @@
 		or1k_mtspr(OR1K_SPR_DCBIR, 0);
 	}
 
+	/**
+	 * @brief Setup the instruction cache.
+	 */
+	EXTERN void or1k_icache_setup(void);
+
+	/**
+	 * @brief Setup the data cache.
+	 */
+	EXTERN void or1k_dcache_setup(void);
+
 #endif /* _ASM_FILE_ */
 
 /**@}*/
@@ -89,6 +99,22 @@
 	static inline void dcache_invalidate(void)
 	{
 		or1k_dcache_inval();
+	}
+
+	/**
+	 * @see or1k_icache_setup
+	 */
+	static inline void icache_setup(void)
+	{
+		or1k_icache_setup();
+	}
+
+	/**
+	 * @see or1k_dcache_setup
+	 */
+	static inline void dcache_setup(void)
+	{
+		or1k_dcache_setup();
 	}
 
 #endif /* !_ASM_FILE_ */

--- a/src/hal/arch/cluster/or1k-cluster/boot_code.S
+++ b/src/hal/arch/cluster/or1k-cluster/boot_code.S
@@ -36,6 +36,8 @@
 /* Exported symbols. */
 .globl start
 .globl kstacks
+.globl or1k_icache_setup
+.globl or1k_dcache_setup
 
 /*============================================================================*
  *                              bootstrap section                             *
@@ -58,6 +60,14 @@ start:
 	l.ori	r1, r0, 0x1
 	l.mtspr	r0, r1, OR1K_SPR_SR
 
+	/* Enable Instruction Cache. */
+	l.jal or1k_icache_setup
+	l.nop
+
+	/* Enable Data Cache. */
+	l.jal or1k_dcache_setup
+	l.nop
+
 	/* Reset stack. */
 	l.mfspr r3, r0, OR1K_SPR_COREID
 	or1k_core_stack_reset r3
@@ -78,3 +88,130 @@ start:
 		l.jal or1k_cluster_master_setup
 		l.nop
 		halt
+
+/*----------------------------------------------------------------------------*
+ *                           or1k_icache_setup                                *
+ *----------------------------------------------------------------------------*/
+
+or1k_icache_setup:
+	/* Check if IC present and skip enabling otherwise */
+	l.mfspr r24, r0,  OR1K_SPR_UPR
+	l.andi  r26, r24, OR1K_SPR_UPR_ICP
+	l.sfeq  r26, r0
+	l.bf	9f
+	l.nop
+
+	/* Disable IC */
+	l.mfspr r6, r0, OR1K_SPR_SR
+	l.addi  r5, r0, -1
+	l.xori  r5, r5, OR1K_SPR_SR_ICE
+	l.and   r5, r6, r5
+	l.mtspr r0, r5, OR1K_SPR_SR
+
+	/* 
+	 * Establish cache block size
+	 * If BS=0, 16;
+	 * If BS=1, 32;
+	 * r14 contain block size
+	 */
+	l.mfspr r24, r0,  OR1K_SPR_ICCFGR
+	l.andi	r26, r24, OR1K_SPR_ICCFGR_CBS
+	l.srli	r28, r26, 7
+	l.ori	r30, r0,  16
+	l.sll	r14, r30, r28
+
+	/*
+	 * Establish number of cache sets
+	 * r16 contains number of cache sets
+	 * r28 contains log(# of cache sets)
+	 */
+	l.andi  r26, r24, OR1K_SPR_ICCFGR_NCS
+	l.srli 	r28, r26, 3
+	l.ori   r30, r0,  1
+	l.sll   r16, r30, r28
+
+	/* Invalidate IC */
+	l.addi  r6, r0,  0
+	l.sll   r5, r14, r28
+
+1:
+	l.mtspr r0, r6, OR1K_SPR_ICBIR
+	l.sfne  r6, r5
+	l.bf    1b
+	l.add   r6, r6, r14
+
+	/* Enable IC */
+	l.mfspr r6, r0, OR1K_SPR_SR
+	l.ori   r6, r6, OR1K_SPR_SR_ICE
+	l.mtspr r0, r6, OR1K_SPR_SR
+	l.nop
+	l.nop
+	l.nop
+	l.nop
+	l.nop
+	l.nop
+	l.nop
+	l.nop
+	l.nop
+	l.nop
+9:
+	l.jr    r9
+	l.nop
+
+/*----------------------------------------------------------------------------*
+ *                           or1k_dcache_setup                                *
+ *----------------------------------------------------------------------------*/
+
+or1k_dcache_setup:
+	/* Check if DC present and skip enabling otherwise */
+	l.mfspr r24, r0,  OR1K_SPR_UPR
+	l.andi  r26, r24, OR1K_SPR_UPR_DCP
+	l.sfeq  r26, r0
+	l.bf	9f
+	l.nop
+
+	/* Disable DC */
+	l.mfspr r6, r0, OR1K_SPR_SR
+	l.addi  r5, r0, -1
+	l.xori  r5, r5, OR1K_SPR_SR_DCE
+	l.and   r5, r6, r5
+	l.mtspr r0, r5, OR1K_SPR_SR
+
+	/*
+	 * Establish cache block size
+	 * If BS=0, 16;
+	 * If BS=1, 32;
+	 * r14 contain block size
+	 */
+	l.mfspr r24, r0,  OR1K_SPR_DCCFGR
+	l.andi	r26, r24, OR1K_SPR_DCCFGR_CBS
+	l.srli	r28, r26, 7
+	l.ori	r30, r0,  16
+	l.sll	r14, r30, r28
+
+	/*
+	 * Establish number of cache sets
+	 * r16 contains number of cache sets
+	 * r28 contains log(# of cache sets)
+	 */
+	l.andi  r26, r24, OR1K_SPR_DCCFGR_NCS
+	l.srli 	r28, r26, 3
+	l.ori   r30, r0,  1
+	l.sll   r16, r30, r28
+
+	/* Invalidate DC */
+	l.addi  r6, r0,  0
+	l.sll   r5, r14, r28
+1:
+	l.mtspr r0, r6, OR1K_SPR_DCBIR
+	l.sfne  r6, r5
+	l.bf    1b
+	l.add   r6, r6, r14
+
+	/* Enable DC */
+	l.mfspr r6, r0, OR1K_SPR_SR
+	l.ori   r6, r6, OR1K_SPR_SR_DCE
+	l.mtspr r0, r6, OR1K_SPR_SR
+9:
+	l.jr    r9
+	l.nop


### PR DESCRIPTION
Description
---------------
This PR implements the functions `icache_setup()` and `dcache_setup()` found on issue #232. Although currently none of the targets supports cache, the routines above are smart enough to verify if the cache is present and only if, the cache will be enabled properly.

Related Issues
--------------------
[[hal] Extensions for Memory Cache Interface](https://github.com/nanvix/hal/issues/232)