### PR TITLE
[hal] Bad Cache Inval in Spinlock Release

### DIFF
--- a/include/arch/core/i486/spinlock.h
+++ b/include/arch/core/i486/spinlock.h
@@ -111,8 +111,8 @@
 	 */
 	static inline void i486_spinlock_unlock(i486_spinlock_t *lock)
 	{
-		__sync_synchronize();
 		*lock = I486_SPINLOCK_UNLOCKED;
+		__sync_synchronize();
 	}
 
 /**@}*/

--- a/include/arch/core/k1b/spinlock.h
+++ b/include/arch/core/k1b/spinlock.h
@@ -96,8 +96,8 @@
 	 */
 	static inline void k1b_spinlock_unlock(k1b_spinlock_t *lock)
 	{
-		k1b_dcache_inval();
 		__builtin_k1_sdu(lock, K1B_SPINLOCK_UNLOCKED);
+		k1b_dcache_inval();
 	}
 
 #endif /* !_ASM_FILE */

--- a/include/arch/core/or1k/spinlock.h
+++ b/include/arch/core/or1k/spinlock.h
@@ -107,8 +107,8 @@
 	 */
 	static inline void or1k_spinlock_unlock(or1k_spinlock_t *lock)
 	{
-		__sync_synchronize();
 		*lock = OR1K_SPINLOCK_UNLOCKED;
+		__sync_synchronize();
 	}
 
 #endif

--- a/include/arch/core/rv32gc/spinlock.h
+++ b/include/arch/core/rv32gc/spinlock.h
@@ -115,8 +115,8 @@
 	 */
 	static inline void rv32gc_spinlock_unlock(rv32gc_spinlock_t *lock)
 	{
-		__sync_synchronize();
 		*lock = RV32GC_SPINLOCK_UNLOCKED;
+		__sync_synchronize();
 	}
 
 #endif


### PR DESCRIPTION
Descrption
---------------

Previously, in the spinlock_unlock() operation we were flushing/invalidating the cache in before releasing the lock. As a consequence, the semantics of the unlock operation would not be correct.

Related Issues
--------------------

- [[mppa256] Startup Fence Blocks Master Core](https://github.com/nanvix/hal/issues/476)