### PR TITLE
[openrisc] Bootstrap Link Variables

### DIFF
--- a/build/optimsoc/linker/link.ld
+++ b/build/optimsoc/linker/link.ld
@@ -38,8 +38,10 @@ SECTIONS
 	/* Kernel code section. */
 	.bootstrap : AT(ADDR(.bootstrap))
 	{
+		__BOOTSTRAP_START = .;
 		*hooks*.o
 		*boot_code*.o
+		__BOOTSTRAP_END = .;
 	}
 
 	. = ALIGN(8192);

--- a/build/qemu-openrisc/linker/link.ld
+++ b/build/qemu-openrisc/linker/link.ld
@@ -38,8 +38,10 @@ SECTIONS
 	/* Kernel code section. */
 	.bootstrap : AT(ADDR(.bootstrap))
 	{
+		__BOOTSTRAP_START = .;
 		*hooks*.o
 		*boot_code*.o
+		__BOOTSTRAP_END = .;
 	}
 
 	. = ALIGN(8192);

--- a/include/arch/cluster/optimsoc-cluster/memory.h
+++ b/include/arch/cluster/optimsoc-cluster/memory.h
@@ -173,12 +173,14 @@
 	 * @brief Binary Sections
 	 */
 	/**@{*/
-	EXTERN unsigned char __TEXT_START; /**< Text Start */
-	EXTERN unsigned char __TEXT_END;   /**< Text End   */
-	EXTERN unsigned char __DATA_START; /**< Data Start */
-	EXTERN unsigned char __DATA_END;   /**< Data End   */
-	EXTERN unsigned char __BSS_START;  /**< BSS Start  */
-	EXTERN unsigned char __BSS_END;    /**< BSS End    */
+	EXTERN unsigned char __BOOTSTRAP_START; /**< Bootstrap Start */
+	EXTERN unsigned char __BOOTSTRAP_END;   /**< Bootstrap End   */
+	EXTERN unsigned char __TEXT_START;      /**< Text Start      */
+	EXTERN unsigned char __TEXT_END;        /**< Text End        */
+	EXTERN unsigned char __DATA_START;      /**< Data Start      */
+	EXTERN unsigned char __DATA_END;        /**< Data End        */
+	EXTERN unsigned char __BSS_START;       /**< BSS Start       */
+	EXTERN unsigned char __BSS_END;         /**< BSS End         */
 	/**@}*/
 
 #ifdef __NANVIX_HAL

--- a/include/arch/cluster/or1k-cluster/memory.h
+++ b/include/arch/cluster/or1k-cluster/memory.h
@@ -126,12 +126,14 @@
 	 * @brief Binary Sections
 	 */
 	/**@{*/
-	EXTERN unsigned char __TEXT_START; /**< Text Start */
-	EXTERN unsigned char __TEXT_END;   /**< Text End   */
-	EXTERN unsigned char __DATA_START; /**< Data Start */
-	EXTERN unsigned char __DATA_END;   /**< Data End   */
-	EXTERN unsigned char __BSS_START;  /**< BSS Start  */
-	EXTERN unsigned char __BSS_END;    /**< BSS End    */
+	EXTERN unsigned char __BOOTSTRAP_START; /**< Bootstrap Start */
+	EXTERN unsigned char __BOOTSTRAP_END;   /**< Bootstrap End   */
+	EXTERN unsigned char __TEXT_START;      /**< Text Start      */
+	EXTERN unsigned char __TEXT_END;        /**< Text End        */
+	EXTERN unsigned char __DATA_START;      /**< Data Start      */
+	EXTERN unsigned char __DATA_END;        /**< Data End        */
+	EXTERN unsigned char __BSS_START;       /**< BSS Start       */
+	EXTERN unsigned char __BSS_END;         /**< BSS End         */
 	/**@}*/
 
 #ifdef __NANVIX_HAL


### PR DESCRIPTION
Description
---------------
This PR adds the bootstrap variables required to the linker scripts for both qemu-openrisc and optimsoc targets.

Related Issues
-------------------
[[hal] Platform Independent Link Variables](https://github.com/nanvix/hal/issues/410)