### PR TITLE
[k1b] Bugfix: Removes __builtin_k1_dflush call.

### DIFF
--- a/include/arch/core/k1b/cache.h
+++ b/include/arch/core/k1b/cache.h
@@ -97,7 +97,6 @@
 	 */
 	static inline void k1b_dcache_flush(void)
 	{
-		__builtin_k1_dflush();
 		__builtin_k1_wpurge();
 	}
 


### PR DESCRIPTION
In this PR, I remove the `__builtin_k1_dflush` call because that it isn't implemented for the k1b architecture, only for k1a.

Even though in the documentation, it appears that this function exists for k1b, compilation generates both implicit invocation errors and no implementation found.
The following snippet was also found in the headers:

```
/* DFLUSHL is K1A only */
extern void __builtin_k1_dflush(void);
/* DFLUSHLL is K1A only */
extern void __builtin_k1_dflushl(const void *addr);
```