### PR TITLE
[hal] Portal ports support

### DIFF
--- a/include/arch/target/kalray/mppa256/portal.h
+++ b/include/arch/target/kalray/mppa256/portal.h
@@ -49,6 +49,11 @@
 	#define MPPA256_PORTAL_MAX_SIZE (8*KB)
 
 	/**
+	 * @brief Number of ports in a single portal.
+	 */
+	#define MPPA256_PORTAL_PORT_NR 16
+
+	/**
 	 * @brief Creates a portal.
 	 *
 	 * @param local ID of the local NoC node.
@@ -158,11 +163,13 @@
 	 * @see MPPA256_PORTAL_CREATE_MAX
 	 * @see MPPA256_PORTAL_OPEN_MAX
 	 * @see MPPA256_PORTAL_MAX_SIZE
+	 * @see MPPA256_PORTAL_PORT_NR
 	 */
 	/**@{*/
 	#define PORTAL_CREATE_MAX MPPA256_PORTAL_CREATE_MAX
 	#define PORTAL_OPEN_MAX   MPPA256_PORTAL_OPEN_MAX
 	#define PORTAL_MAX_SIZE   MPPA256_PORTAL_MAX_SIZE
+	#define PORTAL_PORT_NR    MPPA256_PORTAL_PORT_NR
 	/**@}*/
 
 	/**

--- a/include/arch/target/kalray/mppa256/portal.h
+++ b/include/arch/target/kalray/mppa256/portal.h
@@ -46,7 +46,7 @@
 	/**
 	 * @brief Maximum size of transfer data.
 	 */
-	#define MPPA256_PORTAL_MAX_SIZE (1*MB)
+	#define MPPA256_PORTAL_MAX_SIZE (8*KB)
 
 	/**
 	 * @brief Creates a portal.

--- a/include/arch/target/unix64/unix64/portal.h
+++ b/include/arch/target/unix64/unix64/portal.h
@@ -55,7 +55,7 @@
 	/**
 	 * @brief Maximum size of transfer data.
 	 */
-	#define UNIX64_PORTAL_MAX_SIZE (1*MB)
+	#define UNIX64_PORTAL_MAX_SIZE (8*KB)
 
 #ifdef __NANVIX_HAL
 

--- a/include/arch/target/unix64/unix64/portal.h
+++ b/include/arch/target/unix64/unix64/portal.h
@@ -57,6 +57,11 @@
 	 */
 	#define UNIX64_PORTAL_MAX_SIZE (8*KB)
 
+	/**
+	 * @brief Number of ports in a single portal.
+	 */
+	#define UNIX64_PORTAL_PORT_NR 16
+
 #ifdef __NANVIX_HAL
 
 	/**
@@ -191,6 +196,7 @@
 	#define PORTAL_CREATE_MAX UNIX64_PORTAL_CREATE_MAX /**< UNIX64_PORTAL_CREATE_MAX */
 	#define PORTAL_OPEN_MAX   UNIX64_PORTAL_OPEN_MAX   /**< UNIX64_PORTAL_OPEN_MAX   */
 	#define PORTAL_MAX_SIZE   UNIX64_PORTAL_MAX_SIZE   /**< UNIX64_PORTAL_MAX_SIZE   */
+	#define PORTAL_PORT_NR    UNIX64_PORTAL_PORT_NR    /**< UNIX64_PORTAL_PORT_NR    */
 	/**@}*/
 
 	/**

--- a/include/nanvix/hal/target/portal.h
+++ b/include/nanvix/hal/target/portal.h
@@ -52,6 +52,9 @@
 		#ifndef PORTAL_MAX_SIZE
 		#error "PORTAL_MAX_SIZE not defined"
 		#endif
+		#ifndef PORTAL_PORT_NR
+		#error "PORTAL_PORT_NR not defined"
+		#endif
 
 		/* Functions */
 		#ifndef __portal_setup_fn
@@ -88,6 +91,7 @@
 		#define PORTAL_CREATE_MAX 1
 		#define PORTAL_OPEN_MAX   1
 		#define PORTAL_MAX_SIZE   1
+		#define PORTAL_PORT_NR    1
 
 	#endif
 

--- a/src/hal/arch/target/mppa256/portal.c
+++ b/src/hal/arch/target/mppa256/portal.c
@@ -800,6 +800,10 @@ PUBLIC ssize_t mppa256_portal_awrite(int portalid, const void * buffer, uint64_t
 	if (resource_is_busy(&portaltab.txs[portalid].resource))
 		return (-EAGAIN);
 
+	/* Bad buffer*/
+	if (buffer == NULL)
+		return (-EINVAL);
+
 	/* Bad size. */
 	if (size == 0 || size > MPPA256_PORTAL_MAX_SIZE || buffer == NULL)
 		return (-EINVAL);
@@ -895,6 +899,10 @@ PUBLIC ssize_t mppa256_portal_aread(int portalid, void * buffer, uint64_t size)
 	/* Busy portal. */
 	if (resource_is_busy(&portaltab.rxs[portalid].resource))
 		return (-EBUSY);
+
+	/* Bad buffer. */
+	if (buffer == NULL)
+		return (-EINVAL);
 
 	/* Bad size. */
 	if (size == 0 || size > MPPA256_PORTAL_MAX_SIZE || buffer == NULL)

--- a/src/hal/arch/target/mppa256/portal.c
+++ b/src/hal/arch/target/mppa256/portal.c
@@ -783,6 +783,8 @@ PRIVATE ssize_t do_mppa256_portal_awrite(int portalid, const void * buffer, uint
 
 /**
  * @see do_mppa256_portal_awrite().
+ *
+ * @todo Check fixed size from microkernel.
  */
 PUBLIC ssize_t mppa256_portal_awrite(int portalid, const void * buffer, uint64_t size)
 {
@@ -805,7 +807,7 @@ PUBLIC ssize_t mppa256_portal_awrite(int portalid, const void * buffer, uint64_t
 		return (-EINVAL);
 
 	/* Bad size. */
-	if (size == 0 || size > MPPA256_PORTAL_MAX_SIZE || buffer == NULL)
+	if (size == 0)
 		return (-EINVAL);
 
 	return (do_mppa256_portal_awrite(portalid, buffer, size));
@@ -883,6 +885,8 @@ PUBLIC ssize_t do_mppa256_portal_aread(int portalid, void * buffer, uint64_t siz
 
 /**
  * @see do_mppa256_portal_aread().
+ *
+ * @todo Check fixed size from microkernel.
  */
 PUBLIC ssize_t mppa256_portal_aread(int portalid, void * buffer, uint64_t size)
 {
@@ -905,7 +909,7 @@ PUBLIC ssize_t mppa256_portal_aread(int portalid, void * buffer, uint64_t size)
 		return (-EINVAL);
 
 	/* Bad size. */
-	if (size == 0 || size > MPPA256_PORTAL_MAX_SIZE || buffer == NULL)
+	if (size == 0)
 		return (-EINVAL);
 
 	/* Read not allowed. */

--- a/src/hal/arch/target/mppa256/portal.c
+++ b/src/hal/arch/target/mppa256/portal.c
@@ -768,15 +768,15 @@ PRIVATE int mppa256_portal_send_data(int portalid)
  */
 PRIVATE ssize_t do_mppa256_portal_awrite(int portalid, const void * buffer, uint64_t size)
 {
+	if (!portaltab.txs[portalid].is_allowed)
+		return (-EAGAIN);
+
 	portaltab.txs[portalid].buffer = buffer;
 	portaltab.txs[portalid].size   = size;
 	resource_set_busy(&portaltab.txs[portalid].resource);
 
-	if (portaltab.txs[portalid].is_allowed)
-	{
-		if (mppa256_portal_send_data(portalid) != 0)
-			return (-EAGAIN);
-	}
+	if (mppa256_portal_send_data(portalid) != 0)
+		return (-EAGAIN);
 
 	return (size);
 }
@@ -798,7 +798,7 @@ PUBLIC ssize_t mppa256_portal_awrite(int portalid, const void * buffer, uint64_t
 
 	/* Busy portal. */
 	if (resource_is_busy(&portaltab.txs[portalid].resource))
-		return (-EBUSY);
+		return (-EAGAIN);
 
 	/* Bad size. */
 	if (size == 0 || size > MPPA256_PORTAL_MAX_SIZE || buffer == NULL)

--- a/src/hal/arch/target/mppa256/portal.c
+++ b/src/hal/arch/target/mppa256/portal.c
@@ -777,7 +777,10 @@ PRIVATE ssize_t do_mppa256_portal_awrite(int portalid, const void * buffer, uint
 	resource_set_busy(&portaltab.txs[portalid].resource);
 
 	if (mppa256_portal_send_data(portalid) != 0)
+	{
+		resource_set_notbusy(&portaltab.txs[portalid].resource);
 		return (-EAGAIN);
+	}
 
 	return (size);
 }

--- a/src/hal/arch/target/mppa256/portal.c
+++ b/src/hal/arch/target/mppa256/portal.c
@@ -338,6 +338,7 @@ PRIVATE void mppa256_portal_sender_handler(int interface, int tag)
 			continue;
 
 		portaltab.txs[i].is_allowed = 1;
+		dcache_invalidate();
 
 		/* Sends requested message. */
 		if (resource_is_busy(&portaltab.txs[i].resource))

--- a/src/hal/arch/target/unix64/portal.c
+++ b/src/hal/arch/target/unix64/portal.c
@@ -760,6 +760,8 @@ error0:
 
 /**
  * @see do_unix64_portal_read();
+ *
+ * @todo Check fixed size from microkernel.
  */
 PUBLIC ssize_t unix64_portal_read(int portalid, void *buf, size_t n)
 {
@@ -772,7 +774,7 @@ PUBLIC ssize_t unix64_portal_read(int portalid, void *buf, size_t n)
 		return (-EINVAL);
 
 	/* Invalid read size. */
-	if ((n < 1) || (n > UNIX64_PORTAL_MAX_SIZE))
+	if (n == 0)
 		return (-EINVAL);
 
 	return (do_unix64_portal_read(portalid, buf, n));
@@ -854,6 +856,8 @@ error0:
 
 /**
  * @see unix64_do_portal_write().
+ *
+ * @todo Check fixed size from microkernel.
  */
 PUBLIC ssize_t unix64_portal_write(int portalid, const void *buf, size_t n)
 {
@@ -866,7 +870,7 @@ PUBLIC ssize_t unix64_portal_write(int portalid, const void *buf, size_t n)
 		return (-EINVAL);
 
 	/* Invalid write size. */
-	if ((n < 1) || (n > UNIX64_PORTAL_MAX_SIZE))
+	if (n == 0)
 		return (-EINVAL);
 
 	return (do_unix64_portal_write(portalid, buf, n));

--- a/src/test/target/portal.c
+++ b/src/test/target/portal.c
@@ -152,6 +152,8 @@ PRIVATE void test_portal_invalid_close(void)
 
 /**
  * @brief Fault Injection Test: Portal Invalid Read
+ *
+ * @todo Check size upper bound.
  */
 PRIVATE void test_portal_invalid_read(void)
 {
@@ -169,7 +171,6 @@ PRIVATE void test_portal_invalid_read(void)
 
 		/* Invalid buffer size. */
 		KASSERT(portal_aread(portalid, buf, 0) == -EINVAL);
-		KASSERT(portal_aread(portalid, buf, PORTAL_MAX_SIZE + 1) == -EINVAL);
 
 	KASSERT(portal_unlink(portalid) == 0);
 
@@ -177,6 +178,8 @@ PRIVATE void test_portal_invalid_read(void)
 
 /**
  * @brief Fault Injection Test: Portal Invalid Write
+ *
+ * @todo Check size upper bound.
  */
 PRIVATE void test_portal_invalid_write(void)
 {
@@ -194,7 +197,6 @@ PRIVATE void test_portal_invalid_write(void)
 
 		/* Invalid buffer size. */
 		KASSERT(portal_awrite(portalid, buf, 0) == -EINVAL);
-		KASSERT(portal_awrite(portalid, buf, PORTAL_MAX_SIZE + 1) == -EINVAL);
 
 	KASSERT(portal_close(portalid) == 0);
 }


### PR DESCRIPTION
# Description #
In this PR, were updated the constants provided by the Hal related to the number of logic ports exported to the Microkernel in the Portal facility. Also, small changes were made on the communication functions returns to make retries easier in above layers.

# Related Issues #
[#552 - Portal Logic Ports Support](https://github.com/nanvix/hal/issues/552)