### PR TITLE
[x86-cluster] Enhancing Virtual Memory Setup

### DIFF
--- a/build/qemu-x86/linker/link.ld
+++ b/build/qemu-x86/linker/link.ld
@@ -34,38 +34,46 @@ SECTIONS
 	/* Bootstrap section. */
 	.bootstrap :
 	{
+		__BOOTSTRAP_START = .;
 		*boot*.o *(.bootstrap)
+		__BOOTSTRAP_END = .;
 	}
 
-	. += 0xc0000000;
+	. =ALIGN(4096);
 
 	/* Kernel code section. */
-	.text ALIGN(4096) : AT(ADDR(.text) - 0xc0000000)
-   {
-       *(.text)
-       *(.rodata)
-   }
+	.text ALIGN(4096) : AT(ADDR(.text))
+	{
+		__TEXT_START = .;
+		*(.text)
+		*(.rodata)
+		__TEXT_END = .;
+	}
 
-   /* Initialized kernel data section. */
-   .data ALIGN(4096) : AT(ADDR(.data) - 0xc0000000)
-   {
-       *(.data)
-   }
+	/* Initialized kernel data section. */
+	.data ALIGN(4096) : AT(ADDR(.data))
+	{
+		__DATA_START = .;
+		*(.data)
+		__DATA_END = .;
+	}
 
-   /* Uninitialized kernel data section. */
-   .bss : AT(ADDR(.bss) - 0xc0000000)
-   {
-       *(.bss)
-   }
+	/* Uninitialized kernel data section. */
+	.bss : AT(ADDR(.bss))
+	{
+		__BSS_START = .;
+		*(.bss)
+		__BSS_END = .;
+	}
 
-   . =ALIGN(4096);
+	. =ALIGN(4096);
 
-   KDATA_END = .;
+	KDATA_END = .;
 
-   /* Discarded. */
-   /DISCARD/ :
-   {
-        *(.comment)
-        *(.note)
-   }
+	/* Discarded. */
+	/DISCARD/ :
+	{
+		*(.comment)
+		*(.note)
+	}
 }

--- a/include/arch/cluster/x86-cluster/cores.h
+++ b/include/arch/cluster/x86-cluster/cores.h
@@ -46,6 +46,13 @@
 	 */
 	#define X86_CLUSTER_COREID_MASTER 0
 
+#ifndef _ASM_FILE_
+
+	/**
+	 * @brief Initializes the underlying cluster.
+	 */
+	EXTERN void x86_cluster_setup(void);
+
 	/**
 	 * @brief Gets the number of cores.
 	 *
@@ -58,6 +65,8 @@
 	{
 		return (X86_CLUSTER_NUM_CORES);
 	}
+
+#endif /* _ASM_FILE_ */
 
 /**@}*/
 
@@ -86,6 +95,7 @@
 	 */
 	#define COREID_MASTER X86_CLUSTER_COREID_MASTER
 
+#ifndef _ASM_FILE_
 #ifdef __NANVIX_HAL
 
 	/**
@@ -97,6 +107,7 @@
 	}
 
 #endif /* __NANVIX_HAL */
+#endif /* _ASM_FILE_ */
 
 /**@endcond*/
 

--- a/include/arch/cluster/x86-cluster/memmap.h
+++ b/include/arch/cluster/x86-cluster/memmap.h
@@ -22,47 +22,38 @@
  * SOFTWARE.
  */
 
-#ifndef ARCH_I486_CACHE_H_
-#define ARCH_I486_CACHE_H_
+#ifndef CLUSTER_X86_CLUSTER_MEMMAP_H_
+#define CLUSTER_X86_CLUSTER_MEMMAP_H_
+
+	#ifndef __NEED_CLUSTER_MEMMAP
+		#error "do not include this file"
+	#endif
+
+	/* Cluster Interface Implementation */
+	#include <arch/cluster/x86-cluster/_x86-cluster.h>
 
 /**
- * @addtogroup i486-core-cache Cache
- * @ingroup i486-core
+ * @addtogroup x86_cluster-cluster-memmap Memory Map
+ * @ingroup x86_cluster-cluster
  *
- * @brief Memory Cache
+ * @brief Physical memory map.
  */
 /**@{*/
 
 	/**
-	 * @name Provided Interface
+	 * @name Physical Memory Layout
 	 */
 	/**@{*/
-	#define __dcache_invalidate_fn
+	#define X86_CLUSTER_DRAM_BASE_PHYS 0x00000000 /**< DRAM Base */
+	#define X86_CLUSTER_DRAM_END_PHYS  0x04000000 /**< DRAM End  */
 	/**@}*/
 
 	/**
-	 * @brief Cache line size (in bytes).
-	 *
-	 * @bug The cache line size of i486 may change.
+	 * @brief DRAM brief (in bytes).
 	 */
-	#define I486_CACHE_LINE_SIZE 64
-
-	/**
-	 * @see I486_CACHE_LINE_SIZE
-	 */
-	#define CACHE_LINE_SIZE I486_CACHE_LINE_SIZE
-
-#ifndef _ASM_FILE_
-
-	/**
-	 * @note The i486 target features cache coherency.
-	 */
-	static inline void dcache_invalidate(void)
-	{
-	}
-
-#endif /* _ASM_FILE_ */
+	#define X86_CLUSTER_DRAM_SIZE \
+		(X86_CLUSTER_DRAM_END_PHYS - X86_CLUSTER_DRAM_BASE_PHYS)
 
 /**@}*/
 
-#endif /* ARCH_I486_CACHE_H_ */
+#endif /* CLUSTER_X86_CLUSTER_MEMMAP_H_ */

--- a/include/arch/cluster/x86-cluster/memory.h
+++ b/include/arch/cluster/x86-cluster/memory.h
@@ -22,63 +22,107 @@
  * SOFTWARE.
  */
 
-#ifndef CLUSTER_X86_MEMORY_H_
-#define CLUSTER_X86_MEMORY_H_
+#ifndef CLUSTER_X86_CLUSTER_MEMORY_H_
+#define CLUSTER_X86_CLUSTER_MEMORY_H_
 
 	/* Cluster Interface Implementation */
 	#include <arch/cluster/x86-cluster/_x86-cluster.h>
 
 /**
- * @addtogroup i486-cluster-mem Memory
- * @ingroup i486-cluster
+ * @addtogroup x86-cluster-mem Memory
+ * @ingroup x86-cluster
  *
  * @brief Memory System
  */
 /**@{*/
 
-	/**
-	 * @brief Memory size (in bytes).
-	 */
-	#define I486_MEM_SIZE (32*1024*1024)
+	/* Must come first. */
+	#define __NEED_CLUSTER_MEMMAP
 
-	/**
-	 * @brief Kernel memory size (in bytes).
-	 */
-	#define I486_KMEM_SIZE (16*1024*1024)
-
-	/**
-	 * @brief Kernel page pool size (in bytes).
-	 */
-	#define I486_KPOOL_SIZE (4*1024*1024)
-
-	/**
-	 * @brief User memory size (in bytes).
-	 */
-	#define I486_UMEM_SIZE (I486_MEM_SIZE - I486_KMEM_SIZE - I486_KPOOL_SIZE)
-
-	/**
-	 * @brief Kernel stack size (in bytes).
-	 */
-	#define I486_KSTACK_SIZE I486_PAGE_SIZE
-
-	/**
-	 * @name Virtual Memory Layout
-	 */
-	/**@{*/
-	#define I486_USER_BASE_VIRT   0x02000000 /**< User Base             */
-	#define I486_USTACK_BASE_VIRT 0xc0000000 /**< User Stack Base       */
-	#define I486_KERNEL_BASE_VIRT 0xc0000000 /**< Kernel Base           */
-	#define I486_KPOOL_BASE_VIRT  0xc1000000 /**< Kernel Page Pool Base */
-	/**@}*/
+	#include <nanvix/const.h>
+	#include <arch/cluster/x86-cluster/memmap.h>
 
 	/**
 	 * @name Physical Memory Layout
 	 */
 	/**@{*/
-	#define I486_KERNEL_BASE_PHYS 0x00000000 /**< Kernel Base           */
-	#define I486_KPOOL_BASE_PHYS  0x01000000 /**< Kernel Page Pool Base */
-	#define I486_USER_BASE_PHYS   0x02000000 /**< User Base             */
+	#define X86_CLUSTER_KERNEL_BASE_PHYS X86_CLUSTER_DRAM_BASE_PHYS                       /**< Kernel Code and Data */
+	#define X86_CLUSTER_KERNEL_END_PHYS  (X86_CLUSTER_KERNEL_BASE_PHYS + I486_PGTAB_SIZE) /**< Kernel End           */
+	#define X86_CLUSTER_KPOOL_BASE_PHYS  (X86_CLUSTER_KERNEL_END_PHYS  + I486_PGTAB_SIZE) /**< Kernel Page Pool     */
+	#define X86_CLUSTER_KPOOL_END_PHYS   (X86_CLUSTER_KPOOL_BASE_PHYS  + I486_PGTAB_SIZE) /**< Kernel Pool End      */
+	#define X86_CLUSTER_USER_BASE_PHYS   X86_CLUSTER_KPOOL_END_PHYS                       /**< User Base            */
+	#define X86_CLUSTER_USER_END_PHYS    X86_CLUSTER_DRAM_END_PHYS                        /**< User End             */
 	/**@}*/
+
+	/**
+	 * @name Virtual Memory Layout
+	 */
+	/**@{*/
+	#define X86_CLUSTER_KERNEL_BASE_VIRT X86_CLUSTER_KERNEL_BASE_PHYS  /**< Kernel Code and Data */
+	#define X86_CLUSTER_KERNEL_END_VIRT  X86_CLUSTER_KERNEL_END_PHYS   /**< Kernel End           */
+	#define X86_CLUSTER_KPOOL_BASE_VIRT  X86_CLUSTER_KPOOL_BASE_PHYS   /**< Kernel Page Pool     */
+	#define X86_CLUSTER_KPOOL_END_VIRT   X86_CLUSTER_KPOOL_END_PHYS    /**< Kernel Pool End      */
+	#define X86_CLUSTER_USER_BASE_VIRT   0xa0000000                    /**< User Base            */
+	#define X86_CLUSTER_USER_END_VIRT    0xc0000000                    /**< User End             */
+	#define X86_CLUSTER_USTACK_BASE_VIRT 0xc0000000                    /**< User Stack Base      */
+	#define X86_CLUSTER_USTACK_END_VIRT  0xb0000000                    /**< User Stack End       */
+	/**@}*/
+
+	/**
+	 * @brief Memory size (in bytes).
+	 */
+	#define X86_CLUSTER_MEM_SIZE \
+		X86_CLUSTER_DRAM_SIZE
+
+	/**
+	 * @brief Kernel memory size (in bytes).
+	 */
+	#define X86_CLUSTER_KMEM_SIZE \
+		(X86_CLUSTER_KERNEL_END_PHYS - X86_CLUSTER_KERNEL_BASE_PHYS)
+
+	/**
+	 * @brief Kernel page pool size (in bytes).
+	 */
+	#define X86_CLUSTER_KPOOL_SIZE \
+		(X86_CLUSTER_KPOOL_END_PHYS - X86_CLUSTER_KPOOL_BASE_PHYS)
+
+	/**
+	 * @brief User memory size (in bytes).
+	 */
+	#define X86_CLUSTER_UMEM_SIZE \
+		(X86_CLUSTER_USER_END_PHYS - X86_CLUSTER_USER_BASE_PHYS)
+
+#ifndef _ASM_FILE
+
+	/**
+	 * @brief Binary Sections
+	 */
+	/**@{*/
+	EXTERN unsigned char __BOOTSTRAP_START; /**< Bootstrap Start */
+	EXTERN unsigned char __BOOTSTRAP_END;   /**< Bootstrap End   */
+	EXTERN unsigned char __TEXT_START;      /**< Text Start      */
+	EXTERN unsigned char __TEXT_END;        /**< Text End        */
+	EXTERN unsigned char __DATA_START;      /**< Data Start      */
+	EXTERN unsigned char __DATA_END;        /**< Data End        */
+	EXTERN unsigned char __BSS_START;       /**< BSS Start       */
+	EXTERN unsigned char __BSS_END;         /**< BSS End         */
+	/**@}*/
+
+#ifdef __NANVIX_HAL
+
+	/**
+	 * @brief Initializes the Memory Interface.
+	 */
+	EXTERN void x86_cluster_mem_setup(void);
+
+	/**
+	 * @brief Enable paging in the underlying core.
+	 */
+	EXTERN void _x86_cluster_enable_paging(void);
+
+#endif /* __NANVIX_HAL */
+
+#endif /* _ASM_FILE_ */
 
 /**@}*/
 
@@ -93,18 +137,18 @@
 	/**
 	 * @name Exported Constants
 	 */
-	#define MEMORY_SIZE  I486_MEM_SIZE          /**< @see I486_MEM_SIZE         */
-	#define KMEM_SIZE    I486_KMEM_SIZE         /**< @see I486_KMEM_SIZE        */
-	#define UMEM_SIZE    I486_UMEM_SIZE         /**< @see I486_UMEM_SIZE        */
-	#define KSTACK_SIZE  I486_KSTACK_SIZE       /**< @see I486_KSTACK_SIZE      */
-	#define KPOOL_SIZE   I486_KPOOL_SIZE        /**< @see I486_KPOOL_SIZE       */
-	#define KBASE_PHYS   I486_KERNEL_BASE_PHYS  /**< @see I486_KERNEL_BASE_PHYS */
-	#define KPOOL_PHYS   I486_KPOOL_BASE_PHYS   /**< @see I486_KPOOL_BASE_PHYS  */
-	#define UBASE_PHYS   I486_USER_BASE_PHYS    /**< @see I486_USER_BASE_PHYS   */
-	#define USTACK_VIRT  I486_USTACK_BASE_VIRT  /**< @see I486_USTACK_BASE_VIRT */
-	#define UBASE_VIRT   I486_USER_BASE_VIRT    /**< @see I486_USER_BASE_VIRT   */
-	#define KBASE_VIRT   I486_KERNEL_BASE_VIRT  /**< @see I486_KERNEL_BASE_VIRT */
-	#define KPOOL_VIRT   I486_KPOOL_BASE_VIRT   /**< @see I486_KPOOL_BASE_VIRT  */
+	#define MEMORY_SIZE  X86_CLUSTER_MEM_SIZE          /**< @see X86_CLUSTER_MEM_SIZE         */
+	#define KMEM_SIZE    X86_CLUSTER_KMEM_SIZE         /**< @see X86_CLUSTER_KMEM_SIZE        */
+	#define UMEM_SIZE    X86_CLUSTER_UMEM_SIZE         /**< @see X86_CLUSTER_UMEM_SIZE        */
+	#define KSTACK_SIZE  X86_CLUSTER_KSTACK_SIZE       /**< @see X86_CLUSTER_KSTACK_SIZE      */
+	#define KPOOL_SIZE   X86_CLUSTER_KPOOL_SIZE        /**< @see X86_CLUSTER_KPOOL_SIZE       */
+	#define KBASE_PHYS   X86_CLUSTER_KERNEL_BASE_PHYS  /**< @see X86_CLUSTER_KERNEL_BASE_PHYS */
+	#define KPOOL_PHYS   X86_CLUSTER_KPOOL_BASE_PHYS   /**< @see X86_CLUSTER_KPOOL_BASE_PHYS  */
+	#define UBASE_PHYS   X86_CLUSTER_USER_BASE_PHYS    /**< @see X86_CLUSTER_USER_BASE_PHYS   */
+	#define USTACK_VIRT  X86_CLUSTER_USTACK_BASE_VIRT  /**< @see X86_CLUSTER_USTACK_BASE_VIRT */
+	#define UBASE_VIRT   X86_CLUSTER_USER_BASE_VIRT    /**< @see X86_CLUSTER_USER_BASE_VIRT   */
+	#define KBASE_VIRT   X86_CLUSTER_KERNEL_BASE_VIRT  /**< @see X86_CLUSTER_KERNEL_BASE_VIRT */
+	#define KPOOL_VIRT   X86_CLUSTER_KPOOL_BASE_VIRT   /**< @see X86_CLUSTER_KPOOL_BASE_VIRT  */
 	/**@}*/
 
 /**@endcond*/

--- a/include/arch/core/i486/asm.h
+++ b/include/arch/core/i486/asm.h
@@ -154,4 +154,40 @@
 
 	.endm
 
+/*============================================================================*
+ * Misc                                                                       *
+ *============================================================================*/
+
+	/*
+	 * Clear all GPR registers.
+	 */
+	.macro i486_clear_gprs
+
+		xorl %eax, %eax
+		xorl %ebx, %ebx
+		xorl %ecx, %ecx
+		xorl %edx, %edx
+		xorl %esi, %esi
+		xorl %edi, %edi
+		xorl %ebp, %ebp
+		xorl %esp, %esp
+
+	.endm
+
+	/*
+	 * Resets the stack.
+	 * - coreid ID of the calling core
+	 */
+	.macro i486_core_stack_reset coreid
+
+		movl $kstacks, %esp
+		movl %\coreid, %eax
+		addl %eax, 1
+		shll $I486_PAGE_SHIFT, %eax
+		addl %esp, %eax
+		addl $-I486_WORD_SIZE, %esp  /* Stack pointer. */
+		movl %esp, %ebp              /* Frame pointer. */
+
+	.endm
+
 #endif /* ARCH_CORE_I486_ASM_H_ */

--- a/include/arch/core/i486/mmu.h
+++ b/include/arch/core/i486/mmu.h
@@ -60,6 +60,27 @@
 	#define I486_PDE_SIZE   4                       /**< Page Directory Entry Size */
 	/**@}*/
 
+	/**
+	 * @brief Length of virtual addresses.
+	 *
+	 * Number of bits in a virtual address.
+	 */
+	#define I486_VADDR_LENGTH 32
+
+	/**
+	 * @brief Page Directory length.
+	 *
+	 * Number of Page Directory Entries (PDEs) per Page Directory.
+	 */
+	#define I486_PGDIR_LENGTH (1 << (I486_VADDR_LENGTH - I486_PGTAB_SHIFT))
+
+	/**
+	 * @brief Page Table length.
+	 *
+	 * Number of Page Table Entries (PTEs) per Page Table.
+	 */
+	#define I486_PGTAB_LENGTH (1 << (I486_PGTAB_SHIFT - I486_PAGE_SHIFT))
+
 #ifndef _ASM_FILE_
 
 	/**
@@ -101,11 +122,12 @@
 	 * @param paddr Physical address of the target page frame.
 	 * @param vaddr Virtual address of the target page.
 	 * @param w     Writable page?
+	 * @param x     Executable page?
 	 *
 	 * @returns Upon successful completion, zero is returned. Upon
 	 * failure, a negative error code is returned instead.
 	 */
-	EXTERN int i486_page_map(struct pte *pgtab, paddr_t paddr, vaddr_t vaddr, int w);
+	EXTERN int i486_page_map(struct pte *pgtab, paddr_t paddr, vaddr_t vaddr, int w, int x);
 
 	/**
 	 * @brief Maps a page table.
@@ -779,9 +801,7 @@
 	 */
 	static inline int mmu_page_map(struct pte *pgtab, paddr_t paddr, vaddr_t vaddr, int w, int x)
 	{
-		UNUSED(x);
-
-		return (i486_page_map(pgtab, paddr, vaddr, w));
+		return (i486_page_map(pgtab, paddr, vaddr, w, x));
 	}
 
 	/**

--- a/include/arch/core/i486/spinlock.h
+++ b/include/arch/core/i486/spinlock.h
@@ -48,6 +48,8 @@
 	#define I486_SPINLOCK_LOCKED   0x1 /**< Locked   */
 	/**@}*/
 
+#ifndef _ASM_FILE_
+
 	/**
 	 * @brief Spinlock.
 	 */
@@ -114,6 +116,8 @@
 		*lock = I486_SPINLOCK_UNLOCKED;
 		__sync_synchronize();
 	}
+
+#endif /* _ASM_FILE_ */
 
 /**@}*/
 

--- a/src/hal/arch/cluster/x86-cluster/_cluster.S
+++ b/src/hal/arch/cluster/x86-cluster/_cluster.S
@@ -22,47 +22,33 @@
  * SOFTWARE.
  */
 
-#ifndef ARCH_I486_CACHE_H_
-#define ARCH_I486_CACHE_H_
+/* Must come first. */
+#define _ASM_FILE_
+#define __NEED_CORE_TYPES
 
-/**
- * @addtogroup i486-core-cache Cache
- * @ingroup i486-core
- *
- * @brief Memory Cache
+#include <arch/core/i486/asm.h>
+#include <arch/core/i486/mmu.h>
+#include <arch/core/i486/types.h>
+
+/* Exported symbols. */
+.global _x86_cluster_enable_paging
+.global root_pgdir
+
+.section .text
+
+/*===========================================================================*
+ * _x86_cluster_enable_paging                                                *
+ *===========================================================================*/
+
+/*
+ * Enable paging for the underlying core.
  */
-/**@{*/
+.align I486_WORD_SIZE
+_x86_cluster_enable_paging:
 
-	/**
-	 * @name Provided Interface
-	 */
-	/**@{*/
-	#define __dcache_invalidate_fn
-	/**@}*/
-
-	/**
-	 * @brief Cache line size (in bytes).
-	 *
-	 * @bug The cache line size of i486 may change.
-	 */
-	#define I486_CACHE_LINE_SIZE 64
-
-	/**
-	 * @see I486_CACHE_LINE_SIZE
-	 */
-	#define CACHE_LINE_SIZE I486_CACHE_LINE_SIZE
-
-#ifndef _ASM_FILE_
-
-	/**
-	 * @note The i486 target features cache coherency.
-	 */
-	static inline void dcache_invalidate(void)
-	{
-	}
-
-#endif /* _ASM_FILE_ */
-
-/**@}*/
-
-#endif /* ARCH_I486_CACHE_H_ */
+	movl root_pgdir, %eax
+	movl %eax, %cr3
+	movl %cr0, %eax
+	orl $0x80000000, %eax
+	movl %eax, %cr0
+	ret

--- a/src/hal/arch/cluster/x86-cluster/boot.S
+++ b/src/hal/arch/cluster/x86-cluster/boot.S
@@ -26,8 +26,7 @@
 #define _ASM_FILE_
 
 #include <grub/mboot.h>
-#include <arch/core/i486/core.h>
-#include <arch/core/i486/mmu.h>
+#include <arch/cluster/x86-cluster/cores.h>
 
 /**
  * @brief Multiboot flags.
@@ -36,9 +35,7 @@
 
 /* Exported symbols. */
 .globl start
-.globl i486_root_pgdir
-.globl i486_kernel_pgtab
-.globl i486_kpool_pgtab
+.globl kstacks
 
 /*============================================================================*
  *                              bootstrap section                             *
@@ -68,54 +65,16 @@ mboot_header:
  * Kernel entry point.
  */
 start:
-
-	/* Build kernel page tables. */
-	start.kernel.init:
-		movl $i486_kernel_pgtab, %edi
-		movl $0x00000000 + 7, %eax
-		start.kernel.init.loop:
-			stosl
-			addl $I486_PAGE_SIZE, %eax
-			cmpl $i486_kernel_pgtab + I486_PAGE_SIZE, %edi
-			jl start.kernel.init.loop
-
-	/* Build kernel pool tables. */
-	start.kpool.init:
-		movl $i486_kpool_pgtab, %edi
-		movl $0x01000000 + 7, %eax
-		start.kpool.init.loop:
-			stosl
-			addl $I486_PAGE_SIZE, %eax
-			cmpl $i486_kpool_pgtab + I486_PAGE_SIZE, %edi
-			jl start.kpool.init.loop
-
-	/*
-	 * Build initial page directory.
-	 *   - Kernel code + data at 0x00000000
-	 *   - Kernel code + data at 0xc0000000
-	 *   - Kernel page pool at 0xc1000000
-	 */
-	start.kpgdir.init:
-		movl $i486_kernel_pgtab + 3, i486_root_pgdir + I486_PTE_SIZE*0
-		movl $i486_kernel_pgtab + 3, i486_root_pgdir + I486_PTE_SIZE*768
-		movl $i486_kpool_pgtab  + 3, i486_root_pgdir + I486_PTE_SIZE*772
-
-	/* Enable paging. */
-	start.paging.enable:
-		movl $i486_root_pgdir, %eax
-		movl %eax, %cr3
-		movl %cr0, %eax
-		orl $0x80000000, %eax
-		movl %eax, %cr0
+	
+	i486_clear_gprs
 
 	/* Setup stack. */
-	start.kstack.setup:
-		movl $core0.kstack + I486_PAGE_SIZE - I486_WORD_SIZE, %ebp
-		movl $core0.kstack + I486_PAGE_SIZE - I486_WORD_SIZE, %esp
+	movl $0, %eax
+	i486_core_stack_reset eax
 
+	/* Core and cluster setup. */
+	call x86_cluster_setup
 	call i486_core_setup
-
-	call i486_cluster_setup
 
 	call kmain
 
@@ -125,45 +84,12 @@ start:
 		jmp start.halt
 
 /*----------------------------------------------------------------------------*
- * i486_kernel_pgtab                                                          *
+ * kstacks                                                                    *
  *----------------------------------------------------------------------------*/
 
 /**
- * @brief Page table for kernel code and data.
+ * @brief Kernel stack for all cores.
  */
 .align I486_PAGE_SIZE
-i486_kernel_pgtab:
-	.fill I486_PAGE_SIZE/I486_PTE_SIZE, I486_PTE_SIZE, 0
-
-/*----------------------------------------------------------------------------*
- * i486_kpool_pgtab                                                           *
- *----------------------------------------------------------------------------*/
-
-/**
- * @brief Page table for kernel page pool.
- */
-.align I486_PAGE_SIZE
-i486_kpool_pgtab:
-	.fill I486_PAGE_SIZE/I486_PTE_SIZE, I486_PTE_SIZE, 0
-
-/*----------------------------------------------------------------------------*
- * i486_root_pgdir                                                            *
- *----------------------------------------------------------------------------*/
-
-/**
- * @brief Page directory of idle process.
- */
-.align I486_PAGE_SIZE
-i486_root_pgdir:
-	.fill I486_PAGE_SIZE/I486_PTE_SIZE, I486_PTE_SIZE, 0
-
-/*----------------------------------------------------------------------------*
- * core0.kstack                                                               *
- *----------------------------------------------------------------------------*/
-
-/**
- * @brief Kernel stack for core 0.
- */
-.align I486_PAGE_SIZE
-core0.kstack:
-	.fill I486_PAGE_SIZE/I486_PTE_SIZE, I486_PTE_SIZE, 0
+kstacks:
+	.skip I486_PAGE_SIZE * X86_CLUSTER_NUM_CORES

--- a/src/hal/arch/cluster/x86-cluster/cluster.c
+++ b/src/hal/arch/cluster/x86-cluster/cluster.c
@@ -31,7 +31,7 @@
 #include <nanvix/klib.h>
 
 /*============================================================================*
- * i486_cluster_setup()                                                       *
+ * x86_cluster_setup()                                                       *
  *============================================================================*/
 
 /**
@@ -39,8 +39,11 @@
  *
  * @author Davidson Francis
  */
-PUBLIC void i486_cluster_setup(void)
+PUBLIC void x86_cluster_setup(void)
 {
 	/* Initialize events table. */
 	event_setup();
+
+	/* Initialize memory layout. */
+	x86_cluster_mem_setup();
 }

--- a/src/hal/arch/cluster/x86-cluster/memory.c
+++ b/src/hal/arch/cluster/x86-cluster/memory.c
@@ -1,0 +1,250 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2019 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <arch/cluster/x86-cluster/cores.h>
+#include <arch/cluster/x86-cluster/memory.h>
+#include <nanvix/const.h>
+
+/**
+ * @brief Number of memory regions.
+ */
+#define X86_CLUSTER_MEM_REGIONS 2
+
+/**
+ * @brief Memory region.
+ */
+struct memory_region
+{
+	paddr_t pbase;   /**< Base physical address. */
+	vaddr_t vbase;   /**< Base virtual address.  */
+	size_t size;     /**< Size.                  */
+	bool writable;   /**< Writable?              */
+	bool executable; /**< Executable?            */
+};
+
+/**
+ * @brief Memory layout.
+ */
+PRIVATE struct memory_region x86_cluster_mem_layout[X86_CLUSTER_MEM_REGIONS] = {
+	{ X86_CLUSTER_KERNEL_BASE_PHYS, X86_CLUSTER_KERNEL_BASE_VIRT, X86_CLUSTER_KMEM_SIZE,  true, true  },
+	{ X86_CLUSTER_KPOOL_BASE_PHYS,  X86_CLUSTER_KPOOL_BASE_VIRT,  X86_CLUSTER_KPOOL_SIZE, true, false },
+};
+
+/**
+ * @brief Root page directory.
+ */
+PRIVATE struct pde x86_cluster_root_pgdir[I486_PGDIR_LENGTH] ALIGN(PAGE_SIZE);
+
+/**
+ * @brief Root page tables.
+ */
+PRIVATE struct pte x86_cluster_root_pgtabs[X86_CLUSTER_MEM_REGIONS][I486_PGTAB_LENGTH] ALIGN(PAGE_SIZE);
+
+/**
+ * Alias to root page directory.
+ */
+PUBLIC struct pde *root_pgdir = &x86_cluster_root_pgdir[0];
+
+/**
+ * Alias to kernel page table.
+ */
+PUBLIC struct pte *kernel_pgtab = x86_cluster_root_pgtabs[0];
+
+/**
+ * Alias to kernel page pool page table.
+ */
+PUBLIC struct pte *kpool_pgtab = x86_cluster_root_pgtabs[1];
+
+/*============================================================================*
+ * x86_cluster_mem_info()                                                     *
+ *============================================================================*/
+
+/**
+ * @brief Prints information about memory layout.
+ *
+ * The x86_cluster_mem_info() prints information about the virtual
+ * memory layout.
+ *
+ * @author Davidson Francis
+ */
+PRIVATE void x86_cluster_mem_info(void)
+{
+	kprintf("[hal] text = %d KB data = %d KB bss = %d KB",
+		(&__TEXT_END - &__TEXT_START)/KB,
+		(&__DATA_END - &__DATA_START)/KB,
+		(&__BSS_END  - &__BSS_START)/KB
+	);
+	kprintf("[hal] kernel_base=%x kernel_end=%x",
+		X86_CLUSTER_KERNEL_BASE_VIRT,
+		X86_CLUSTER_KERNEL_END_VIRT
+	);
+	kprintf("[hal]  kpool_base=%x  kpool_end=%x",
+		X86_CLUSTER_KPOOL_BASE_VIRT,
+		X86_CLUSTER_KPOOL_END_VIRT
+	);
+	kprintf("[hal]   user_base=%x   user_end=%x",
+		X86_CLUSTER_USER_BASE_VIRT,
+		X86_CLUSTER_USER_END_VIRT
+	);
+	kprintf("[hal] memsize=%d MB kmem=%d KB kpool=%d KB umem=%d KB",
+		X86_CLUSTER_MEM_SIZE/MB,
+		X86_CLUSTER_KMEM_SIZE/KB,
+		X86_CLUSTER_KPOOL_SIZE/KB,
+		X86_CLUSTER_UMEM_SIZE/KB
+	);
+}
+
+/*============================================================================*
+ * x86_cluster_mem_check_align()                                              *
+ *============================================================================*/
+
+/**
+ * @brief Asserts the memory alignment.
+ *
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Davidson Francis
+ */
+PRIVATE void x86_cluster_mem_check_align(void)
+{
+	/* These should be aligned at page table boundaries. */
+	if (X86_CLUSTER_KERNEL_BASE_VIRT & (I486_PGTAB_SIZE - 1))
+		kpanic("kernel base address misaligned");
+	if (X86_CLUSTER_KERNEL_END_VIRT & (I486_PGTAB_SIZE - 1))
+		kpanic("kernel end address misaligned");
+	if (X86_CLUSTER_KPOOL_BASE_VIRT & (I486_PGTAB_SIZE - 1))
+		kpanic("kernel pool base address misaligned");
+	if (X86_CLUSTER_KPOOL_END_VIRT & (I486_PGTAB_SIZE - 1))
+		kpanic("kernel pool end address misaligned");
+	if (X86_CLUSTER_USER_BASE_VIRT & (I486_PGTAB_SIZE - 1))
+		kpanic("user base address misaligned");
+	if (X86_CLUSTER_USER_END_VIRT & (I486_PGTAB_SIZE - 1))
+		kpanic("user end address misaligned");
+}
+
+/*============================================================================*
+ * x86_cluster_mem_check_layout()                                             *
+ *============================================================================*/
+
+/**
+ * @brief Asserts the memory layout.
+ *
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Davidson Francis
+ */
+PRIVATE void x86_cluster_mem_check_layout(void)
+{
+	/*
+	 * These should be identity mapped, because the this is called
+	 * with paging disabled.
+	 */
+	if (X86_CLUSTER_KERNEL_BASE_VIRT != X86_CLUSTER_KERNEL_BASE_PHYS)
+		kpanic("kernel base address is not identity mapped");
+	if (X86_CLUSTER_KERNEL_END_VIRT != X86_CLUSTER_KERNEL_END_PHYS)
+		kpanic("kernel end address is not identity mapped");
+	if (X86_CLUSTER_KPOOL_BASE_VIRT != X86_CLUSTER_KPOOL_BASE_PHYS)
+		kpanic("kernel pool base address is identity mapped");
+	if (X86_CLUSTER_KPOOL_END_VIRT != X86_CLUSTER_KPOOL_END_PHYS)
+		kpanic("kernel pool end address is not identity mapped");
+}
+
+/*============================================================================*
+ * x86_cluster_mem_map()                                                     *
+ *============================================================================*/
+
+/**
+ * @brief Builds the memory layout.
+ *
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Davidson Francis
+ */
+PRIVATE void x86_cluster_mem_map(void)
+{
+	/* Clean root page directory. */
+	for (int i = 0; i < I486_PGDIR_LENGTH; i++)
+		pde_clear(&x86_cluster_root_pgdir[i]);
+
+	/* Build root address space. */
+	for (int i = 0; i < X86_CLUSTER_MEM_REGIONS; i++)
+	{
+		paddr_t j;
+		vaddr_t k;
+		paddr_t pbase = x86_cluster_mem_layout[i].pbase;
+		vaddr_t vbase = x86_cluster_mem_layout[i].vbase;
+		size_t size = x86_cluster_mem_layout[i].size;
+		int w = x86_cluster_mem_layout[i].writable;
+		int x = x86_cluster_mem_layout[i].executable;
+
+		/* Map underlying pages. */
+		for (j = pbase, k = vbase;
+			 k < (pbase + size);
+			 j += I486_PAGE_SIZE, k += I486_PAGE_SIZE)
+		{
+			i486_page_map(x86_cluster_root_pgtabs[i], j, k, w, x);
+		}
+
+		/* Map underlying page table. */
+		i486_pgtab_map(
+				x86_cluster_root_pgdir,
+				I486_PADDR(x86_cluster_root_pgtabs[i]),
+				vbase
+		);
+	}
+}
+
+/*============================================================================*
+ * x86_cluster_mem_setup()                                                    *
+ *============================================================================*/
+
+/**
+ * The x86_cluster_mem_setup() function initializes the Memory
+ * Interface of the underlying x86 Cluster.
+ *
+ * @author Davidson Francis
+ */
+PUBLIC void x86_cluster_mem_setup(void)
+{
+	int coreid;
+
+	coreid = i486_core_get_id();
+
+	kprintf("[hal] initializing memory layout...");
+
+	/* Master core builds root virtual address space. */
+	if (coreid == X86_CLUSTER_COREID_MASTER)
+	{
+		x86_cluster_mem_info();
+
+		/* Check for memory layout. */
+		x86_cluster_mem_check_layout();
+		x86_cluster_mem_check_align();
+
+		x86_cluster_mem_map();
+	}
+
+	/* Enable paging. */
+	_x86_cluster_enable_paging();
+}

--- a/src/hal/arch/core/i486/mmu.c
+++ b/src/hal/arch/core/i486/mmu.c
@@ -26,43 +26,15 @@
 #include <nanvix/const.h>
 
 /**
- * @brief Root page directory.
- */
-EXTERN struct pde i486_root_pgdir[];
-
-/**
- * @brief Kernel page table.
- */
-EXTERN struct pte i486_kernel_pgtab[];
-
-/**
- * @brief Kernel page pool page table.
- */
-EXTERN struct pte i486_kpool_pgtab[];
-
-/**
- * Alias to root page directory.
- */
-PUBLIC struct pde *root_pgdir = &i486_root_pgdir[0];
-
-/**
- * Alias to kernel page table.
- */
-PUBLIC struct pte *kernel_pgtab = &i486_kernel_pgtab[0];
-
-/**
- * Alias to kernel page pool page table.
- */
-PUBLIC struct pte *kpool_pgtab = &i486_kpool_pgtab[0];
-
-/**
  * @todo TODO provide a detailed description for this function.
  *
  * @author Pedro Henrique Penna
  */
-PUBLIC int i486_page_map(struct pte *pgtab, paddr_t paddr, vaddr_t vaddr, int w)
+PUBLIC int i486_page_map(struct pte *pgtab, paddr_t paddr, vaddr_t vaddr, int w, int x)
 {
 	int idx;
+
+	UNUSED(x);
 
 	/* Invalid page table. */
 	if (UNLIKELY(pgtab == NULL))


### PR DESCRIPTION
Description
---------------
In order to proceed with #371, the x86-cluster needs some refactor from before starting with a platform independent setup, since x86 is way outdated comparing with another clusters.

Thus, this PR updates the x86-cluster at the same point as the other clusters.

Related Issues
--------------------

- [[hal] Platform Independent Link Variables](https://github.com/nanvix/hal/issues/410)
- [[hal] Platform Independent Setup for Virtual Memory](https://github.com/nanvix/hal/issues/371)