### PR TITLE
[mppa256] Fixing Regression Tests on Target AL

### DIFF
--- a/include/nanvix/hal/processor/noc.h
+++ b/include/nanvix/hal/processor/noc.h
@@ -101,17 +101,17 @@
 	/**
 	 * @brief Asserts whether a NoC node is attached to an IO cluster.
 	 *
-	 * @param nodeid ID of the target NoC node.
+	 * @param nodenum Logic ID of the target NoC node.
 	 *
 	 * @returns One if the target NoC node is attached to an IO cluster,
 	 * and zero otherwise.
 	 */
 #if (PROCESSOR_HAS_NOC)
-	EXTERN int processor_noc_is_ionode(int nodeid);
+	EXTERN int processor_noc_is_ionode(int nodenum);
 #else
-	static inline int processor_noc_is_ionode(int nodeid)
+	static inline int processor_noc_is_ionode(int nodenum)
 	{
-		UNUSED(nodeid);
+		UNUSED(nodenum);
 
 		return (1);
 	}
@@ -120,17 +120,17 @@
 	/**
 	 * @brief Asserts whether a NoC node is attached to a compute cluster.
 	 *
-	 * @param nodeid ID of the target NoC node.
+	 * @param nodenum Logic ID of the target NoC node.
 	 *
 	 * @returns One if the target NoC node is attached to a compute
 	 * cluster, and zero otherwise.
 	 */
 #if (PROCESSOR_HAS_NOC)
-	EXTERN int processor_noc_is_cnode(int nodeid);
+	EXTERN int processor_noc_is_cnode(int nodenum);
 #else
-	static inline int processor_noc_is_cnode(int nodeid)
+	static inline int processor_noc_is_cnode(int nodenum)
 	{
-		UNUSED(nodeid);
+		UNUSED(nodenum);
 
 		return (0);
 	}
@@ -139,7 +139,6 @@
 	/**
 	 * @brief Gets the logic number of the target NoC node.
 	 *
-	 * @param nodeid ID of the target NoC node.
 	 * @returns The logic number of the target NoC node.
 	 */
 #if (PROCESSOR_HAS_NOC)
@@ -154,28 +153,7 @@
 #ifdef __NANVIX_HAL
 
 	/**
-	 * @brief Converts a nodes list.
-	 *
-	 * @param _nodes Place to store converted list.
-	 * @param nodes  Target nodes list.
-	 * @param nnodes Number of nodes in the list.
-	 *
-	 * @returns Upon successful completion, zero is returned. Upon
-	 * failure, a negative error code is returned instead.
-	 */
-#if (PROCESSOR_HAS_NOC)
-	EXTERN int processor_node_convert_nums_to_ids(int *_nodes, const int *nodes, int nnodes);
-#else
-	static inline int processor_node_convert_nums_to_ids(int *_nodes, const int *nodes, int nnodes)
-	{
-		kmemcpy(_nodes, nodes, nnodes);
-
-		return (0);
-	}
-#endif
-
-	/**
-	 * @todo TODO: Provide a detailed description to this function.
+	 * @brief Initializes the mailbox interface.
 	 */
 #if (PROCESSOR_HAS_NOC)
 	EXTERN void processor_noc_setup(void);

--- a/src/test/main.c
+++ b/src/test/main.c
@@ -103,7 +103,9 @@ PRIVATE void test_target_al(void)
 	test_mailbox();
 #endif
 
+#if (__TARGET_HAS_PORTAL)
 	test_portal();
+#endif
 }
 
 #ifndef __unix64__

--- a/src/test/target/mailbox.c
+++ b/src/test/target/mailbox.c
@@ -34,11 +34,11 @@
  * @brief ID of master NoC node.
  */
 #define NODES_AMOUNT   2
-#define NODENUM_MASTER PROCESSOR_CLUSTERNUM_MASTER
+#define NODENUM_MASTER PROCESSOR_NODENUM_MASTER
 #ifdef __mppa256__
-	#define NODENUM_SLAVE (PROCESSOR_CLUSTERNUM_MASTER + PROCESSOR_NOC_IONODES_NUM)
+	#define NODENUM_SLAVE (PROCESSOR_NODENUM_MASTER + PROCESSOR_NOC_IONODES_NUM)
 #else
-	#define NODENUM_SLAVE (PROCESSOR_CLUSTERNUM_MASTER + 1)
+	#define NODENUM_SLAVE (PROCESSOR_NODENUM_MASTER + 1)
 #endif
 
 /*============================================================================*

--- a/src/test/target/portal.c
+++ b/src/test/target/portal.c
@@ -34,13 +34,13 @@
  * @brief ID of master NoC node.
  */
 #define NODES_AMOUNT   2
-#define NODENUM_MASTER PROCESSOR_CLUSTERNUM_MASTER
-#ifdef __mppa256__
-	#define NODENUM_SLAVE (PROCESSOR_CLUSTERNUM_MASTER + PROCESSOR_NOC_IONODES_NUM)
-#else
-	#define NODENUM_SLAVE (PROCESSOR_CLUSTERNUM_MASTER + 1)
-#endif
 #define PORTAL_SIZE    256
+#define NODENUM_MASTER PROCESSOR_NODENUM_MASTER
+#ifdef __mppa256__
+	#define NODENUM_SLAVE (PROCESSOR_NODENUM_MASTER + PROCESSOR_NOC_IONODES_NUM)
+#else
+	#define NODENUM_SLAVE (PROCESSOR_NODENUM_MASTER + 1)
+#endif
 
 /*============================================================================*
  * API Tests                                                                  *


### PR DESCRIPTION
In this PR, I fix the following bugs:
- Sync: adds validation function to sync abstraction to check a node list doesn't contain duplicated nodes, contain only valid nodes and if the local node is included.
- test/main.c: I add a `#ifdef` check to call `test_portal()` on target tests.
- Dummy Cluster/Noc Interface: Wrong parameters' name.