### PR TITLE
[unix64] Rename Sync, Mailboxes & Portals

### DIFF
--- a/src/hal/arch/target/unix64/mailbox.c
+++ b/src/hal/arch/target/unix64/mailbox.c
@@ -41,6 +41,11 @@
 #define UNIX64_MAILBOX_NAME_LENGTH 128
 
 /**
+ * @brief Base name for a mailbox
+ */
+#define UNIX64_MAILBOX_BASENAME "nanvix-mailbox"
+
+/**
  * @brief Mailbox.
  */
 struct mailbox
@@ -198,7 +203,8 @@ PRIVATE int do_unix64_mailbox_create(int nodenum)
 
 	/* Build pathname for NoC connector. */
 	sprintf(pathname,
-		"/mailbox-%d",
+		"/%s-%d",
+		UNIX64_MAILBOX_BASENAME,
 		nodenum
 	);
 
@@ -268,7 +274,8 @@ PRIVATE int do_unix64_mailbox_open(int nodenum)
 
 	/* Build pathname for NoC connector. */
 	sprintf(pathname,
-		"/mailbox-%d",
+		"/%s-%d",
+		UNIX64_MAILBOX_BASENAME,
 		nodenum
 	);
 
@@ -660,7 +667,7 @@ PUBLIC void unix64_mailbox_shutdown(void)
 	{
 		char pathname[UNIX64_MAILBOX_NAME_LENGTH];
 
-		sprintf(pathname, "/mailbox-%d", i);
+		sprintf(pathname, "/%s-%d", UNIX64_MAILBOX_BASENAME, i);
 		mq_unlink(pathname);
 	}
 }

--- a/src/hal/arch/target/unix64/portal.c
+++ b/src/hal/arch/target/unix64/portal.c
@@ -45,7 +45,7 @@
 /**
  * @brief Base name for a portal
  */
-#define UNIX64_PORTAL_BASENAME "portal"
+#define UNIX64_PORTAL_BASENAME "nanvix-portal"
 
 /**
  * @brief Portal buffer.

--- a/src/hal/arch/target/unix64/sync.c
+++ b/src/hal/arch/target/unix64/sync.c
@@ -43,6 +43,11 @@
 #define UNIX64_SYNC_NAME_LENGTH 128
 
 /**
+ * @brief Base name for a sync
+ */
+#define UNIX64_SYNC_BASENAME "nanvix-sync"
+
+/**
  * @brief Synchronization point.
  */
 struct sync
@@ -272,7 +277,8 @@ PRIVATE int do_unix64_sync_create(const int *nodes, int nnodes, int type)
 
 			/* Build pathname for NoC connector. */
 			sprintf(pathname,
-				"/sync-%d-broadcast",
+				"/%s-%d-broadcast",
+				UNIX64_SYNC_BASENAME,
 				nodes[0]
 			);
 		}
@@ -288,7 +294,8 @@ PRIVATE int do_unix64_sync_create(const int *nodes, int nnodes, int type)
 
 			/* Build pathname for NoC connector. */
 			sprintf(pathname,
-				"/sync-%d-gather",
+				"/%s-%d-gather",
+				UNIX64_SYNC_BASENAME,
 				nodes[0]
 			);
 		}
@@ -380,7 +387,8 @@ PRIVATE int do_unix64_sync_open(const int *nodes, int nnodes, int type)
 
 			/* Build pathname for NoC connector. */
 			sprintf(pathname,
-				"/sync-%d-broadcast",
+				"/%s-%d-broadcast",
+				UNIX64_SYNC_BASENAME,
 				nodes[0]
 			);
 		}
@@ -396,7 +404,8 @@ PRIVATE int do_unix64_sync_open(const int *nodes, int nnodes, int type)
 
 			/* Build pathname for NoC connector. */
 			sprintf(pathname,
-				"/sync-%d-gather",
+				"/%s-%d-gather",
+				UNIX64_SYNC_BASENAME,
 				nodes[0]
 			);
 		}
@@ -806,9 +815,9 @@ PUBLIC void unix64_sync_shutdown(void)
 	{
 		char pathname[UNIX64_SYNC_NAME_LENGTH];
 
-		sprintf(pathname, "/sync-%d-gather", i);
+		sprintf(pathname, "/%s-%d-gather", UNIX64_SYNC_BASENAME, i);
 		mq_unlink(pathname);
-		sprintf(pathname, "/sync-%d-broadcast", i);
+		sprintf(pathname, "/%s-%d-broadcast", UNIX64_SYNC_BASENAME, i);
 		mq_unlink(pathname);
 	}
 }


### PR DESCRIPTION
# Description
In this PR was added the `nanvix` prefix on the underlying resources for sync, mailboxes and portals.

# Related Issues
[[unix64] Rename Sync, Mailboxes & Portals](https://github.com/nanvix/hal/issues/535)