### PR TITLE
[hal] Exchange of Node Number

### DIFF
--- a/include/arch/processor/bostan/noc.h
+++ b/include/arch/processor/bostan/noc.h
@@ -79,7 +79,7 @@
 	 * thus are skipped.
 	 */
 	/**@{*/
-	#define BOSTAN_MAILBOX_RX_OFF (BOSTAN_PROCESSOR_NOC_RESERVED_RXS_NUM)                   /**< Mailbox. */
+	#define BOSTAN_MAILBOX_RX_OFF (BOSTAN_PROCESSOR_NOC_RESERVED_RXS_NUM)                  /**< Mailbox. */
 	#define BOSTAN_PORTAL_RX_OFF  (BOSTAN_MAILBOX_RX_OFF + BOSTAN_PROCESSOR_NOC_NODES_NUM) /**< Portal.  */
 	#define BOSTAN_SYNC_RX_OFF    (BOSTAN_PORTAL_RX_OFF + BOSTAN_PROCESSOR_NOC_NODES_NUM)  /**< Sync.    */
 	/**@}*/
@@ -88,7 +88,7 @@
 	 * @brief Transfer C-NoC tags offsets.
 	 */
 	/**@{*/
-	#define BOSTAN_MAILBOX_CNOC_TX_OFF (BOSTAN_PROCESSOR_NOC_RESERVED_TXS_NUM)                   /**< Mailbox. */
+	#define BOSTAN_MAILBOX_CNOC_TX_OFF (BOSTAN_PROCESSOR_NOC_RESERVED_TXS_NUM)                  /**< Mailbox. */
 	#define BOSTAN_PORTAL_CNOC_TX_OFF  (BOSTAN_MAILBOX_CNOC_TX_OFF + BOSTAN_MAILBOX_CREATE_MAX) /**< Portal.  */
 	#define BOSTAN_SYNC_CNOC_TX_OFF    (BOSTAN_PORTAL_CNOC_TX_OFF + BOSTAN_PORTAL_CREATE_MAX)   /**< Sync.    */
 	/**@}*/
@@ -97,16 +97,14 @@
 	 * @brief Transfer D-NoC tags offsets.
 	 */
 	/**@{*/
-	#define BOSTAN_MAILBOX_DNOC_TX_OFF (BOSTAN_PROCESSOR_NOC_RESERVED_TXS_NUM)                 /**< Mailbox. */
+	#define BOSTAN_MAILBOX_DNOC_TX_OFF (BOSTAN_PROCESSOR_NOC_RESERVED_TXS_NUM)                /**< Mailbox. */
 	#define BOSTAN_PORTAL_DNOC_TX_OFF  (BOSTAN_MAILBOX_DNOC_TX_OFF + BOSTAN_MAILBOX_OPEN_MAX) /**< Portal.  */
 	/**@}*/
 
 	/**
-	 * @brief Gets the logic number of the target NoC node.
-	 *
-	 * @returns The logic number of the target NoC node.
+	 * @brief Initializes the noc interface.
 	 */
-	EXTERN int bostan_processor_node_get_num(void);
+	EXTERN void bostan_processor_noc_setup(void);
 
 	/**
 	 * @brief Asserts whether a NoC node is attached to an IO cluster.
@@ -129,6 +127,29 @@
 	EXTERN int bostan_processor_noc_is_cnode(int nodenum);
 
 	/**
+	 * @brief Gets the logic number of the target NoC node
+	 * attached with a core.
+	 * 
+	 * @param coreid Attached core ID.
+	 *
+	 * @returns The logic number of the target NoC node attached
+	 * with the @p coreid.
+	 */
+	EXTERN int bostan_processor_node_get_num(int coreid);
+
+	/**
+	 * @brief Exchange the logic number of the target NoC node
+	 * attached with a core.
+	 *
+	 * @param coreid  Attached core ID.
+	 * @param nodenum Logic ID of the target NoC node.
+	 * 
+	 * @returns Zero if the target NoC node is successfully attached
+	 * to the requested @p coreid, and non zero otherwise.
+	 */
+	EXTERN int bostan_processor_node_set_num(int coreid, int nodenum);
+
+	/**
 	 * @brief Converts a nodes list.
 	 *
 	 * @param _nodes Place to store converted list.
@@ -149,7 +170,6 @@
 	 * nodenum is located.
 	 */
 	EXTERN int bostan_processor_noc_cluster_to_node_num(int clusternum);
-
 
 	/**
 	 * @brief Converts a NoC node number to cluster number.
@@ -191,14 +211,6 @@
 	 */
 	EXTERN int bostan_processor_node_portal_tag(int nodenum);
 
-	/**
-	 * @todo Provide a detailed description to this function.
-	 */
-	static inline void bostan_processor_noc_setup(void)
-	{
-		bostan_dma_init();
-	}
-
 /**@}*/
 
 /*============================================================================*
@@ -222,18 +234,19 @@
 	 * @name Exported Functions
 	 */
 	/**@{*/
-	#define __processor_node_get_num_fn  /**< processor_node_get_num()  */
+	#define __processor_noc_setup_fn     /**< processor_noc_setup()     */
 	#define __processor_noc_is_ionode_fn /**< processor_noc_is_ionode() */
 	#define __processor_noc_is_cnode_fn  /**< processor_noc_is_cnode()  */
-	#define __processor_noc_setup_fn     /**< processor_noc_setup()     */
+	#define __processor_node_get_num_fn  /**< processor_node_get_num()  */
+	#define __processor_node_set_num_fn  /**< processor_node_set_num()  */
 	/**@}*/
 
 	/**
-	 * @see bostan_processor_node_get_num()
+	 * @see bostan_processor_noc_setup()
 	 */
-	static inline int processor_node_get_num(void)
+	static inline void processor_noc_setup(void)
 	{
-		return bostan_processor_node_get_num();
+		bostan_processor_noc_setup();
 	}
 
 	/**
@@ -253,11 +266,19 @@
 	}
 
 	/**
-	 * @see bostan_processor_noc_setup()
+	 * @see bostan_processor_node_get_num()
 	 */
-	static inline void processor_noc_setup(void)
+	static inline int processor_node_get_num(int coreid)
 	{
-		bostan_processor_noc_setup();
+		return bostan_processor_node_get_num(coreid);
+	}
+
+	/**
+	 * @see bostan_processor_node_set_num()
+	 */
+	static inline int processor_node_set_num(int coreid, int nodenum)
+	{
+		return bostan_processor_node_set_num(coreid, nodenum);
 	}
 
 /**@endcond*/

--- a/include/arch/processor/linux64/noc.h
+++ b/include/arch/processor/linux64/noc.h
@@ -68,12 +68,9 @@
 #endif /* __NANVIX_HAL */
 
 	/**
-	 * @brief Gets the logic number of the target NoC node.
-	 *
-	 * @param nodeid ID of the target NoC node.
-	 * @returns The logic number of the target NoC node.
+	 * @brief Initializes the noc interface.
 	 */
-	EXTERN int linux64_processor_node_get_num(void);
+	EXTERN void linux64_processor_noc_setup(void);
 
 	/**
 	 * @brief Asserts whether a NoC node is attached to an IO cluster.
@@ -94,6 +91,29 @@
 	 * cluster, and zero otherwise.
 	 */
 	EXTERN int linux64_processor_noc_is_cnode(int nodenum);
+
+	/**
+	 * @brief Gets the logic number of the target NoC node
+	 * attached with a core.
+	 * 
+	 * @param coreid Attached core ID.
+	 *
+	 * @returns The logic number of the target NoC node attached
+	 * with the @p coreid.
+	 */
+	EXTERN int linux64_processor_node_get_num(int coreid);
+
+	/**
+	 * @brief Exchange the logic number of the target NoC node
+	 * attached with a core.
+	 *
+	 * @param coreid  Attached core ID.
+	 * @param nodenum Logic ID of the target NoC node.
+	 * 
+	 * @returns Zero if the target NoC node is successfully attached
+	 * to the requested @p coreid, and non zero otherwise.
+	 */
+	EXTERN int linux64_processor_node_set_num(int coreid, int nodenum);
 
 /**@}*/
 
@@ -118,18 +138,19 @@
 	 * @name Exported Functions
 	 */
 	/**@{*/
-	#define __processor_node_get_num_fn  /**< processor_node_get_num()  */
+	#define __processor_noc_setup_fn     /**< processor_noc_setup()     */
 	#define __processor_noc_is_ionode_fn /**< processor_noc_is_ionode() */
 	#define __processor_noc_is_cnode_fn  /**< processor_noc_is_cnode()  */
-	#define __processor_noc_setup_fn     /**< processor_noc_setup()     */
+	#define __processor_node_get_num_fn  /**< processor_node_get_num()  */
+	#define __processor_node_set_num_fn  /**< processor_node_set_num()  */
 	/**@}*/
 
 	/**
-	 * @see linux64_processor_node_get_num().
+	 * @brief Dummy operation.
 	 */
-	static inline int processor_node_get_num(void)
+	static inline void processor_noc_setup(void)
 	{
-		return (linux64_processor_node_get_num());
+		linux64_processor_noc_setup();
 	}
 
 	/**
@@ -149,10 +170,19 @@
 	}
 
 	/**
-	 * @brief Dummy operation.
+	 * @see linux64_processor_node_get_num().
 	 */
-	static inline void processor_noc_setup(void)
+	static inline int processor_node_get_num(int coreid)
 	{
+		return (linux64_processor_node_get_num(coreid));
+	}
+
+	/**
+	 * @see linux64_processor_node_set_num().
+	 */
+	static inline int processor_node_set_num(int coreid, int nodenum)
+	{
+		return (linux64_processor_node_set_num(coreid, nodenum));
 	}
 
 /**@endcond*/

--- a/include/nanvix/hal/processor/noc.h
+++ b/include/nanvix/hal/processor/noc.h
@@ -54,6 +54,9 @@
 		#endif
 
 		/* Functions */
+		#ifndef __processor_noc_setup_fn
+		#error "__processor_noc_setup() not defined?"
+		#endif
 		#ifndef __processor_noc_is_ionode_fn
 		#error "__processor_noc_is_ionode() not defined?"
 		#endif
@@ -63,8 +66,8 @@
 		#ifndef __processor_node_get_num_fn
 		#error "__processor_node_get_num() not defined?"
 		#endif
-		#ifndef __processor_noc_setup_fn
-		#error "__processor_noc_setup() not defined?"
+		#ifndef __processor_node_set_num_fn
+		#error "__processor_node_set_num() not defined?"
 		#endif
 
 	#else
@@ -97,6 +100,22 @@
 	 */
 	#define PROCESSOR_NOC_NODES_NUM \
 		(PROCESSOR_NOC_IONODES_NUM + PROCESSOR_NOC_CNODES_NUM)
+
+#ifdef __NANVIX_HAL
+
+	/**
+	 * @brief Initializes the mailbox interface.
+	 */
+#if (PROCESSOR_HAS_NOC)
+	EXTERN void processor_noc_setup(void);
+#else
+	static inline void processor_noc_setup(void)
+	{
+
+	}
+#endif
+
+#endif /* __NANVIX_HAL */
 
 	/**
 	 * @brief Asserts whether a NoC node is attached to an IO cluster.
@@ -137,34 +156,53 @@
 #endif
 
 	/**
-	 * @brief Gets the logic number of the target NoC node.
+	 * @brief Gets the logic number of the target NoC node
+	 * attached with a core.
+	 * 
+	 * @param coreid Attached core ID.
 	 *
-	 * @returns The logic number of the target NoC node.
+	 * @returns The logic number of the target NoC node attached
+	 * with the @p coreid.
 	 */
 #if (PROCESSOR_HAS_NOC)
-	EXTERN int processor_node_get_num(void);
+	EXTERN int processor_node_get_num(int coreid);
 #else
-	static inline int processor_node_get_num(void)
+	static inline int processor_node_get_num(int coreid)
 	{
+		/* Invalid coreid. */
+		if (!WITHIN(coreid, 0, CORES_NUM))
+			return (-EINVAL);
+
 		return (0);
 	}
 #endif
 
-#ifdef __NANVIX_HAL
-
 	/**
-	 * @brief Initializes the mailbox interface.
+	 * @brief Exchange the logic number of the target NoC node
+	 * attached with a core.
+	 *
+	 * @param coreid  Attached core ID.
+	 * @param nodenum Logic ID of the target NoC node.
+	 * 
+	 * @returns Zero if the target NoC node is successfully attached
+	 * to the requested @p coreid, and non zero otherwise.
 	 */
 #if (PROCESSOR_HAS_NOC)
-	EXTERN void processor_noc_setup(void);
+	EXTERN int processor_node_set_num(int coreid, int nodenum);
 #else
-	static inline void processor_noc_setup(void)
+	static inline int processor_node_set_num(int coreid, int nodenum)
 	{
+		/* Invalid coreid. */
+		if (!WITHIN(coreid, 0, CORES_NUM))
+			return (-EINVAL);
+		
+		/* Invalid coreid. */
+		if (!WITHIN(nodenum, 0, PROCESSOR_NOC_NODES_NUM))
+			return (-EINVAL);
 
+		return (0);
 	}
 #endif
-
-#endif /* __NANVIX_HAL */
 
 /**@}*/
 

--- a/src/hal/arch/processor/bostan/noc.c
+++ b/src/hal/arch/processor/bostan/noc.c
@@ -27,15 +27,26 @@
 
 #include <nanvix/hal/processor.h>
 
+/*=======================================================================*
+ * Private defines and Control variables                                 *
+ *=======================================================================*/
+
 /**
  * @brief Macro to get the number of NoC nodes inside an IO Cluster.
  */
-#define BOSTAN_PROCESSOR_NOC_NODES_PER_IOCLUSTER (PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM)
+#define BOSTAN_NODES_PER_IOCLUSTER \
+	(PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM)
+
+/**
+ * @brief Macro to get the number of NoC nodes inside an Compute Cluster.
+ */
+#define BOSTAN_NODES_PER_CCLUSTER \
+	(PROCESSOR_NOC_CNODES_NUM / PROCESSOR_CCLUSTERS_NUM)
 
 /**
  * @brief Map of logical IDs to physical IDs of Nodes.
  */
-PRIVATE const int bostan_processor_nodeids[PROCESSOR_NOC_NODES_NUM] = {
+PRIVATE const int bostan_nodeids[PROCESSOR_NOC_NODES_NUM] = {
 	BOSTAN_PROCESSOR_CLUSTERID_IOCLUSTER0 + 0,
 	BOSTAN_PROCESSOR_CLUSTERID_IOCLUSTER0 + 1,
 	BOSTAN_PROCESSOR_CLUSTERID_IOCLUSTER0 + 2,
@@ -63,6 +74,51 @@ PRIVATE const int bostan_processor_nodeids[PROCESSOR_NOC_NODES_NUM] = {
 };
 
 /**
+ * @brief Auxiliar macros for Core Numbering with Node numbers.
+ *
+* @details Since only IO Clusters have more than one valid node number,
+ * Compute Clusters only simulate the behavior of being able to configure
+ * other numbers.
+ */
+#ifdef __node__
+	#define BOSTAN_CORENUMS_NUM           (1)                          /**< Size of corenum array.           */
+	#define BOSTAN_CORENUMS_INDEX(coreid) (0)                          /**< Core index in corenum array.     */
+	#define BOSTAN_NODES_AVAILABLE        (BOSTAN_NODES_PER_CCLUSTER)  /**< Amount of node numbers avaiable. */
+#else
+	#define BOSTAN_CORENUMS_NUM           (K1BIO_CORES_NUM)            /**< Size of corenum array.           */
+	#define BOSTAN_CORENUMS_INDEX(coreid) (coreid)                     /**< Core index in corenum array.     */
+	#define BOSTAN_NODES_AVAILABLE        (BOSTAN_NODES_PER_IOCLUSTER) /**< Amount of node numbers avaiable. */
+#endif
+
+/**
+ * @brief Map of core ids to nodenums.
+ */
+PRIVATE int bostan_corenums[BOSTAN_CORENUMS_NUM];
+
+/*=======================================================================*
+ * bostan_processor_noc_setup()                                          *
+ *=======================================================================*/
+
+/**
+ * @brief Initializes the noc interface.
+ */
+PUBLIC void bostan_processor_noc_setup(void)
+{
+	int nodenum;
+
+	bostan_dma_init();
+
+	nodenum = bostan_processor_noc_cluster_to_node_num(cluster_get_num());
+
+	for (int i = 0; i < BOSTAN_CORENUMS_NUM; ++i)
+		bostan_corenums[i] = nodenum;
+}
+
+/*=======================================================================*
+ * bostan_processor_noc_cluster_to_node_num()                            *
+ *=======================================================================*/
+
+/**
  * @brief Converts a cluster number to NoC node number.
  *
  * @param clusternum Target node number.
@@ -73,7 +129,7 @@ PRIVATE const int bostan_processor_nodeids[PROCESSOR_NOC_NODES_NUM] = {
 PUBLIC int bostan_processor_noc_cluster_to_node_num(int clusternum)
 {
 	if (cluster_is_iocluster(clusternum))
-		return (clusternum * BOSTAN_PROCESSOR_NOC_NODES_PER_IOCLUSTER);
+		return (clusternum * BOSTAN_NODES_PER_IOCLUSTER);
 
 	else if (cluster_is_ccluster(clusternum))
 		return (clusternum + PROCESSOR_NOC_IONODES_NUM - PROCESSOR_IOCLUSTERS_NUM);
@@ -81,44 +137,9 @@ PUBLIC int bostan_processor_noc_cluster_to_node_num(int clusternum)
 	return (-EINVAL);
 }
 
-
-/**
- * @brief Converts a NoC node number to cluster number.
- *
- * @param nodenum Target node number.
- *
- * @returns The logical cluster number in which the node number @p
- * nodenum is located.
- */
-PUBLIC int bostan_processor_noc_node_to_cluster_num(int nodenum)
-{
-	if (processor_noc_is_ionode(nodenum))
-		return (nodenum / BOSTAN_PROCESSOR_NOC_NODES_PER_IOCLUSTER);
-
-	else if (processor_noc_is_cnode(nodenum))
-		return (nodenum - PROCESSOR_NOC_IONODES_NUM + PROCESSOR_IOCLUSTERS_NUM);
-
-	return (-EINVAL);
-}
-
-/**
- * @brief Gets the logic number of a NoC node.
- *
- * @returns The logic number of the target NoC node.
- *
- * @note This function is non-blocking.
- * @note This function is thread-safe.
- */
-PUBLIC int bostan_processor_node_get_num(void)
-{
-	int coreid;
-	int clusternum;
-
-	clusternum = cluster_get_num();
-	coreid = cluster_is_iocluster(clusternum) ? (core_get_id()) : (0);
-
-	return (bostan_processor_noc_cluster_to_node_num(clusternum) + coreid);
-}
+/*=======================================================================*
+ * bostan_processor_noc_is_ionode()                                      *
+ *=======================================================================*/
 
 /**
  * @brief Asserts whether a NoC node is attached to an IO cluster.
@@ -129,9 +150,13 @@ PUBLIC int bostan_processor_node_get_num(void)
  * and zero otherwise.
  */
 PUBLIC int bostan_processor_noc_is_ionode(int nodenum)
-{	
+{
 	return (WITHIN(nodenum, 0, PROCESSOR_NOC_IONODES_NUM));
 }
+
+/*=======================================================================*
+ * bostan_processor_noc_is_cnode()                                       *
+ *=======================================================================*/
 
 /**
  * @brief Asserts whether a NoC node is attached to a compute cluster.
@@ -152,6 +177,88 @@ PUBLIC int bostan_processor_noc_is_cnode(int nodenum)
 	);
 }
 
+/*=======================================================================*
+ * bostan_processor_noc_node_to_cluster_num()                            *
+ *=======================================================================*/
+
+/**
+ * @brief Converts a NoC node number to cluster number.
+ *
+ * @param nodenum Target node number.
+ *
+ * @returns The logical cluster number in which the node number @p
+ * nodenum is located.
+ */
+PUBLIC int bostan_processor_noc_node_to_cluster_num(int nodenum)
+{
+	if (processor_noc_is_ionode(nodenum))
+		return (nodenum / BOSTAN_NODES_PER_IOCLUSTER);
+
+	else if (processor_noc_is_cnode(nodenum))
+		return (nodenum - PROCESSOR_NOC_IONODES_NUM + PROCESSOR_IOCLUSTERS_NUM);
+
+	return (-EINVAL);
+}
+
+/*=======================================================================*
+ * bostan_processor_node_get_num()                                       *
+ *=======================================================================*/
+
+/**
+ * @brief Gets the logic number of the target NoC node
+ * attached with a core.
+ *
+ * @param coreid Attached core ID.
+ *
+ * @returns The logic number of the target NoC node attached
+ * with the @p coreid.
+ */
+PUBLIC int bostan_processor_node_get_num(int coreid)
+{
+	/* Invalid coreid. */
+	if (!WITHIN(coreid, 0, CORES_NUM))
+		return (-EINVAL);
+
+	return (bostan_corenums[BOSTAN_CORENUMS_INDEX(coreid)]);
+}
+
+/*=======================================================================*
+ * bostan_processor_node_set_num()                                       *
+ *=======================================================================*/
+
+/**
+ * @brief Exchange the logic number of the target NoC node
+ * attached with a core.
+ *
+ * @param coreid  Attached core ID.
+ * @param nodenum Logic ID of the target NoC node.
+ * 
+ * @returns Zero if the target NoC node is successfully attached
+ * to the requested @p coreid, and non zero otherwise.
+ */
+PUBLIC int bostan_processor_node_set_num(int coreid, int nodenum)
+{
+	int cluster_nodenum;
+
+	/* Invalid coreid. */
+	if (!WITHIN(coreid, 0, CORES_NUM))
+		return (-EINVAL);
+
+	cluster_nodenum = bostan_processor_noc_cluster_to_node_num(cluster_get_num());
+
+	/* Invalid nodenum. */
+	if (!WITHIN(nodenum, cluster_nodenum, cluster_nodenum + BOSTAN_NODES_AVAILABLE))
+		return (-EINVAL);
+
+	bostan_corenums[BOSTAN_CORENUMS_INDEX(coreid)] = nodenum;
+
+	return (0);
+}
+
+/*=======================================================================*
+ * bostan_processor_noc_node_num_to_id()                                 *
+ *=======================================================================*/
+
 /**
  * @brief Converts a nodes list.
  *
@@ -162,11 +269,11 @@ PUBLIC int bostan_processor_noc_is_cnode(int nodenum)
  */
 PUBLIC int bostan_processor_noc_node_num_to_id(int nodenum)
 {
-	/* Invalid nodenum. */		
+	/* Invalid nodenum. */
 	if (!WITHIN(nodenum, 0, PROCESSOR_NOC_NODES_NUM))
 		return (-EINVAL);
-		
-	return bostan_processor_nodeids[nodenum];
+
+	return bostan_nodeids[nodenum];
 }
 
 /*=======================================================================*
@@ -186,9 +293,10 @@ PUBLIC int bostan_processor_noc_node_num_to_id(int nodenum)
  */
 PUBLIC int bostan_processor_node_mailbox_tag(int nodenum)
 {
+	/* Invalid nodenum. */
 	if (!WITHIN(nodenum, 0, PROCESSOR_NOC_NODES_NUM))
 		return (-EINVAL);
-	
+
 	return (BOSTAN_MAILBOX_RX_OFF + nodenum);
 }
 
@@ -209,6 +317,7 @@ PUBLIC int bostan_processor_node_mailbox_tag(int nodenum)
  */
 PUBLIC int bostan_processor_node_portal_tag(int nodenum)
 {
+	/* Invalid nodenum. */
 	if (!WITHIN(nodenum, 0, PROCESSOR_NOC_NODES_NUM))
 		return (-EINVAL);
 
@@ -229,6 +338,7 @@ PUBLIC int bostan_processor_node_portal_tag(int nodenum)
  */
 PUBLIC int bostan_processor_node_sync_tag(int nodenum)
 {
+	/* Invalid nodenum. */
 	if (!WITHIN(nodenum, 0, PROCESSOR_NOC_NODES_NUM))
 		return (-EINVAL);
 

--- a/src/hal/arch/target/unix64/mailbox.c
+++ b/src/hal/arch/target/unix64/mailbox.c
@@ -237,7 +237,7 @@ PUBLIC int unix64_mailbox_create(int nodenum)
 		return (-EINVAL);
 
 	/* Bad NoC node. */
-	if (nodenum != processor_node_get_num())
+	if (nodenum != processor_node_get_num(core_get_id()))
 		return (-EINVAL);
 
 	unix64_mailbox_lock();
@@ -307,7 +307,7 @@ PUBLIC int unix64_mailbox_open(int nodenum)
 		return (-EINVAL);
 
 	/* Bad NoC node. */
-	if (nodenum == processor_node_get_num())
+	if (nodenum == processor_node_get_num(core_get_id()))
 		return (-EINVAL);
 
 again:

--- a/src/hal/arch/target/unix64/portal.c
+++ b/src/hal/arch/target/unix64/portal.c
@@ -448,7 +448,7 @@ PUBLIC int unix64_portal_create(int local)
 		return (-EINVAL);
 
 	/* Bad local NoC node. */
-	if (local != processor_node_get_num())
+	if (local != processor_node_get_num(core_get_id()))
 		return (-EINVAL);
 
 	return (do_unix64_portal_create(local));
@@ -546,7 +546,7 @@ PUBLIC int unix64_portal_allow(int portalid, int remote)
 		return (-EINVAL);
 
 	/* Bad remote. */
-	if (remote == processor_node_get_num())
+	if (remote == processor_node_get_num(core_get_id()))
 		return (-EINVAL);
 
 	return (do_unix64_portal_allow(portalid, remote));
@@ -646,7 +646,7 @@ PUBLIC int unix64_portal_open(int local, int remote)
 		return (-EINVAL);
 
 	/* Bad local. */
-	if (local != processor_node_get_num())
+	if (local != processor_node_get_num(core_get_id()))
 		return (-EINVAL);
 
 	/* Bad remote. */

--- a/src/hal/arch/target/unix64/sync.c
+++ b/src/hal/arch/target/unix64/sync.c
@@ -247,7 +247,7 @@ PRIVATE int do_unix64_sync_create(const int *nodes, int nnodes, int type)
 	int syncid;     /* Synchronization point. */
 	char *pathname; /* NoC connector name.    */
 
-	nodenum = processor_node_get_num();
+	nodenum = processor_node_get_num(core_get_id());
 
 	unix64_sync_lock();
 
@@ -358,7 +358,7 @@ PRIVATE int do_unix64_sync_open(const int *nodes, int nnodes, int type)
 	int syncid;     /* Synchronization point. */
 	char *pathname; /* NoC connector name.    */
 
-	nodenum = processor_node_get_num();
+	nodenum = processor_node_get_num(core_get_id());
 
 	unix64_sync_lock();
 
@@ -669,7 +669,7 @@ again:
 	 */
 	unix64_sync_unlock();
 
-	nodenum = processor_node_get_num();
+	nodenum = processor_node_get_num(core_get_id());
 
 	/* Broadcast. */
 	ret = (synctab.txs[syncid].type == UNIX64_SYNC_ONE_TO_ALL) ?

--- a/src/test/processor/cnoc.c
+++ b/src/test/processor/cnoc.c
@@ -93,7 +93,7 @@ PRIVATE void test_cnoc_loopback_with_events(void)
 {
 	int local;
 
-	local = processor_node_get_num();
+	local = processor_node_get_num(COREID_MASTER);
 
 	KASSERT(bostan_dma_control_create(INTERFACE, RX_TAG, RX_MASK, NULL) == 0);
 	KASSERT(bostan_dma_control_open(INTERFACE, TX_TAG) == 0);
@@ -122,7 +122,7 @@ PRIVATE void test_cnoc_loopback_with_interrupts(void)
 {
 	int local;
 
-	local = processor_node_get_num();
+	local = processor_node_get_num(COREID_MASTER);
 
 	KASSERT(bostan_dma_control_create(INTERFACE, RX_TAG, RX_MASK, test_cnoc_dummy_handler) == 0);
 	KASSERT(bostan_dma_control_open(INTERFACE, TX_TAG) == 0);
@@ -155,7 +155,7 @@ static void test_cnoc_stress_with_events(void)
 {
 	int local;
 
-	local = processor_node_get_num();
+	local = processor_node_get_num(COREID_MASTER);
 
 	KASSERT(bostan_dma_control_create(INTERFACE, RX_TAG, RX_MASK, NULL) == 0);
 	KASSERT(bostan_dma_control_open(INTERFACE, TX_TAG) == 0);
@@ -189,7 +189,7 @@ static void test_cnoc_stress_with_interrupts(void)
 {
 	int local;
 
-	local = processor_node_get_num();
+	local = processor_node_get_num(COREID_MASTER);
 
 	KASSERT(bostan_dma_control_create(INTERFACE, RX_TAG, RX_MASK, test_cnoc_dummy_handler) == 0);
 	KASSERT(bostan_dma_control_open(INTERFACE, TX_TAG) == 0);

--- a/src/test/processor/dnoc.c
+++ b/src/test/processor/dnoc.c
@@ -108,7 +108,7 @@ PRIVATE void test_dnoc_loopback_with_events(void)
 	char rx_buffer[BUFFER_MAX_SIZE];
 	char tx_buffer[BUFFER_MAX_SIZE];
 
-	local = processor_node_get_num();
+	local = processor_node_get_num(COREID_MASTER);
 
 	kmemset(rx_buffer, 0, BUFFER_MAX_SIZE);
 	kmemset(tx_buffer, 1, BUFFER_MAX_SIZE);
@@ -130,7 +130,8 @@ PRIVATE void test_dnoc_loopback_with_events(void)
 	);
 
 	KASSERT(bostan_dma_data_open(INTERFACE, TX_TAG) == 0);
-#if 1
+
+#if 1 /* Async write is not working yet. */
 	KASSERT(
 		bostan_dma_data_write(
 			INTERFACE,
@@ -175,7 +176,7 @@ PRIVATE void test_dnoc_loopback_with_interrupts(void)
 	char rx_buffer[BUFFER_MAX_SIZE];
 	char tx_buffer[BUFFER_MAX_SIZE];
 
-	local = processor_node_get_num();
+	local = processor_node_get_num(COREID_MASTER);
 
 	kmemset(rx_buffer, 0, BUFFER_MAX_SIZE);
 	kmemset(tx_buffer, 1, BUFFER_MAX_SIZE);
@@ -249,7 +250,7 @@ PRIVATE void test_dnoc_loopback_with_offset(void)
 	char tx_buffer[10];
 
 	offset = 10;
-	local = processor_node_get_num();
+	local = processor_node_get_num(COREID_MASTER);
 
 	kmemset(rx_buffer, 0, 100);
 	kmemset(rx_buffer, 1, 10);


### PR DESCRIPTION
In this PR, I introduce the concept of exchange of node number. The idea comes from the multiples node numbers available inside an IO cluster of the MPPA-256. Thus, the client application can use all those numbers without the HAL needs to handler implicitly.