### PR TITLE
[unix64]  Sync Facility Refactor

### DIFF
--- a/include/arch/processor/bostan/noc.h
+++ b/include/arch/processor/bostan/noc.h
@@ -137,11 +137,12 @@
 	 * @brief Returns the synchronization NoC tag for a target NoC node ID.
 	 *
 	 * @param nodenum Logical ID of the target NoC node.
+	 * @param slot    Slot of tags (0 or 1).
 	 *
 	 * @returns The NoC tag attached to the underlying node ID is
 	 * returned.
 	 */
-	EXTERN int bostan_processor_node_sync_tag(int nodenum);
+	EXTERN int bostan_processor_node_sync_tag(int nodenum, int slot);
 
     /**
 	 * @brief Returns the mailbox NoC tag for a target NoC node ID.

--- a/include/arch/processor/bostan/noc/ctag.h
+++ b/include/arch/processor/bostan/noc/ctag.h
@@ -87,9 +87,9 @@
 	 */
 	/**@{*/
 	#define BOSTAN_MAILBOX_CNOC_TX_BASE 0 /**< C-NoC Transfer Tag reserved for Mailbox. */
-	#define BOSTAN_SYNC_CNOC_TX_BASE    1 /**< C-NoC Transfer Tag reserved for Sync.    */
-	#define BOSTAN_PORTAL_CNOC_TX_BASE  2 /**< C-NoC Transfer Tag reserved for Portal.  */
-//! #define BOSTAN_PORTAL_CNOC_TX_BASE  3 /**< C-NoC Transfer Tag reserved for Portal.  */
+	#define BOSTAN_PORTAL_CNOC_TX_BASE  1 /**< C-NoC Transfer Tag reserved for Portal.  */
+	#define BOSTAN_SYNC_CNOC_TX_BASE    2 /**< C-NoC Transfer Tag reserved for Sync.    */
+//! #define BOSTAN_PORTAL_CNOC_TX_BASE  3 /**< C-NoC Transfer Tag reserved for Sync.    */
 	/**@}*/
 
 	/**
@@ -163,6 +163,16 @@
 		uint64_t mask,
 		bostan_processor_noc_handler_fn handler
 	);
+
+	/**
+	 * @brief Reads C-NoC buffer.
+	 *
+	 * @param interface Number of the DMA channel.
+	 * @param tag       Number of receiver buffer.
+	 *
+	 * @return Receiver buffer value.
+	 */
+	EXTERN uint64_t bostan_cnoc_rx_read(int interface, int tag);
 
 /*============================================================================*
  * C-Noc Transfer Interface                                                   *

--- a/include/arch/processor/bostan/noc/dma.h
+++ b/include/arch/processor/bostan/noc/dma.h
@@ -65,6 +65,7 @@
 	 *
 	 * @param interface Number of the DMA channel.
 	 * @param tag       Number of the control receiver buffer.
+	 * @param mode      C-NoC receiver mode.
 	 * @param mask      Initial value of the buffer.
 	 * @param handler   Interrupt handler to receive the signal (if NULL use events).
 	 *
@@ -73,6 +74,7 @@
 	EXTERN int bostan_dma_control_create(
 		int interface,
 		int tag,
+		int mode,
 		uint64_t mask,
 		bostan_processor_noc_handler_fn handler
 	);
@@ -82,6 +84,7 @@
 	 *
 	 * @param interface Number of the DMA channel.
 	 * @param tag       Number of the control receiver buffer.
+	 * @param mode      C-NoC receiver mode.
 	 * @param mask      Initial value of the buffer.
 	 * @param handler   Interrupt handler to receive the signal (if NULL use events).
 	 *
@@ -90,6 +93,7 @@
 	static inline int bostan_dma_control_config(
 		int interface,
 		int tag,
+		int mode,
 		uint64_t mask,
 		bostan_processor_noc_handler_fn handler
 	)
@@ -97,7 +101,7 @@
 		return bostan_cnoc_rx_config(
 			interface,
 			tag,
-			BOSTAN_CNOC_BARRIER_MODE,
+			mode,
 			mask,
 			handler
 		);
@@ -172,9 +176,9 @@
 	EXTERN int bostan_dma_control_signal(
 		int interface,
 		int tag,
-		const int *remotes,
+		const int * remotes,
 		int nremotes,
-		int remote_tag,
+		const int * remotes_tags,
 		uint64_t mask
 	);
 

--- a/include/arch/target/kalray/mppa256/sync.h
+++ b/include/arch/target/kalray/mppa256/sync.h
@@ -59,6 +59,22 @@
 	/**@}*/
 
 	/**
+	* @name File descriptor offset.
+	*/
+	/**@{*/
+	#define MPPA256_SYNC_CREATE_OFFSET 0                       /**< Initial File Descriptor ID for Creates. */
+	#define MPPA256_SYNC_OPEN_OFFSET   MPPA256_SYNC_CREATE_MAX /**< Initial File Descriptor ID for Opens.   */
+	/**@}*/
+
+	/**
+	 * @todo TODO: rely on dummy platform-independent dummy function.
+	 *
+	 * @todo Maybe this function can be used to initialize the intercluster
+	 * fence resources.
+	 */
+	EXTERN void mppa256_sync_setup(void);
+
+	/**
 	 * @brief Allocates and configures the receiving side of the synchronization point.
 	 *
 	 * @param nodenums Logic IDs of target NoC nodes.
@@ -147,67 +163,52 @@
 	 * @see BOSTAN_SYNC_OPEN_MAX
 	 */
 	/**@{*/
-	#define SYNC_CREATE_MAX MPPA256_SYNC_CREATE_MAX
-	#define SYNC_OPEN_MAX   MPPA256_SYNC_OPEN_MAX
+	#define SYNC_CREATE_MAX    MPPA256_SYNC_CREATE_MAX    /**< MPPA256_SYNC_CREATE_MAX    */
+	#define SYNC_CREATE_OFFSET MPPA256_SYNC_CREATE_OFFSET /**< MPPA256_SYNC_CREATE_OFFSET */
+	#define SYNC_OPEN_MAX      MPPA256_SYNC_OPEN_MAX      /**< MPPA256_SYNC_OPEN_MAX      */
+	#define SYNC_OPEN_OFFSET   MPPA256_SYNC_OPEN_OFFSET   /**< MPPA256_SYNC_OPEN_OFFSET   */
 	/**@}*/
 
 	/**
-	 * @todo TODO: rely on dummy platform-independent dummy function.
-	 *
-	 * @todo Maybe this function can be used to initialize the intercluster
-	 * fence resources.
+	 * @see mppa256_sync_setup()
 	 */
-	static inline void sync_setup(void)
-	{
-
-	}
+	#define __sync_setup() \
+		mppa256_sync_setup()
 
 	/**
 	 * @see mppa256_sync_create()
 	 */
-	static inline int sync_create(const int *nodenums, int nnodes, int type)
-	{
-		return mppa256_sync_create(nodenums, nnodes, type);
-	}
+	#define __sync_create(nodenums, nnodes, type) \
+		mppa256_sync_create(nodenums, nnodes, type)
 
 	/**
 	 * @see mppa256_sync_open()
 	 */
-	static inline int sync_open(const int *nodenums, int nnodes, int type)
-	{
-		return mppa256_sync_open(nodenums, nnodes, type);
-	}
+	#define __sync_open(nodenums, nnodes, type) \
+		mppa256_sync_open(nodenums, nnodes, type)
 
 	/**
 	 * @see mppa256_sync_unlink()
 	 */
-	static inline int sync_unlink(int syncid)
-	{
-		return mppa256_sync_unlink(syncid);
-	}
+	#define __sync_unlink(syncid) \
+		mppa256_sync_unlink(syncid)
 
 	/**
 	 * @see mppa256_sync_close()
 	 */
-	static inline int sync_close(int syncid)
-	{
-		return mppa256_sync_close(syncid);
-	}
+	#define __sync_close(syncid) \
+		mppa256_sync_close(syncid)
 
 	/**
 	 * @see mppa256_sync_wait()
 	 */
-	static inline int sync_wait(int syncid)
-	{
-		return mppa256_sync_wait(syncid);
-	}
+	#define __sync_wait(syncid) \
+		mppa256_sync_wait(syncid)
 
 	/**
 	 * @see mppa256_sync_signal()
 	 */
-	static inline int sync_signal(int syncid)
-	{
-		return mppa256_sync_signal(syncid);
-	}
+	#define __sync_signal(syncid) \
+		mppa256_sync_signal(syncid)
 
 #endif /* TARGET_KALRAY_MPPA256_SYNC_H_ */

--- a/include/arch/target/unix64/unix64/sync.h
+++ b/include/arch/target/unix64/unix64/sync.h
@@ -55,6 +55,14 @@
 	/**@}*/
 
 	/**
+	* @name File descriptor offset.
+	*/
+	/**@{*/
+	#define UNIX64_SYNC_CREATE_OFFSET 0                      /**< Initial File Descriptor ID for Creates. */
+	#define UNIX64_SYNC_OPEN_OFFSET   UNIX64_SYNC_CREATE_MAX /**< Initial File Descriptor ID for Opens.   */
+	/**@}*/
+
+	/**
 	 * @brief Total number of sync points.
 	 */
 	#define UNIX64_SYNC_MAX (UNIX64_SYNC_CREATE_MAX + UNIX64_SYNC_OPEN_MAX)
@@ -67,6 +75,11 @@
 	PUBLIC void unix64_sync_shutdown(void);
 
 #endif
+
+	/**
+	 * @todo TODO: rely on dummy platform-independent dummy function.
+	 */
+	EXTERN void unix64_sync_setup(void);
 
 	/**
 	 * @brief Allocates and configures the receiving side of the synchronization point.
@@ -161,67 +174,55 @@
 	/**@}*/
 
 	/**@{*/
-	#define SYNC_ONE_TO_ALL UNIX64_SYNC_ONE_TO_ALL /**< UNIX64_SYNC_ONE_TO_ALL */
-	#define SYNC_ALL_TO_ONE UNIX64_SYNC_ALL_TO_ONE /**< UNIX64_SYNC_ALL_TO_ONE */
-	#define SYNC_CREATE_MAX UNIX64_SYNC_CREATE_MAX /**< UNIX64_SYNC_CREATE_MAX */
-	#define SYNC_OPEN_MAX   UNIX64_SYNC_OPEN_MAX   /**< UNIX64_SYNC_OPEN_MAX   */
+	#define SYNC_ONE_TO_ALL    UNIX64_SYNC_ONE_TO_ALL    /**< UNIX64_SYNC_ONE_TO_ALL    */
+	#define SYNC_ALL_TO_ONE    UNIX64_SYNC_ALL_TO_ONE    /**< UNIX64_SYNC_ALL_TO_ONE    */
+	#define SYNC_CREATE_MAX    UNIX64_SYNC_CREATE_MAX    /**< UNIX64_SYNC_CREATE_MAX    */
+	#define SYNC_CREATE_OFFSET UNIX64_SYNC_CREATE_OFFSET /**< UNIX64_SYNC_CREATE_OFFSET */
+	#define SYNC_OPEN_MAX      UNIX64_SYNC_OPEN_MAX      /**< UNIX64_SYNC_OPEN_MAX      */
+	#define SYNC_OPEN_OFFSET   UNIX64_SYNC_OPEN_OFFSET   /**< UNIX64_SYNC_OPEN_OFFSET   */
 	/**@}*/
 
 	/**
-	 * @todo TODO: rely on dummy platform-independent dummy function.
+	 * @see unix64_sync_setup()
 	 */
-	static inline void sync_setup(void)
-	{
-
-	}
+	#define __sync_setup() \
+		unix64_sync_setup()
 
 	/**
 	 * @see unix64_sync_create()
 	 */
-	static inline int sync_create(const int *nodes, int nnodes, int type)
-	{
-		return (unix64_sync_create(nodes, nnodes, type));
-	}
+	#define __sync_create(nodes, nnodes, type) \
+		unix64_sync_create(nodes, nnodes, type)
 
 	/**
 	 * @see unix64_sync_open()
 	 */
-	static inline int sync_open(const int *nodes, int nnodes, int type)
-	{
-		return (unix64_sync_open(nodes, nnodes, type));
-	}
+	#define __sync_open(nodes, nnodes, type) \
+		unix64_sync_open(nodes, nnodes, type)
 
 	/**
 	 * @see unix64_sync_unlink()
 	 */
-	static inline int sync_unlink(int syncid)
-	{
-		return (unix64_sync_unlink(syncid));
-	}
+	#define __sync_unlink(syncid) \
+		unix64_sync_unlink(syncid)
 
 	/**
 	 * @see unix64_sync_close()
 	 */
-	static inline int sync_close(int syncid)
-	{
-		return (unix64_sync_close(syncid));
-	}
+	#define __sync_close(syncid) \
+		unix64_sync_close(syncid)
 
 	/**
 	 * @see unix64_sync_wait()
 	 */
-	static inline int sync_wait(int syncid)
-	{
-		return (unix64_sync_wait(syncid));
-	}
+	#define __sync_wait(syncid) \
+		unix64_sync_wait(syncid)
 
 	/**
 	 * @see unix64_sync_signal()
 	 */
-	static inline int sync_signal(int syncid)
-	{
-		return (unix64_sync_signal(syncid));
-	}
+	#define __sync_signal(syncid) \
+		unix64_sync_signal(syncid)
 
 /**@}*/
 

--- a/include/nanvix/hal/target/sync.h
+++ b/include/nanvix/hal/target/sync.h
@@ -52,8 +52,14 @@
 		#ifndef SYNC_CREATE_MAX
 		#error "SYNC_CREATE_MAX not defined"
 		#endif
+		#ifndef SYNC_OPEN_OFFSET
+		#error "SYNC_OPEN_OFFSET not defined"
+		#endif
 		#ifndef SYNC_OPEN_MAX
 		#error "SYNC_OPEN_MAX not defined"
+		#endif
+		#ifndef SYNC_OPEN_OFFSET
+		#error "SYNC_OPEN_OFFSET not defined"
 		#endif
 
 		/* Functions */
@@ -86,10 +92,12 @@
 /* Dummy Constants */
 #if (!__TARGET_HAS_SYNC)
 
-	#define SYNC_ONE_TO_ALL 0
-	#define SYNC_ALL_TO_ONE 1
-	#define SYNC_CREATE_MAX 1
-	#define SYNC_OPEN_MAX   1
+	#define SYNC_ONE_TO_ALL    0
+	#define SYNC_ALL_TO_ONE    1
+	#define SYNC_CREATE_MAX    1
+	#define SYNC_CREATE_OFFSET 0
+	#define SYNC_OPEN_MAX      1
+	#define SYNC_OPEN_OFFSET   SYNC_CREATE_MAX
 
 #endif /* !__TARGET_HAS_SYNC */
 
@@ -112,14 +120,7 @@
 	/**
 	 * @brief Initializes the sync interface.
 	 */
-#if (__TARGET_HAS_SYNC)
 	EXTERN void sync_setup(void);
-#else
-	static inline void sync_setup(void)
-	{
-
-	}
-#endif
 
 	/**
 	 * @brief Allocates and configures the receiving side of the synchronization point.
@@ -130,18 +131,7 @@
 	 *
 	 * @return The tag of underlying resource ID.
 	 */
-#if (__TARGET_HAS_SYNC)
 	EXTERN int sync_create(const int *nodenums, int nnodes, int type);
-#else
-	static inline int sync_create(const int *nodenums, int nnodes, int type)
-	{
-		UNUSED(nodenums);
-		UNUSED(nnodes);
-		UNUSED(type);
-
-		return (-ENOSYS);
-	}
-#endif
 
 	/**
 	 * @brief Allocates and configures the sending side of the synchronization point.
@@ -152,19 +142,7 @@
 	 *
 	 * @return The tag of underlying resource ID.
 	 */
-#if (__TARGET_HAS_SYNC)
 	EXTERN int sync_open(const int *nodenums, int nnodes, int type);
-#else
-	static inline int sync_open(const int *nodenums, int nnodes, int type)
-	{
-		UNUSED(nodenums);
-		UNUSED(nnodes);
-		UNUSED(type);
-
-		return (-ENOSYS);
-	}
-#endif
-
 	/**
 	 * @brief Releases and cleans receiver buffer.
 	 *
@@ -172,16 +150,7 @@
 	 *
 	 * @return Zero if free the resource and non zero otherwise.
 	 */
-#if (__TARGET_HAS_SYNC)
 	EXTERN int sync_unlink(int syncid);
-#else
-	static inline int sync_unlink(int syncid)
-	{
-		UNUSED(syncid);
-
-		return (-ENOSYS);
-	}
-#endif
 
 	/**
 	 * @brief Releases the sender resources on a specific DMA channel.
@@ -190,16 +159,7 @@
 	 *
 	 * @return Zero if free the resource and non zero otherwise.
 	 */
-#if (__TARGET_HAS_SYNC)
 	EXTERN int sync_close(int syncid);
-#else
-	static inline int sync_close(int syncid)
-	{
-		UNUSED(syncid);
-
-		return (-ENOSYS);
-	}
-#endif
 
 	/**
 	 * @brief Wait signal on a specific synchronization point.
@@ -208,16 +168,7 @@
 	 *
 	 * @return Zero if wait signal correctly and non zero otherwise.
 	 */
-#if (__TARGET_HAS_SYNC)
 	EXTERN int sync_wait(int syncid);
-#else
-	static inline int sync_wait(int syncid)
-	{
-		UNUSED(syncid);
-
-		return (-ENOSYS);
-	}
-#endif
 
 	/**
 	 * @brief Send signal on a specific synchronization point.
@@ -229,16 +180,7 @@
 	 *
 	 * @return Zero if send signal correctly and non zero otherwise.
 	 */
-#if (__TARGET_HAS_SYNC)
 	EXTERN int sync_signal(int syncid);
-#else
-	static inline int sync_signal(int syncid)
-	{
-		UNUSED(syncid);
-
-		return (-ENOSYS);
-	}
-#endif
 
 /**@}*/
 

--- a/src/hal/arch/processor/bostan/ctag.c
+++ b/src/hal/arch/processor/bostan/ctag.c
@@ -635,6 +635,28 @@ PUBLIC int bostan_cnoc_rx_config(
 }
 
 /*============================================================================*
+ * bostan_cnoc_rx_read()                                                      *
+ *============================================================================*/
+
+/**
+ * @brief Wait events on C-NoC receiver tag.
+ *
+ * @param interface Number of the DMA channel.
+ * @param tag       Number of receiver tag.
+ *
+ * @return Receiver buffer value.
+ */
+PUBLIC int bostan_cnoc_rx_read(int interface, int tag)
+{
+	if (!bostan_cnoc_rx_is_valid(interface, tag))
+		return (-EINVAL);
+
+	if (!bostan_cnoc_rx_is_used(interface, tag))
+		return (-EINVAL);
+
+	return (mppa_cnoc[interface]->message_ram[tag].dword);
+}
+/*============================================================================*
  * bostan_cnoc_tx_alloc()                                                     *
  *============================================================================*/
 

--- a/src/hal/arch/processor/bostan/dma.c
+++ b/src/hal/arch/processor/bostan/dma.c
@@ -48,6 +48,7 @@
 PUBLIC int bostan_dma_control_create(
 	int interface,
 	int tag,
+	int mode,
 	uint64_t mask,
 	bostan_processor_noc_handler_fn handler
 )
@@ -55,7 +56,7 @@ PUBLIC int bostan_dma_control_create(
 	if (bostan_cnoc_rx_alloc(interface, tag) != 0)
 		return (-EBUSY);
 
-	if (bostan_cnoc_rx_config(interface, tag, BOSTAN_CNOC_BARRIER_MODE, mask, handler) != 0)
+	if (bostan_cnoc_rx_config(interface, tag, mode, mask, handler) != 0)
 	{
 		bostan_cnoc_rx_free(interface, tag);
 		return (-ECONNABORTED);
@@ -83,7 +84,7 @@ PUBLIC int bostan_dma_control_create(
 PUBLIC int bostan_dma_control_signal(
 	int interface,
 	int tag,
-	const int *remotes,
+	const int * remotes,
 	int nremotes,
 	int remote_tag,
 	uint64_t mask

--- a/src/hal/arch/processor/bostan/noc.c
+++ b/src/hal/arch/processor/bostan/noc.c
@@ -196,15 +196,16 @@ PUBLIC int bostan_processor_node_portal_tag(int nodenum)
  * @brief Returns the synchronization NoC tag for a target NoC node ID.
  *
  * @param nodenum Logic ID of the target NoC node.
+ * @param slot    Slot of tags (0 or 1).
  *
  * @note This function is non-blocking.
  * @note This function is thread-safe.
  */
-PUBLIC int bostan_processor_node_sync_tag(int nodenum)
+PUBLIC int bostan_processor_node_sync_tag(int nodenum, int slot)
 {
 	/* Invalid nodenum. */
 	if (!WITHIN(nodenum, 0, PROCESSOR_NOC_NODES_NUM))
 		return (-EINVAL);
 
-	return (BOSTAN_SYNC_RX_OFF + nodenum);
+	return (BOSTAN_SYNC_RX_OFF + nodenum + (slot * PROCESSOR_NOC_NODES_NUM));
 }

--- a/src/hal/target/sync.c
+++ b/src/hal/target/sync.c
@@ -1,0 +1,333 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <nanvix/hal/target/portal.h>
+#include <posix/errno.h>
+#include <posix/stddef.h>
+#include <posix/stdint.h>
+
+/*============================================================================*
+ * sync_rx_is_valid()                                                         *
+ *============================================================================*/
+
+#if (__TARGET_HAS_SYNC)
+
+/**
+ * @brief Asserts whether or not a receiver portal is valid.
+ *
+ * @param syncid ID of the target portal.
+ *
+ * @returns One if the target portal is valid, and false
+ * otherwise.
+ *
+ * @note This function is non-blocking.
+ * @note This function is thread-safe.
+ * @note This function is reentrant.
+ */
+PRIVATE int sync_rx_is_valid(int syncid)
+{
+	return (
+		WITHIN(
+			syncid,
+			SYNC_CREATE_OFFSET,
+			SYNC_CREATE_OFFSET + SYNC_CREATE_MAX
+		)
+	);
+}
+
+#endif /* __TARGET_HAS_SYNC */
+
+/*============================================================================*
+ * sync_tx_is_valid()                                                         *
+ *============================================================================*/
+
+#if (__TARGET_HAS_SYNC)
+
+/**
+ * @brief Asserts whether or not a sender portal is valid.
+ *
+ * @param syncid ID of the target portal.
+ *
+ * @returns One if the target portal is valid, and false
+ * otherwise.
+ *
+ * @note This function is non-blocking.
+ * @note This function is thread-safe.
+ * @note This function is reentrant.
+ */
+PRIVATE int sync_tx_is_valid(int syncid)
+{
+	return (
+		WITHIN(
+			syncid,
+			SYNC_OPEN_OFFSET,
+			SYNC_OPEN_OFFSET + SYNC_OPEN_MAX
+		)
+	);
+}
+
+#endif /* __TARGET_HAS_SYNC */
+
+/*============================================================================*
+ * sync_nodelist_is_valid()                                                   *
+ *============================================================================*/
+
+#if (__TARGET_HAS_SYNC)
+
+/**
+ * @brief Node list validation.
+ *
+ * @param local  Logic ID of local node.
+ * @param nodes  IDs of target NoC nodes.
+ * @param nnodes Number of target NoC nodes.
+ *
+ * @return Non zero if node list is valid and zero otherwise.
+ */
+PRIVATE int sync_nodelist_is_valid(const int * nodes, int nnodes, int is_the_one)
+{
+	int local;       /* Local node.          */
+	uint64_t checks; /* Bit-stream of nodes. */
+
+	checks = 0ULL;
+	local  = processor_node_get_num();
+
+	/* Is the local the one? */
+	if (is_the_one && (nodes[0] != local))
+		return (0);
+
+	/* Isn't the local the one? */
+	if (!is_the_one && (nodes[0] == local))
+		return (0);
+
+	/* Build nodelist. */
+	for (int i = 0; i < nnodes; ++i)
+	{
+		/* Invalid node. */
+		if (!WITHIN(nodes[i], 0, PROCESSOR_NOC_NODES_NUM))
+			return (0);
+
+		/* Does a node appear twice? */
+		if (checks & (1ULL << nodes[i]))
+			return (0);
+
+		checks |= (1ULL << nodes[i]);
+	}
+
+	/* Is the local node founded? */
+	return (checks & (1ULL << local));
+}
+
+#endif /* __TARGET_HAS_SYNC */
+
+/*============================================================================*
+ * sync_create()                                                              *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC int sync_create(const int * nodes, int nnodes, int type)
+{
+#if (__TARGET_HAS_SYNC)
+	int is_the_one;
+
+	/*  Invalid nodes list. */
+	if (nodes == NULL)
+		return (-EINVAL);
+
+	/* Bad nodes list. */
+	if (!WITHIN(nnodes, 2, PROCESSOR_NOC_NODES_NUM + 1))
+		return (-EINVAL);
+
+	/* Bad sync type. */
+	if ((type != SYNC_ONE_TO_ALL) && (type != SYNC_ALL_TO_ONE))
+		return (-EINVAL);
+
+	is_the_one = (type == SYNC_ALL_TO_ONE);
+
+	/* Is nodelist valid? */
+	if (!sync_nodelist_is_valid(nodes, nnodes, is_the_one))
+		return (-EINVAL);
+
+	return (__sync_create(nodes, nnodes, type));
+
+#else /* __TARGET_HAS_SYNC */
+	UNUSED(nodes);
+	UNUSED(nnodes);
+	UNUSED(type);
+
+	return (-ENOSYS);
+#endif /* __TARGET_HAS_SYNC */
+}
+
+/*============================================================================*
+ * sync_open()                                                                *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC int sync_open(const int * nodes, int nnodes, int type)
+{
+#if (__TARGET_HAS_SYNC)
+	int is_the_one;
+
+	/*  Invalid nodes list. */
+	if (nodes == NULL)
+		return (-EINVAL);
+
+	/* Bad nodes list. */
+	if (!WITHIN(nnodes, 2, PROCESSOR_NOC_NODES_NUM + 1))
+		return (-EINVAL);
+
+	/* Bad sync type. */
+	if ((type != SYNC_ONE_TO_ALL) && (type != SYNC_ALL_TO_ONE))
+		return (-EINVAL);
+
+	is_the_one = (type == SYNC_ONE_TO_ALL);
+
+	/* Is nodelist valid? */
+	if (!sync_nodelist_is_valid(nodes, nnodes, is_the_one))
+		return (-EINVAL);
+
+	return (__sync_open(nodes, nnodes, type));
+
+#else /* __TARGET_HAS_SYNC */
+	UNUSED(nodes);
+	UNUSED(nnodes);
+	UNUSED(type);
+
+	return (-ENOSYS);
+#endif /* __TARGET_HAS_SYNC */
+}
+
+/*============================================================================*
+ * sync_unlink()                                                              *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC int sync_unlink(int syncid)
+{
+#if (__TARGET_HAS_SYNC)
+
+	/* Invalid portal. */
+	if (!sync_rx_is_valid(syncid))
+		return (-EBADF);
+
+	return (__sync_unlink(syncid));
+
+#else /* __TARGET_HAS_SYNC */
+	UNUSED(syncid);
+
+	return (-ENOSYS);
+#endif /* __TARGET_HAS_SYNC */
+}
+
+/*============================================================================*
+ * sync_close()                                                               *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC int sync_close(int syncid)
+{
+#if (__TARGET_HAS_SYNC)
+
+	/* Invalid portal. */
+	if (!sync_tx_is_valid(syncid))
+		return (-EBADF);
+
+	return (__sync_close(syncid));
+
+#else /* __TARGET_HAS_SYNC */
+	UNUSED(syncid);
+
+	return (-ENOSYS);
+#endif /* __TARGET_HAS_SYNC */
+}
+
+/*============================================================================*
+ * sync_signal()                                                              *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC ssize_t sync_signal(int syncid)
+{
+#if (__TARGET_HAS_SYNC)
+
+	/* Invalid NoC node ID. */
+	if (!sync_tx_is_valid(syncid))
+		return (-EBADF);
+
+	return (__sync_signal(syncid));
+
+#else /* __TARGET_HAS_SYNC */
+	UNUSED(syncid);
+
+	return (-ENOSYS);
+#endif /* __TARGET_HAS_SYNC */
+}
+
+/*============================================================================*
+ * sync_wait()                                                                *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC int sync_wait(int syncid)
+{
+#if (__TARGET_HAS_SYNC)
+
+	/* Invalid mailbox. */
+	if (!sync_rx_is_valid(syncid))
+		return (-EBADF);
+
+	return (__sync_wait(syncid));
+
+#else /* __TARGET_HAS_SYNC */
+	UNUSED(syncid);
+
+	return (-ENOSYS);
+#endif /* __TARGET_HAS_SYNC */
+}
+
+/*============================================================================*
+ * sync_setup()                                                               *
+ *============================================================================*/
+
+/**
+ * @todo TODO: provide a detailed description for this function.
+ */
+PUBLIC void sync_setup(void)
+{
+#if (__TARGET_HAS_SYNC)
+	__sync_setup();
+#endif /* __TARGET_HAS_SYNC */
+}


### PR DESCRIPTION
In this PR, I change de sync system to support the differents node lists in an independent manner. The interface still the same where the main changes occurred in Unix and MPPA-256 implementation. An important point is the abstraction of the checks like mailbox/portal targets.

**Obs.: Not tested on MPPA-256 yet.**
_____
# Implementation overview
## Common
- A signal message is a [hash](https://github.com/nanvix/hal/blob/enhancement-sync-refactor/src/hal/arch/target/unix64/sync.c#L51) as follow:
``` c
struct hash
{
	uint64_t source    :  5;
	uint64_t type      :  1;
	uint64_t master    :  5;
	uint64_t nodeslist : 20;
	uint64_t unused    : 33;
};
```
## Unix

- Each node has a unique mqueue to receive signal messages;
- Wait operation will read a message and updates the barrier hash (node list of nodes that sent a signal) and will try reads while the barrier node is not complete;
- The read on mqueue is protected and only one thread can read and updates the barrier value;
- When a barrier is complete, a counter is incremented. That way, we will not miss the signals if the receiver has not yet waited for it. However, there will be losses if a signal is received from the same emitter in the same synchronization step (barrier not completed).

## MPPA-256

- Each node open a C-NoC slot to receive the hash;
- The receiver handler perform a similar behavior of Unix system, but the counter is now a semaphore where handler does an `up` and slave a `down` on semaphore.
- To the sender not overwrite a previews hash that not been consumed yet, a control flow similar to mailbox is introduced. In this way, the sender only will send a signal when the slave as ready to receive it.
- When the sender isn't allowed to emit the signal, it returns an `-EAGAIN` error.