### PR TITLE
[hal] Feature: Dynamic Initialization for Sync, Mailbox and Portal

### DIFF
--- a/include/arch/target/kalray/mppa256/mailbox.h
+++ b/include/arch/target/kalray/mppa256/mailbox.h
@@ -133,13 +133,14 @@
 	 * @name Provided Interface
 	 */
 	/**@{*/
-	#define __mailbox_create_fn    /**< mailbox_create() */
-	#define __mailbox_open_fn      /**< mailbox_open()   */
-	#define __mailbox_unlink_fn    /**< mailbox_unlink() */
-	#define __mailbox_close_fn     /**< mailbox_close()  */
-	#define __mailbox_awrite_fn    /**< mailbox_awrite() */
-	#define __mailbox_aread_fn     /**< mailbox_aread()  */
-	#define __mailbox_wait_fn      /**< mailbox_wait()   */
+	#define __mailbox_setup_fn  /**< mailbox_setup()  */
+	#define __mailbox_create_fn /**< mailbox_create() */
+	#define __mailbox_open_fn   /**< mailbox_open()   */
+	#define __mailbox_unlink_fn /**< mailbox_unlink() */
+	#define __mailbox_close_fn  /**< mailbox_close()  */
+	#define __mailbox_awrite_fn /**< mailbox_awrite() */
+	#define __mailbox_aread_fn  /**< mailbox_aread()  */
+	#define __mailbox_wait_fn   /**< mailbox_wait()   */
 	/**@}*/
 
 	/**
@@ -157,6 +158,14 @@
 	#define MAILBOX_CREATE_MAX MPPA256_MAILBOX_CREATE_MAX
 	#define MAILBOX_OPEN_MAX   MPPA256_MAILBOX_OPEN_MAX
 	/**@}*/
+
+	/**
+	 * @todo TODO: rely on dummy platform-independent dummy function.
+	 */
+	static inline void mailbox_setup(void)
+	{
+
+	}
 
 	/**
 	 * @see mppa256_mailbox_create()

--- a/include/arch/target/kalray/mppa256/portal.h
+++ b/include/arch/target/kalray/mppa256/portal.h
@@ -143,6 +143,7 @@
 	 * @name Provided Interface
 	 */
 	/**@{*/
+	#define __portal_setup_fn  /**< portal_setup()  */
 	#define __portal_create_fn /**< portal_create() */
 	#define __portal_allow_fn  /**< portal_allow()  */
 	#define __portal_open_fn   /**< portal_open()   */
@@ -163,6 +164,14 @@
 	#define PORTAL_OPEN_MAX   MPPA256_PORTAL_OPEN_MAX
 	#define PORTAL_MAX_SIZE   MPPA256_PORTAL_MAX_SIZE
 	/**@}*/
+
+	/**
+	 * @todo TODO: rely on dummy platform-independent dummy function.
+	 */
+	static inline void portal_setup(void)
+	{
+
+	}
 
 	/**
 	 * @see mppa256_portal_create()

--- a/include/arch/target/kalray/mppa256/sync.h
+++ b/include/arch/target/kalray/mppa256/sync.h
@@ -75,7 +75,7 @@
 	 * @param nodenums Logic IDs of target NoC nodes.
 	 * @param nnodes   Number of target NoC nodes.
 	 * @param type     Type of synchronization point.
-	 * 
+	 *
 	 * @return The File descriptor ID.
 	 */
 	EXTERN int mppa256_sync_open(const int *nodenums, int nnodes, int type);
@@ -124,6 +124,7 @@
 	 * @name Provided Interface
 	 */
 	/**@{*/
+	#define __sync_setup_fn  /**< sync_setup()  */
 	#define __sync_create_fn /**< sync_create() */
 	#define __sync_open_fn   /**< sync_open()   */
 	#define __sync_unlink_fn /**< sync_unlink() */
@@ -149,6 +150,17 @@
 	#define SYNC_CREATE_MAX MPPA256_SYNC_CREATE_MAX
 	#define SYNC_OPEN_MAX   MPPA256_SYNC_OPEN_MAX
 	/**@}*/
+
+	/**
+	 * @todo TODO: rely on dummy platform-independent dummy function.
+	 *
+	 * @todo Maybe this function can be used to initialize the intercluster
+	 * fence resources.
+	 */
+	static inline void sync_setup(void)
+	{
+
+	}
 
 	/**
 	 * @see mppa256_sync_create()

--- a/include/arch/target/unix64/unix64/mailbox.h
+++ b/include/arch/target/unix64/unix64/mailbox.h
@@ -148,10 +148,11 @@
 	 * @name Provided Functions
 	 */
 	/**@{*/
-	#define __mailbox_create_fn  /**< mailbox_create() */
-	#define __mailbox_open_fn    /**< mailbox_open()   */
-	#define __mailbox_unlink_fn  /**< mailbox_unlink() */
-	#define __mailbox_close_fn   /**< mailbox_close()  */
+	#define __mailbox_setup_fn  /**< mailbox_setup()  */
+	#define __mailbox_create_fn /**< mailbox_create() */
+	#define __mailbox_open_fn   /**< mailbox_open()   */
+	#define __mailbox_unlink_fn /**< mailbox_unlink() */
+	#define __mailbox_close_fn  /**< mailbox_close()  */
 	/**@}*/
 
 	/**
@@ -162,6 +163,14 @@
 	#define MAILBOX_CREATE_MAX UNIX64_MAILBOX_CREATE_MAX /**< UNIX64_MAILBOX_CREATE_MAX */
 	#define MAILBOX_OPEN_MAX   UNIX64_MAILBOX_OPEN_MAX   /**< UNIX64_MAILBOX_OPEN_MAX   */
 	/**@}*/
+
+	/**
+	 * @todo TODO: rely on dummy platform-independent dummy function.
+	 */
+	static inline void mailbox_setup(void)
+	{
+
+	}
 
 	/**
 	 * @see unix64_mailbox_create()

--- a/include/arch/target/unix64/unix64/portal.h
+++ b/include/arch/target/unix64/unix64/portal.h
@@ -172,6 +172,7 @@
 	 * @name Provided Functions
 	 */
 	/**@{*/
+	#define __portal_setup_fn  /**< portal_setup()  */
 	#define __portal_create_fn /**< portal_create() */
 	#define __portal_allow_fn  /**< portal_allow()  */
 	#define __portal_open_fn   /**< portal_open()   */
@@ -188,6 +189,18 @@
 	#define PORTAL_OPEN_MAX   UNIX64_PORTAL_OPEN_MAX   /**< UNIX64_PORTAL_OPEN_MAX   */
 	#define PORTAL_MAX_SIZE   UNIX64_PORTAL_MAX_SIZE   /**< UNIX64_PORTAL_MAX_SIZE   */
 	/**@}*/
+
+	/**
+	 * @todo TODO: call unix64_portal_setup().
+	 */
+	static inline void portal_setup(void)
+	{
+		/*
+		 * Afterwards we provide a platform-independent initialization
+		 * for the target we can add a call to unix64_portal_setup()
+		 * here.
+		 */
+	}
 
 	/**
 	 * @see unix64_portal_create()

--- a/include/arch/target/unix64/unix64/sync.h
+++ b/include/arch/target/unix64/unix64/sync.h
@@ -85,7 +85,7 @@
 	 * @brief Opens a synchronization point.
 	 *
 	 * @param nodes  IDs of target NoC nodes.
-	 * @param nnodes Number of target NoC nodes. 
+	 * @param nnodes Number of target NoC nodes.
 	 * @param type   Type of synchronization point.
 	 *
 	 * @returns Upon successful completion, the ID of the target
@@ -151,12 +151,13 @@
 	 * @name Provided Functions
 	 */
 	/**@{*/
-	#define __sync_create_fn /**< sync_create()    */
-	#define __sync_open_fn   /**< sync_open()      */
-	#define __sync_unlink_fn /**< sync_unlink()    */
-	#define __sync_close_fn  /**< sync_close()     */
-	#define __sync_wait_fn   /**< sync_wait()      */
-	#define __sync_signal_fn /**< sync_signal()    */
+	#define __sync_setup_fn  /**< sync_setup()  */
+	#define __sync_create_fn /**< sync_create() */
+	#define __sync_open_fn   /**< sync_open()   */
+	#define __sync_unlink_fn /**< sync_unlink() */
+	#define __sync_close_fn  /**< sync_close()  */
+	#define __sync_wait_fn   /**< sync_wait()   */
+	#define __sync_signal_fn /**< sync_signal() */
 	/**@}*/
 
 	/**@{*/
@@ -165,6 +166,14 @@
 	#define SYNC_CREATE_MAX UNIX64_SYNC_CREATE_MAX /**< UNIX64_SYNC_CREATE_MAX */
 	#define SYNC_OPEN_MAX   UNIX64_SYNC_OPEN_MAX   /**< UNIX64_SYNC_OPEN_MAX   */
 	/**@}*/
+
+	/**
+	 * @todo TODO: rely on dummy platform-independent dummy function.
+	 */
+	static inline void sync_setup(void)
+	{
+
+	}
 
 	/**
 	 * @see unix64_sync_create()

--- a/include/nanvix/hal/target/mailbox.h
+++ b/include/nanvix/hal/target/mailbox.h
@@ -51,6 +51,9 @@
 		#endif
 
 		/* Functions */
+		#ifndef __mailbox_setup_fn
+		#error "mailbox_setup() not defined?"
+		#endif
 		#ifndef __mailbox_create_fn
 		#error "mailbox_create() not defined?"
 		#endif
@@ -91,7 +94,7 @@
 #if (__TARGET_HAS_MAILBOX)
 
 /**
- * @defgroup kernel-hal-target-sync Syncrhonization service
+ * @defgroup kernel-hal-target-mailbox Mailbox service
  * @ingroup kernel-hal-target
  *
  * @brief Target Standard Output HAL Interface
@@ -101,6 +104,11 @@
 	#include <nanvix/const.h>
 	#include <nanvix/klib.h>
 	#include <errno.h>
+
+	/**
+	 * @brief Initializes the mailbox interface.
+	 */
+	EXTERN void mailbox_setup(void);
 
 	/**
 	 * @brief Creates a mailbox.

--- a/include/nanvix/hal/target/portal.h
+++ b/include/nanvix/hal/target/portal.h
@@ -39,7 +39,7 @@
 	#error "does this target feature a portal interface?"
 	#endif
 
-	/* Has Mailbox Interface */
+	/* Has Portal Interface */
 	#if (__TARGET_HAS_PORTAL)
 
 		/* Constants */
@@ -54,6 +54,9 @@
 		#endif
 
 		/* Functions */
+		#ifndef __portal_setup_fn
+		#error "portal_setup() not defined?"
+		#endif
 		#ifndef __portal_create_fn
 		#error "portal_create() not defined?"
 		#endif
@@ -95,7 +98,7 @@
  *============================================================================*/
 
 /**
- * @defgroup kernel-hal-target-sync Syncrhonization service
+ * @defgroup kernel-hal-target-portal Portal service
  * @ingroup kernel-hal-target
  *
  * @brief Target Standard Output HAL Interface
@@ -105,6 +108,18 @@
 	#include <nanvix/const.h>
 	#include <nanvix/klib.h>
 	#include <errno.h>
+
+	/**
+	 * @brief Initializes the portal interface.
+	 */
+#if (__TARGET_HAS_PORTAL)
+	EXTERN void portal_setup(void);
+#else
+	static inline void portal_setup(void)
+	{
+
+	}
+#endif
 
 	/**
 	 * @brief Creates a portal.

--- a/include/nanvix/hal/target/sync.h
+++ b/include/nanvix/hal/target/sync.h
@@ -57,6 +57,9 @@
 		#endif
 
 		/* Functions */
+		#ifndef __sync_setup_fn
+		#error "sync_setup() not defined?"
+		#endif
 		#ifndef __sync_create_fn
 		#error "sync_create() not defined?"
 		#endif
@@ -105,6 +108,18 @@
 	#include <errno.h>
 
 	/**
+	 * @brief Initializes the sync interface.
+	 */
+#if (__TARGET_HAS_SYNC)
+	EXTERN void sync_setup(void);
+#else
+	static inline void sync_setup(void)
+	{
+
+	}
+#endif
+
+	/**
 	 * @brief Allocates and configures the receiving side of the synchronization point.
 	 *
 	 * @param nodenums IDs of target NoC nodes.
@@ -132,7 +147,7 @@
 	 * @param nodenums Logic IDs of target NoC nodes.
 	 * @param nnodes   Number of target NoC nodes.
 	 * @param type     Type of synchronization point.
-	 * 
+	 *
 	 * @return The tag of underlying resource ID.
 	 */
 #if (__TARGET_HAS_SYNC)

--- a/src/hal/hal.c
+++ b/src/hal/hal.c
@@ -56,4 +56,14 @@ PUBLIC void hal_init(void)
 	exception_setup();
 	interrupt_setup();
 	processor_noc_setup();
+
+#if (__TARGET_HAS_SYNC)
+	sync_setup();
+#endif
+#if (__TARGET_HAS_MAILBOX)
+	mailbox_setup();
+#endif
+#if (__TARGET_HAS_PORTAL)
+	portal_setup();
+#endif
 }


### PR DESCRIPTION
In this PR, I provide initialization functions for the Sync, Mailbox and Portal interface though with some caveats.

- **MPPA-256:** All structures are statically initialized, so the setup functions don't have operations.
- **unix64:** I provide only the definition and a dummy prototype, so this still must be implemented. 

This PR doesn't complete the follow issue.

Related Issues
--------------------

- [[hal] Dynamic Initialization for Sync, Mailbox and Portal](https://github.com/nanvix/hal/issues/527)