### PR TITLE
[processor] Drop Node Number Exchange

### DIFF
--- a/include/arch/processor/bostan/noc.h
+++ b/include/arch/processor/bostan/noc.h
@@ -102,54 +102,6 @@
 	/**@}*/
 
 	/**
-	 * @brief Initializes the noc interface.
-	 */
-	EXTERN void bostan_processor_noc_setup(void);
-
-	/**
-	 * @brief Asserts whether a NoC node is attached to an IO cluster.
-	 *
-	 * @param nodenum Logical ID of the target NoC node.
-	 *
-	 * @returns One if the target NoC node is attached to an IO cluster,
-	 * and zero otherwise.
-	 */
-	EXTERN int bostan_processor_noc_is_ionode(int nodenum);
-
-	/**
-	 * @brief Asserts whether a NoC node is attached to a compute cluster.
-	 *
-	 * @param nodenum Logical ID of the target NoC node.
-	 *
-	 * @returns One if the target NoC node is attached to a compute
-	 * cluster, and zero otherwise.
-	 */
-	EXTERN int bostan_processor_noc_is_cnode(int nodenum);
-
-	/**
-	 * @brief Gets the logic number of the target NoC node
-	 * attached with a core.
-	 * 
-	 * @param coreid Attached core ID.
-	 *
-	 * @returns The logic number of the target NoC node attached
-	 * with the @p coreid.
-	 */
-	EXTERN int bostan_processor_node_get_num(int coreid);
-
-	/**
-	 * @brief Exchange the logic number of the target NoC node
-	 * attached with a core.
-	 *
-	 * @param coreid  Attached core ID.
-	 * @param nodenum Logic ID of the target NoC node.
-	 * 
-	 * @returns Zero if the target NoC node is successfully attached
-	 * to the requested @p coreid, and non zero otherwise.
-	 */
-	EXTERN int bostan_processor_node_set_num(int coreid, int nodenum);
-
-	/**
 	 * @brief Converts a nodes list.
 	 *
 	 * @param _nodes Place to store converted list.
@@ -238,47 +190,58 @@
 	#define __processor_noc_is_ionode_fn /**< processor_noc_is_ionode() */
 	#define __processor_noc_is_cnode_fn  /**< processor_noc_is_cnode()  */
 	#define __processor_node_get_num_fn  /**< processor_node_get_num()  */
-	#define __processor_node_set_num_fn  /**< processor_node_set_num()  */
 	/**@}*/
 
 	/**
-	 * @see bostan_processor_noc_setup()
+	 * @brief Initializes the noc interface.
 	 */
 	static inline void processor_noc_setup(void)
 	{
-		bostan_processor_noc_setup();
+		bostan_dma_init();
 	}
 
 	/**
-	 * @see bostan_processor_noc_is_ionode()
+	 * @brief Asserts whether a NoC node is attached to an IO cluster.
+	 *
+	 * @param nodenum Logic ID of the target NoC node.
+	 *
+	 * @returns One if the target NoC node is attached to an IO cluster,
+	 * and zero otherwise.
 	 */
 	static inline int processor_noc_is_ionode(int nodenum)
 	{
-		return (bostan_processor_noc_is_ionode(nodenum));
+		return (WITHIN(nodenum, 0, PROCESSOR_NOC_IONODES_NUM));
 	}
 
 	/**
-	 * @see bostan_processor_noc_is_cnode()
+	 * @brief Asserts whether a NoC node is attached to a compute cluster.
+	 *
+	 * @param nodenum Logic ID of the target NoC node.
+	 *
+	 * @returns One if the target NoC node is attached to a compute
+	 * cluster, and zero otherwise.
 	 */
 	static inline int processor_noc_is_cnode(int nodenum)
 	{
-		return (bostan_processor_noc_is_cnode(nodenum));
+		return (
+			WITHIN(
+				nodenum,
+				PROCESSOR_NOC_IONODES_NUM,
+				PROCESSOR_NOC_IONODES_NUM + PROCESSOR_NOC_CNODES_NUM
+			)
+		);
 	}
 
 	/**
-	 * @see bostan_processor_node_get_num()
+	 * @brief Gets the logic number of the target NoC node
+	 * attached with a core.
+	 *
+	 * @returns The logic number of the target NoC node attached
+	 * with the @p coreid.
 	 */
-	static inline int processor_node_get_num(int coreid)
+	static inline int processor_node_get_num(void)
 	{
-		return bostan_processor_node_get_num(coreid);
-	}
-
-	/**
-	 * @see bostan_processor_node_set_num()
-	 */
-	static inline int processor_node_set_num(int coreid, int nodenum)
-	{
-		return bostan_processor_node_set_num(coreid, nodenum);
+		return (bostan_processor_noc_cluster_to_node_num(cluster_get_num()));
 	}
 
 /**@endcond*/

--- a/include/arch/processor/linux64/noc.h
+++ b/include/arch/processor/linux64/noc.h
@@ -68,11 +68,6 @@
 #endif /* __NANVIX_HAL */
 
 	/**
-	 * @brief Initializes the noc interface.
-	 */
-	EXTERN void linux64_processor_noc_setup(void);
-
-	/**
 	 * @brief Asserts whether a NoC node is attached to an IO cluster.
 	 *
 	 * @param nodenum Logical number of the target NoC node.
@@ -92,29 +87,6 @@
 	 */
 	EXTERN int linux64_processor_noc_is_cnode(int nodenum);
 
-	/**
-	 * @brief Gets the logic number of the target NoC node
-	 * attached with a core.
-	 * 
-	 * @param coreid Attached core ID.
-	 *
-	 * @returns The logic number of the target NoC node attached
-	 * with the @p coreid.
-	 */
-	EXTERN int linux64_processor_node_get_num(int coreid);
-
-	/**
-	 * @brief Exchange the logic number of the target NoC node
-	 * attached with a core.
-	 *
-	 * @param coreid  Attached core ID.
-	 * @param nodenum Logic ID of the target NoC node.
-	 * 
-	 * @returns Zero if the target NoC node is successfully attached
-	 * to the requested @p coreid, and non zero otherwise.
-	 */
-	EXTERN int linux64_processor_node_set_num(int coreid, int nodenum);
-
 /**@}*/
 
 /*============================================================================*
@@ -131,7 +103,7 @@
 	/**@{*/
 	#define PROCESSOR_NOC_IONODES_NUM LINUX64_PROCESSOR_NOC_IONODES_NUM /**< LINUX64_PROCESSOR_NOC_IONODES_NUM */
 	#define PROCESSOR_NOC_CNODES_NUM  LINUX64_PROCESSOR_NOC_CNODES_NUM  /**< LINUX64_PROCESSOR_NOC_CNODES_NUM  */
-	#define PROCESSOR_NODENUM_MASTER LINUX64_PROCESSOR_NODENUM_MASTER   /**< LINUX64_PROCESSOR_NODENUM_MASTER  */
+	#define PROCESSOR_NODENUM_MASTER  LINUX64_PROCESSOR_NODENUM_MASTER  /**< LINUX64_PROCESSOR_NODENUM_MASTER  */
 	/**@}*/
 
 	/**
@@ -142,15 +114,14 @@
 	#define __processor_noc_is_ionode_fn /**< processor_noc_is_ionode() */
 	#define __processor_noc_is_cnode_fn  /**< processor_noc_is_cnode()  */
 	#define __processor_node_get_num_fn  /**< processor_node_get_num()  */
-	#define __processor_node_set_num_fn  /**< processor_node_set_num()  */
 	/**@}*/
 
 	/**
-	 * @brief Dummy operation.
+	 * @brief Initializes the noc interface.
 	 */
 	static inline void processor_noc_setup(void)
 	{
-		linux64_processor_noc_setup();
+
 	}
 
 	/**
@@ -170,19 +141,15 @@
 	}
 
 	/**
-	 * @see linux64_processor_node_get_num().
+	 * @brief Gets the logic number of the target NoC node
+	 * attached with a core.
+	 *
+	 * @returns The logic number of the target NoC node attached
+	 * with the @p coreid.
 	 */
-	static inline int processor_node_get_num(int coreid)
+	static inline int processor_node_get_num(void)
 	{
-		return (linux64_processor_node_get_num(coreid));
-	}
-
-	/**
-	 * @see linux64_processor_node_set_num().
-	 */
-	static inline int processor_node_set_num(int coreid, int nodenum)
-	{
-		return (linux64_processor_node_set_num(coreid, nodenum));
+		return (linux64_cluster_get_num());
 	}
 
 /**@endcond*/

--- a/include/nanvix/hal/processor/noc.h
+++ b/include/nanvix/hal/processor/noc.h
@@ -41,7 +41,7 @@
 
 	/* Feature Checking */
 	#ifndef PROCESSOR_HAS_NOC
-	#error "Does  this processor have a NoC?"
+	#error "Does this processor have a NoC?"
 	#endif
 
 	#if (PROCESSOR_HAS_NOC)
@@ -69,9 +69,6 @@
 		#endif
 		#ifndef __processor_node_get_num_fn
 		#error "__processor_node_get_num() not defined?"
-		#endif
-		#ifndef __processor_node_set_num_fn
-		#error "__processor_node_set_num() not defined?"
 		#endif
 
 	#endif
@@ -131,24 +128,10 @@
 	 * @brief Gets the logic number of the target NoC node
 	 * attached with a core.
 	 *
-	 * @param coreid Attached core ID.
-	 *
 	 * @returns The logic number of the target NoC node attached
 	 * with the @p coreid.
 	 */
-	EXTERN int processor_node_get_num(int coreid);
-
-	/**
-	 * @brief Exchange the logic number of the target NoC node
-	 * attached with a core.
-	 *
-	 * @param coreid  Attached core ID.
-	 * @param nodenum Logic ID of the target NoC node.
-	 *
-	 * @returns Zero if the target NoC node is successfully attached
-	 * to the requested @p coreid, and non zero otherwise.
-	 */
-	EXTERN int processor_node_set_num(int coreid, int nodenum);
+	EXTERN int processor_node_get_num(void);
 
 	/**
 	 * @brief Asserts whether or not a node number is valid.
@@ -175,7 +158,7 @@
 	 */
 	static inline int node_is_local(int nodenum)
 	{
-		return (nodenum == processor_node_get_num(core_get_id()));
+		return (nodenum == processor_node_get_num());
 	}
 
 /**@}*/

--- a/src/hal/arch/processor/linux64/noc.c
+++ b/src/hal/arch/processor/linux64/noc.c
@@ -88,36 +88,6 @@ struct
 	}
 };
 
-/**
- * @brief Map of core ids to nodenums.
- */
-PRIVATE int linux64_corenums[CORES_NUM];
-
-/*============================================================================*
- * linux64_processor_node_get_id()                                            *
- *============================================================================*/
-
-/**
- * @todo TODO: Provide a detailed description to this function.
- */
-PRIVATE int linux64_processor_node_get_id(void)
-{
-	return (linux64_cluster_get_num());
-}
-
-/*=======================================================================*
- * linux64_processor_noc_setup()                                         *
- *=======================================================================*/
-
-/**
- * @brief Initializes the noc interface.
- */
-PUBLIC void linux64_processor_noc_setup(void)
-{
-	for (int i = 0; i < CORES_NUM; ++i)
-		linux64_corenums[i] = linux64_processor_node_get_id();
-}
-
 /*============================================================================*
  * linux64_processor_noc_lock()                                               *
  *============================================================================*/
@@ -167,60 +137,6 @@ PRIVATE int linux64_processor_noc_node_to_cluster_num(int nodenum)
 
 		j += noc.configuration[i];
 	}
-
-	return (0);
-}
-
-/*============================================================================*
- * linux64_processor_node_get_num()                                           *
- *============================================================================*/
-
-/**
- * @brief Gets the logic number of the target NoC node
- * attached with a core.
- *
- * @param coreid Attached core ID.
- *
- * @returns The logic number of the target NoC node attached
- * with the @p coreid.
- */
-PUBLIC int linux64_processor_node_get_num(int coreid)
-{
-	/* Invalid coreid. */
-	if (!WITHIN(coreid, 0, CORES_NUM))
-		return (-EINVAL);
-
-	return (linux64_corenums[coreid]);
-}
-
-/*============================================================================*
- * linux64_processor_node_get_num()                                           *
- *============================================================================*/
-
-/**
- * @brief Exchange the logic number of the target NoC node
- * attached with a core.
- *
- * @param coreid  Attached core ID.
- * @param nodenum Logic ID of the target NoC node.
- *
- * @returns Zero if the target NoC node is successfully attached
- * to the requested @p coreid, and non zero otherwise.
- */
-PUBLIC int linux64_processor_node_set_num(int coreid, int nodenum)
-{
-	/* Invalid coreid. */
-	if (!WITHIN(coreid, 0, CORES_NUM))
-		return (-EINVAL);
-
-	if (!WITHIN(nodenum, 0, PROCESSOR_NOC_NODES_NUM))
-		return (-EINVAL);
-
-	/* Invalid nodenum. */
-	if (cluster_get_num() != linux64_processor_noc_node_to_cluster_num(nodenum))
-		return (-EINVAL);
-
-	linux64_corenums[coreid] = nodenum;
 
 	return (0);
 }

--- a/src/hal/arch/target/unix64/portal.c
+++ b/src/hal/arch/target/unix64/portal.c
@@ -775,7 +775,7 @@ again:
 	unix64_portals_lock();
 
 		/* Bad local NoC node. */
-		if (portaltab.rxs[portalid].local != processor_node_get_num(core_get_id()))
+		if (portaltab.rxs[portalid].local != processor_node_get_num())
 		{
 			unix64_portals_unlock();
 			return (-EPERM);

--- a/src/hal/arch/target/unix64/sync.c
+++ b/src/hal/arch/target/unix64/sync.c
@@ -267,7 +267,7 @@ PRIVATE int do_unix64_sync_create(const int *nodes, int nnodes, int type)
 	char *pathname;     /* NoC connector name.    */
 	uint64_t nodeslist; /* Target nodes list.     */
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = processor_node_get_num();
 
 	unix64_sync_lock();
 
@@ -384,7 +384,7 @@ PRIVATE int do_unix64_sync_open(const int *nodes, int nnodes, int type)
 	char *pathname;     /* NoC connector name.    */
 	uint64_t nodeslist; /* Target nodes list.     */
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = processor_node_get_num();
 
 	unix64_sync_lock();
 
@@ -700,7 +700,7 @@ again:
 	 */
 	unix64_sync_unlock();
 
-	nodenum = processor_node_get_num(core_get_id());
+	nodenum = processor_node_get_num();
 
 	/* Broadcast. */
 	ret = (synctab.txs[syncid].type == UNIX64_SYNC_ONE_TO_ALL) ?

--- a/src/test/processor/cnoc.c
+++ b/src/test/processor/cnoc.c
@@ -93,7 +93,7 @@ PRIVATE void test_cnoc_loopback_with_events(void)
 {
 	int local;
 
-	local = processor_node_get_num(COREID_MASTER);
+	local = processor_node_get_num();
 
 	KASSERT(bostan_dma_control_create(INTERFACE, RX_TAG, RX_MASK, NULL) == 0);
 	KASSERT(bostan_dma_control_open(INTERFACE, TX_TAG) == 0);
@@ -122,7 +122,7 @@ PRIVATE void test_cnoc_loopback_with_interrupts(void)
 {
 	int local;
 
-	local = processor_node_get_num(COREID_MASTER);
+	local = processor_node_get_num();
 
 	KASSERT(bostan_dma_control_create(INTERFACE, RX_TAG, RX_MASK, test_cnoc_dummy_handler) == 0);
 	KASSERT(bostan_dma_control_open(INTERFACE, TX_TAG) == 0);
@@ -155,7 +155,7 @@ static void test_cnoc_stress_with_events(void)
 {
 	int local;
 
-	local = processor_node_get_num(COREID_MASTER);
+	local = processor_node_get_num();
 
 	KASSERT(bostan_dma_control_create(INTERFACE, RX_TAG, RX_MASK, NULL) == 0);
 	KASSERT(bostan_dma_control_open(INTERFACE, TX_TAG) == 0);
@@ -189,7 +189,7 @@ static void test_cnoc_stress_with_interrupts(void)
 {
 	int local;
 
-	local = processor_node_get_num(COREID_MASTER);
+	local = processor_node_get_num();
 
 	KASSERT(bostan_dma_control_create(INTERFACE, RX_TAG, RX_MASK, test_cnoc_dummy_handler) == 0);
 	KASSERT(bostan_dma_control_open(INTERFACE, TX_TAG) == 0);

--- a/src/test/processor/dnoc.c
+++ b/src/test/processor/dnoc.c
@@ -108,7 +108,7 @@ PRIVATE void test_dnoc_loopback_with_events(void)
 	char rx_buffer[BUFFER_MAX_SIZE];
 	char tx_buffer[BUFFER_MAX_SIZE];
 
-	local = processor_node_get_num(COREID_MASTER);
+	local = processor_node_get_num();
 
 	kmemset(rx_buffer, 0, BUFFER_MAX_SIZE);
 	kmemset(tx_buffer, 1, BUFFER_MAX_SIZE);
@@ -176,7 +176,7 @@ PRIVATE void test_dnoc_loopback_with_interrupts(void)
 	char rx_buffer[BUFFER_MAX_SIZE];
 	char tx_buffer[BUFFER_MAX_SIZE];
 
-	local = processor_node_get_num(COREID_MASTER);
+	local = processor_node_get_num();
 
 	kmemset(rx_buffer, 0, BUFFER_MAX_SIZE);
 	kmemset(tx_buffer, 1, BUFFER_MAX_SIZE);
@@ -250,7 +250,7 @@ PRIVATE void test_dnoc_loopback_with_offset(void)
 	char tx_buffer[10];
 
 	offset = 10;
-	local = processor_node_get_num(COREID_MASTER);
+	local = processor_node_get_num();
 
 	kmemset(rx_buffer, 0, 100);
 	kmemset(rx_buffer, 1, 10);

--- a/src/test/processor/noc.c
+++ b/src/test/processor/noc.c
@@ -49,7 +49,7 @@ PRIVATE void test_node_get_num(void)
 {
 	int nodenum;
 
-	nodenum = processor_node_get_num(COREID_MASTER);
+	nodenum = processor_node_get_num();
 
 #if (TEST_NOC_VERBOSE)
 	kprintf("[test][processor][node][api] noc node %d online", nodenum);
@@ -71,115 +71,13 @@ PRIVATE void test_node_get_type(void)
 	KASSERT(!processor_noc_is_cnode(PROCESSOR_NODENUM_MASTER));
 }
 
-/*----------------------------------------------------------------------------*
- * Exchange Logical NoC Node Number                                           *
- *----------------------------------------------------------------------------*/
-
-/**
- * @brief API Test: Exchange Logical NoC Node Number
- */
-PRIVATE void test_node_set_num(void)
-{
-	int nodenum;
-
-	nodenum = processor_node_get_num(COREID_MASTER);
-	KASSERT(nodenum == PROCESSOR_NODENUM_MASTER);
-
-#if (TEST_NOC_VERBOSE)
-	kprintf("[test][processor][node][api] noc node %d online", nodenum);
-#endif
-
-	/* New nodenum (1 % (Interfaces available in only one IO Cluster)) */
-	nodenum += (1 % (PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM));
-
-#if (TEST_NOC_VERBOSE)
-	kprintf("[test][processor][node][api] exchange noc node number to %d", nodenum);
-#endif
-
-	KASSERT(processor_node_set_num(COREID_MASTER, nodenum) == 0);
-	KASSERT(processor_node_get_num(COREID_MASTER) == nodenum);
-
-	/* Restoure old nodenum. */
-	nodenum -= (1 % (PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM));
-
-	KASSERT(processor_node_set_num(COREID_MASTER, nodenum) == 0);
-}
-
 /**
  * @brief API Tests.
  */
 PRIVATE struct test test_api_node[] = {
 	{ test_node_get_num,  "get logical noc node num" },
-	{ test_node_set_num,  "set logical noc node num" },
 	{ test_node_get_type, "get noc node type       " },
 	{ NULL,                NULL                      },
-};
-
-/*============================================================================*
- * FAULT Tests                                                                *
- *============================================================================*/
-
-/*----------------------------------------------------------------------------*
- * Query Logical NoC Node Number with invalid arguments                       *
- *----------------------------------------------------------------------------*/
-
-/**
- * @brief FAULT Test: Invalid Get Logical NoC Node Number
- */
-PRIVATE void test_node_invalid_get_num(void)
-{
-	KASSERT(processor_node_get_num(-1) == -EINVAL);
-	KASSERT(processor_node_get_num(CORES_NUM) == -EINVAL);
-}
-
-/*----------------------------------------------------------------------------*
- * Exchange Logical NoC Node Number with invalid arguments                    *
- *----------------------------------------------------------------------------*/
-
-/**
- * @brief FAULT Test: Invalid Set Logical NoC Node Number
- */
-PRIVATE void test_node_invalid_set_num(void)
-{
-	/* Invalid coreid. */
-	KASSERT(processor_node_set_num(-1, PROCESSOR_NODENUM_MASTER) == -EINVAL);
-	KASSERT(processor_node_set_num(CORES_NUM, PROCESSOR_NODENUM_MASTER) == -EINVAL);
-
-	/* Invalid nodenum. */
-	KASSERT(processor_node_set_num(COREID_MASTER, -1) == -EINVAL);
-	KASSERT(processor_node_set_num(COREID_MASTER, PROCESSOR_NOC_NODES_NUM) == -EINVAL);
-}
-
-/*----------------------------------------------------------------------------*
- * Exchange Logical NoC Node Number with bad arguments                        *
- *----------------------------------------------------------------------------*/
-
-/**
- * @brief FAULT Test: Bad Set Logical NoC Node Number
- */
-PRIVATE void test_node_bad_set_num(void)
-{
-	int nodenum;
-
-	/* nodenum + (Interfaces available in only one IO Cluster). */
-	nodenum = PROCESSOR_NODENUM_MASTER + (PROCESSOR_NOC_IONODES_NUM / PROCESSOR_IOCLUSTERS_NUM);
-
-	/* Bad nodenum. */
-	KASSERT(processor_node_set_num(COREID_MASTER, nodenum) == -EINVAL);
-}
-
-/*============================================================================*
- * Test Driver                                                                *
- *============================================================================*/
-
-/**
- * @brief API Tests.
- */
-PRIVATE struct test test_fault_node[] = {
-	{ test_node_invalid_get_num, "invalid get logical noc node num" },
-	{ test_node_invalid_set_num, "invalid set logical noc node num" },
-	{ test_node_bad_set_num,     "bad set logical noc node num    " },
-	{ NULL,                       NULL                              },
 };
 
 /**
@@ -198,16 +96,6 @@ PUBLIC void test_noc(void)
 		test_api_node[i].test_fn();
 		kprintf("[test][processor][node][api] %s [passed]",
 			test_api_node[i].name
-		);
-	}
-
-	/* FAULT Tests */
-	kprintf(HLINE);
-	for (int i = 0; test_fault_node[i].test_fn != NULL; i++)
-	{
-		test_fault_node[i].test_fn();
-		kprintf("[test][processor][node][api] %s [passed]",
-			test_fault_node[i].name
 		);
 	}
 }


### PR DESCRIPTION
# Description

In this PR, I remove the dependency of the coreid to get the local `nodenum`. Also, I remove the unnecessary `processor_node_set_num` and its redundant code.