### PR TITLE
[hal] Timer Interface Extensions

### DIFF
--- a/include/arch/cluster/k1b-cluster.h
+++ b/include/arch/cluster/k1b-cluster.h
@@ -62,6 +62,7 @@
 		#define CLUSTER_IS_COMPUTE 1 /**< Compute Cluster   */
 	#endif
 	#define CLUSTER_HAS_EVENTS     1 /**< Event Support?    */
+	#define CLUSTER_HAS_RTC        1 /**< RTC Support?      */
 	/**@}*/
 
 /**@}*/

--- a/include/arch/cluster/linux64-cluster.h
+++ b/include/arch/cluster/linux64-cluster.h
@@ -54,6 +54,7 @@
 	#define CLUSTER_IS_IO         1 /**< I/O Cluster       */
 	#define CLUSTER_IS_COMPUTE    0 /**< Compute Cluster   */
 	#define CLUSTER_HAS_EVENTS    0 /**< Event Support?    */
+	#define CLUSTER_HAS_RTC       1 /**< RTC Support?      */
 	/**@}*/
 
 /**@}*/

--- a/include/arch/cluster/optimsoc-cluster.h
+++ b/include/arch/cluster/optimsoc-cluster.h
@@ -53,6 +53,7 @@
 	#define CLUSTER_IS_IO         1 /**< I/O Cluster       */
 	#define CLUSTER_IS_COMPUTE    0 /**< Compute Cluster   */
 	#define CLUSTER_HAS_EVENTS    0 /**< Event Support?    */
+	#define CLUSTER_HAS_RTC       0 /**< RTC Support?      */
 	/**@}*/
 
 /**@}*/

--- a/include/arch/cluster/optimsoc-cluster/timer.h
+++ b/include/arch/cluster/optimsoc-cluster/timer.h
@@ -44,22 +44,6 @@
 	 */
 	#define OR1K_CLUSTER_FREQUENCY 50000000
 
-#ifndef _ASM_FILE_
-
-	/**
-	 * @brief Stub function.
-	 *
-	 * @returns Always zero.
-	 *
-	 * @todo TODO implement this function.
-	 */
-	static inline uint64_t optimsoc_cluster_clock_read(void)
-	{
-		return (0);
-	}
-
-#endif /* !_ASM_FILE_ */
-
 /*============================================================================*
  * Exported Interface                                                         *
  *============================================================================*/
@@ -100,14 +84,6 @@
 	static inline void timer_reset(void)
 	{
 		or1k_timer_reset();
-	}
-
-	/**
-	 * @see optimsoc_cluster_clock_read().
-	 */
-	static inline uint64_t clock_read(void)
-	{
-		return (optimsoc_cluster_clock_read());
 	}
 
 #endif /* !_ASM_FILE_ */

--- a/include/arch/cluster/optimsoc-cluster/timer.h
+++ b/include/arch/cluster/optimsoc-cluster/timer.h
@@ -42,7 +42,7 @@
 	/**
 	 * @brief Estimated CPU frequency (in Hz), 50Mhz.
 	 */
-	#define OR1K_CLUSTER_FREQUENCY 50000000
+	#define OR1K_CLUSTER_FREQUENCY OR1K_CORE_FREQUENCY
 
 /*============================================================================*
  * Exported Interface                                                         *

--- a/include/arch/cluster/or1k-cluster.h
+++ b/include/arch/cluster/or1k-cluster.h
@@ -54,6 +54,7 @@
 	#define CLUSTER_IS_IO         1 /**< I/O Cluster       */
 	#define CLUSTER_IS_COMPUTE    0 /**< Compute Cluster   */
 	#define CLUSTER_HAS_EVENTS    1 /**< Event Support?    */
+	#define CLUSTER_HAS_RTC       0 /**< RTC Support?      */
 	/**@}*/
 
 /**@}*/

--- a/include/arch/cluster/or1k-cluster/timer.h
+++ b/include/arch/cluster/or1k-cluster/timer.h
@@ -44,22 +44,6 @@
 	 */
 	#define OR1K_CLUSTER_FREQUENCY 20000000
 
-#ifndef _ASM_FILE_
-
-	/**
-	 * @brief Stub function.
-	 *
-	 * @returns Always zero.
-	 *
-	 * @todo TODO implement this function.
-	 */
-	static inline uint64_t or1k_cluster_clock_read(void)
-	{
-		return (0);
-	}
-
-#endif /* !_ASM_FILE_ */
-
 /*============================================================================*
  * Exported Interface                                                         *
  *============================================================================*/
@@ -98,14 +82,6 @@
 	static inline void timer_reset(void)
 	{
 		or1k_timer_reset();
-	}
-
-	/**
-	 * @see or1k_cluster_clock_read().
-	 */
-	static inline uint64_t clock_read(void)
-	{
-		return (or1k_cluster_clock_read());
 	}
 
 /**@endcond*/

--- a/include/arch/cluster/or1k-cluster/timer.h
+++ b/include/arch/cluster/or1k-cluster/timer.h
@@ -42,7 +42,7 @@
 	/**
 	 * @brief Estimated CPU frequency (in Hz), 20Mhz.
 	 */
-	#define OR1K_CLUSTER_FREQUENCY 20000000
+	#define OR1K_CLUSTER_FREQUENCY OR1K_CORE_FREQUENCY
 
 /*============================================================================*
  * Exported Interface                                                         *

--- a/include/arch/cluster/riscv32-cluster.h
+++ b/include/arch/cluster/riscv32-cluster.h
@@ -53,6 +53,7 @@
 	#define CLUSTER_IS_IO         1 /**< I/O Cluster       */
 	#define CLUSTER_IS_COMPUTE    0 /**< Compute Cluster   */
 	#define CLUSTER_HAS_EVENTS    1 /**< Event Support?    */
+	#define CLUSTER_HAS_RTC       0 /**< RTC Support?      */
 	/**@}*/
 
 /**@}*/

--- a/include/arch/cluster/riscv32-cluster/timer.h
+++ b/include/arch/cluster/riscv32-cluster/timer.h
@@ -47,22 +47,6 @@
 	 */
 	#define RISCV32_CLUSTER_TIMEBASE 10000000
 
-#ifndef _ASM_FILE_
-
-	/**
-	 * @brief Stub function.
-	 *
-	 * @returns Always zero.
-	 *
-	 * @todo TODO implement this function.
-	 */
-	static inline uint64_t riscv32_cluster_clock_read(void)
-	{
-		return (0);
-	}
-
-#endif /* !_ASM_FILE_ */
-
 /*============================================================================*
  * Exported Interface                                                         *
  *============================================================================*/
@@ -110,14 +94,6 @@
 		rv32gc_timer_reset();
 	}
 
-	/**
-	 * @see riscv32_cluster_clock_read().
-	 */
-	static inline uint64_t clock_read(void)
-	{
-		return (riscv32_cluster_clock_read());
-	}
-
 #endif /* !_ASM_FILE_ */
 
 /**@endcond*/
@@ -127,4 +103,3 @@
 /**@}*/
 
 #endif /* ARCH_CLUSTER_CLUSTER_RISCV32_CLUSTER_TIMER */
-

--- a/include/arch/cluster/x86-cluster.h
+++ b/include/arch/cluster/x86-cluster.h
@@ -44,6 +44,7 @@
  */
 /**@{*/
 
+	#include <arch/cluster/x86-cluster/timer.h>
 	#include <arch/cluster/x86-cluster/cores.h>
 	#include <arch/cluster/x86-cluster/memory.h>
 
@@ -55,6 +56,7 @@
 	#define CLUSTER_IS_IO         1 /**< I/O Cluster       */
 	#define CLUSTER_IS_COMPUTE    0 /**< Compute Cluster   */
 	#define CLUSTER_HAS_EVENTS    0 /**< Event Support?    */
+	#define CLUSTER_HAS_RTC       0 /**< RTC Support?      */
 	/**@}*/
 
 /**@}*/

--- a/include/arch/cluster/x86-cluster/timer.h
+++ b/include/arch/cluster/x86-cluster/timer.h
@@ -1,0 +1,104 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef ARCH_CLUSTER_X86_CLUSTER_TIMER_H_
+#define ARCH_CLUSTER_X86_CLUSTER_TIMER_H_
+
+	/* Cluster Interface Implementation */
+	#include <arch/cluster/x86-cluster/_x86-cluster.h>
+
+/**
+ * @addtogroup x86-cluster-timer Timer
+ * @ingroup x86-cluster
+ *
+ * @brief Integrated Timer Device
+ */
+/**@{*/
+
+	#include <nanvix/const.h>
+	#include <stdint.h>
+
+	/**
+	 * @brief Oscillator frequency (in Hz)
+	 */
+	#define PIT_FREQUENCY 1193182
+
+/*============================================================================*
+ * Exported Interface                                                         *
+ *============================================================================*/
+
+/**
+ * @x86_cluster
+ */
+
+	/**
+	 * @name Exported Constants
+	 */
+	/**@{*/
+	#define CLUSTER_FREQ PIT_FREQUENCY /**< @see PIT_FREQUENCY */
+	/**@}*/
+
+	/**
+	 * @name Registers
+	 */
+	/**@{*/
+	#define PIT_CTRL 0x43 /**< Control */
+	#define PIT_DATA 0x40 /**< Data    */
+	/**@}*/
+
+	/**
+	 * @name Exported Functions
+	 */
+	/**@{*/
+	#define __timer_init_fn  /**< timer_init()  */
+	#define __timer_reset_fn /**< timer_reset() */
+	#define __clock_read_fn  /**< clock_read()  */
+	/**@}*/
+
+#ifndef _ASM_FILE_
+
+	/**
+	 * @see i486_timer_init().
+	 */
+	static inline void timer_init(unsigned freq)
+	{
+		i486_timer_init(freq);
+	}
+
+	/**
+	 * @see i486_timer_reset().
+	 */
+	static inline void timer_reset(void)
+	{
+	}
+
+#endif /* !_ASM_FILE_ */
+
+/**@endcond*/
+
+/*============================================================================*/
+
+/**@}*/
+
+#endif /* ARCH_CLUSTER_X86_CLUSTER_TIMER */

--- a/include/arch/cluster/x86-cluster/timer.h
+++ b/include/arch/cluster/x86-cluster/timer.h
@@ -39,11 +39,6 @@
 	#include <nanvix/const.h>
 	#include <stdint.h>
 
-	/**
-	 * @brief Oscillator frequency (in Hz)
-	 */
-	#define PIT_FREQUENCY 1193182
-
 /*============================================================================*
  * Exported Interface                                                         *
  *============================================================================*/
@@ -57,14 +52,6 @@
 	 */
 	/**@{*/
 	#define CLUSTER_FREQ PIT_FREQUENCY /**< @see PIT_FREQUENCY */
-	/**@}*/
-
-	/**
-	 * @name Registers
-	 */
-	/**@{*/
-	#define PIT_CTRL 0x43 /**< Control */
-	#define PIT_DATA 0x40 /**< Data    */
 	/**@}*/
 
 	/**

--- a/include/arch/core/i486/timer.h
+++ b/include/arch/core/i486/timer.h
@@ -35,25 +35,7 @@
 
 	#include <nanvix/const.h>
 
-	/**
-	 * @name Provided Interface
-	 */
-	/**@{*/
-	#define __timer_init_fn
-	/**@}*/
-
-	/**
-	 * @brief Oscillator frequency (in Hz)
-	 */
-	#define PIT_FREQUENCY 1193182
-
-	/**
-	 * @name Registers
-	 */
-	/**@{*/
-	#define PIT_CTRL 0x43 /**< Control */
-	#define PIT_DATA 0x40 /**< Data    */
-	/**@}*/
+#ifndef _ASM_FILE_
 
 	/**
 	 * @brief Initializes the timer device.
@@ -65,45 +47,10 @@
 	/**
 	 * @brief Resets the timer device.
 	 */
-	static inline void i486_timer_reset(void)
-	{
-	}
+	EXTERN void i486_timer_reset(void);
+
+#endif /* !_ASM_FILE_ */
 
 /**@}*/
 
-/*============================================================================*
- * Exported Interface                                                         *
- *============================================================================*/
-
-/**
- * @cond i486
- */
-
-	/**
-	 * @name Exported functions
-	 */
-	/**@{*/
-	#define __timer_init_fn  /**< timer_init(   */
-	#define __timer_reset_fn /**< timer_reset() */
-	/**@}*/
-
-	/**
-	 * @see i486_timer_init().
-	 */
-	static inline void timer_init(unsigned freq)
-	{
-		i486_timer_init(freq);
-	}
-
-	/**
-	 * @see i486_timer_reset().
-	 */
-	static inline void timer_reset(void)
-	{
-		i486_timer_reset();
-	}
-
-/**@endcond*/
-
 #endif /* ARCH_I486_TIMER_H_ */
-

--- a/include/arch/core/i486/timer.h
+++ b/include/arch/core/i486/timer.h
@@ -38,6 +38,19 @@
 #ifndef _ASM_FILE_
 
 	/**
+	 * @brief Oscillator frequency (in Hz)
+	 */
+	#define PIT_FREQUENCY 1193182
+
+	/**
+	 * @name Registers
+	 */
+	/**@{*/
+	#define PIT_CTRL 0x43 /**< Control */
+	#define PIT_DATA 0x40 /**< Data    */
+	/**@}*/
+
+	/**
 	 * @brief Initializes the timer device.
 	 *
 	 * @param freq Target frequency for the timer device.

--- a/include/arch/core/mor1kx/timer.h
+++ b/include/arch/core/mor1kx/timer.h
@@ -38,6 +38,11 @@
 #ifndef _ASM_FILE_
 
 	/**
+	 * @brief Estimated CPU frequency (in Hz), 50Mhz.
+	 */
+	#define OR1K_CORE_FREQUENCY 50000000
+
+	/**
 	 * @brief Initializes the timer driver in the or1k architecture.
 	 *
 	 * @param freq Target frequency for the timer device.

--- a/include/arch/core/or1k/timer.h
+++ b/include/arch/core/or1k/timer.h
@@ -38,6 +38,11 @@
 #ifndef _ASM_FILE_
 
 	/**
+	 * @brief Estimated CPU frequency (in Hz), 20Mhz.
+	 */
+	#define OR1K_CORE_FREQUENCY 20000000
+
+	/**
 	 * @brief Initializes the timer driver in the or1k architecture.
 	 *
 	 * @param freq Target frequency for the timer device.

--- a/include/nanvix/hal/cluster/timer.h
+++ b/include/nanvix/hal/cluster/timer.h
@@ -68,6 +68,12 @@
 	#include <stdint.h>
 
 	/**
+	 * @brief Simulated clock for architectures that do not
+	 * have Real Time Clock (RTC).
+	 */
+	EXTERN uint64_t timer_value;
+
+	/**
 	 * @brief Initializes the timer device.
 	 *
 	 * @param freq Frequency for the timer device.
@@ -85,10 +91,20 @@
 
 	/**
 	 * @brief Returns the clock value.
+	 *
+	 * If the current architecture have an appropriate Real
+	 * Time Clock, exports the function, otherwise, uses the
+	 * counter provided by the HAL.
 	 */
+#if (CLUSTER_HAS_RTC)
 	EXTERN uint64_t clock_read(void);
+#else
+	static inline uint64_t clock_read(void)
+	{
+		return (timer_value);
+	}
+#endif
 
 /**@}*/
 
 #endif /* NANVIX_HAL_CLUSTER_TIMER_H_ */
-

--- a/src/hal/arch/core/i486/timer.c
+++ b/src/hal/arch/core/i486/timer.c
@@ -22,8 +22,10 @@
  * SOFTWARE.
  */
 
-#include <nanvix/hal/hal.h>
+#include <arch/core/i486/timer.h>
+#include <arch/core/i486/pmio.h>
 #include <nanvix/const.h>
+#include <stdint.h>
 
 /**
  * The i486_timer_init() function initializes the timer driver in the
@@ -43,4 +45,3 @@ PUBLIC void i486_timer_init(unsigned freq)
 	i486_output8(PIT_DATA, (uint8_t)(freq_divisor & 0xff));
 	i486_output8(PIT_DATA, (uint8_t)((freq_divisor >> 8)));
 }
-

--- a/src/hal/arch/core/i486/timer.c
+++ b/src/hal/arch/core/i486/timer.c
@@ -22,9 +22,8 @@
  * SOFTWARE.
  */
 
+#include <nanvix/hal/hal.h>
 #include <nanvix/const.h>
-#include <arch/core/i486/timer.h>
-#include <arch/core/i486/pmio.h>
 
 /**
  * The i486_timer_init() function initializes the timer driver in the

--- a/src/hal/arch/core/or1k/timer.c
+++ b/src/hal/arch/core/or1k/timer.c
@@ -22,9 +22,17 @@
  * SOFTWARE.
  */
 
-#include <nanvix/hal/hal.h>
+#if (defined(__qemu_openrisc__))
+	#include <arch/core/or1k/timer.h>
+#elif (defined(__optimsoc__))
+	#include <arch/core/mor1kx/timer.h>
+#endif
+
+#define __NEED_OR1K_REGS
+#include <arch/core/or1k/regs.h>
 #include <nanvix/const.h>
 #include <nanvix/klib.h>
+#include <stdint.h>
 
 /**
  * @brief Was the timer device initialized?
@@ -98,7 +106,7 @@ PUBLIC void or1k_timer_init(unsigned freq)
 		while (1);
 
 	/* Timer rate. */
-	timer_delta = (OR1K_CLUSTER_FREQUENCY/freq);
+	timer_delta = (OR1K_CORE_FREQUENCY/freq);
 
 	/*
 	 * Timer calibrate.

--- a/src/hal/core/interrupt.c
+++ b/src/hal/core/interrupt.c
@@ -46,6 +46,11 @@ PRIVATE interrupt_handler_t event_handler = NULL;
 PRIVATE unsigned spurious = 0;
 
 /**
+ * @brief Timer value for archs that lacks RTC.
+ */
+PUBLIC uint64_t timer_value = 0;
+
+/**
  * @brief Default hardware interrupt handler.
  *
  * @param num Number of triggered interrupt.
@@ -66,6 +71,9 @@ PRIVATE void default_handler(int num)
  */
 PRIVATE void do_timer(int num)
 {
+	/* Increment timer value. */
+	timer_value++;
+
 	/* Forward timer interrupt handling. */
 	if (timer_handler != NULL)
 		timer_handler(num);


### PR DESCRIPTION
Description
---------------
This PR adds the timer extensions described in #420 for all currently supported targets, which means that for all architectures that do not have a separate hardware clock counter (like the Time-Stamp Counter in x86), a counter introduced by the HAL will be used instead.

Related Issues
--------------------
- [[hal] Timer Interface Extensions](https://github.com/nanvix/hal/issues/420)