### PR TITLE
[unix64] Mailbox Non-blocking Read/Write

### DIFF
--- a/src/test/stress/mailbox.c
+++ b/src/test/stress/mailbox.c
@@ -45,12 +45,13 @@
  /**@{*/
 #define AREAD_CHECKS(_ret)             \
 	  ((_ret == -ETIMEDOUT)            \
+	|| (_ret == -EAGAIN)               \
 	|| (_ret == -EBUSY)                \
 	|| (_ret == -ENOMSG)               \
-	|| (_ret == -EAGAIN)               \
 	|| (_ret == HAL_MAILBOX_MSG_SIZE))
 #define AWRITE_CHECKS(_ret)            \
-	  ((_ret == -EAGAIN)               \
+	  ((_ret == -ETIMEDOUT)            \
+	|| (_ret == -EAGAIN)               \
 	|| (_ret == -EBUSY)                \
 	|| (_ret == HAL_MAILBOX_MSG_SIZE))
 /**@}*/


### PR DESCRIPTION
# Description #
In this PR, the Mailbox Read / Write now return errors when a communication operation doesn't met the requirements to occur at the specified moment, instead of blocking until they are reached.

## Note ##
This is an attempt of solving the Unix Microkernel freezing problem. Need more tests to ensure it.