### PR TITLE
[mppa256] Losing NoC Interrupts

### DIFF
--- a/include/arch/processor/bostan/noc/dtag.h
+++ b/include/arch/processor/bostan/noc/dtag.h
@@ -95,6 +95,11 @@
 	 */
 	EXTERN void bostan_dnoc_setup(void);
 
+	/**
+	 * @brief Verify lost interrupts.
+	 */
+	EXTERN void bostan_dnoc_it_verify(void);
+
 /*============================================================================*
  * D-Noc Receiver Interface                                                   *
  *============================================================================*/

--- a/src/hal/arch/target/mppa256/sync.c
+++ b/src/hal/arch/target/mppa256/sync.c
@@ -267,8 +267,7 @@ PRIVATE void mppa256_sync_it_handler(int interface, int tag)
 
 	if (resource_is_used(&synctab.rxs[syncid].resource))
 	{
-		k1b_spinlock_unlock(&synctab.rxs[syncid].lock);
-
+		/* Reconfigure sync point. */
 		ret = bostan_dma_control_config(
 			interface,
 			tag,
@@ -278,6 +277,9 @@ PRIVATE void mppa256_sync_it_handler(int interface, int tag)
 
 		if (ret < 0)
 			kpanic("[hal][sync] Reconfiguration of the sync falied!");
+
+		/* Releases slave. */
+		k1b_spinlock_unlock(&synctab.rxs[syncid].lock);
 	}
 }
 
@@ -592,7 +594,7 @@ PRIVATE int do_mppa256_sync_unlink(int syncid)
 
 	resource_free(&syncpools.rx_pool, syncid);
 
-	spinlock_unlock(&synctab.rxs[syncid].lock);
+	k1b_spinlock_unlock(&synctab.rxs[syncid].lock);
 
 	return (0);
 }
@@ -686,7 +688,7 @@ PUBLIC int mppa256_sync_wait(int syncid)
 #endif
 
 	/* Waits for the handler release the lock. */
-	spinlock_lock(&synctab.rxs[syncid].lock);
+	k1b_spinlock_lock(&synctab.rxs[syncid].lock);
 
 	return (0);
 }


### PR DESCRIPTION
In this PR, I fix the interrupt handlers of control and data NoCs. The handler performs several checks to ensure that no interruptions have been missed. This bug directly influenced some mailbox benchmarks.