### PR TITLE
[target] Missing Constants and Checks

### DIFF
--- a/include/arch/target/kalray/mppa256/mailbox.h
+++ b/include/arch/target/kalray/mppa256/mailbox.h
@@ -55,7 +55,9 @@
 	 * @name Sizes (in bytes) of a mailbox message.
 	 */
 	/**@{*/
-	#define MPPA256_MAILBOX_MSG_SIZE 128 /**< Data size. */
+	#define MPPA256_MAILBOX_HEADER_SIZE (3 * 4)                                                   /**< Header size (3 * sizeof(int)). */
+	#define MPPA256_MAILBOX_DATA_SIZE   (120)                                                     /**< Data size.                     */
+	#define MPPA256_MAILBOX_MSG_SIZE    (MPPA256_MAILBOX_HEADER_SIZE + MPPA256_MAILBOX_DATA_SIZE) /**< Message size.                  */
 	/**@}*/
 
 	/**
@@ -155,11 +157,13 @@
 	 * @name Provided Constants
 	 */
 	/**@{*/
-	#define HAL_MAILBOX_MSG_SIZE      MPPA256_MAILBOX_MSG_SIZE      /**< MPPA256_MAILBOX_MSG_SIZE      */
 	#define HAL_MAILBOX_CREATE_OFFSET MPPA256_MAILBOX_CREATE_OFFSET /**< MPPA256_MAILBOX_CREATE_OFFSET */
 	#define HAL_MAILBOX_OPEN_OFFSET   MPPA256_MAILBOX_OPEN_OFFSET   /**< MPPA256_MAILBOX_OPEN_OFFSET   */
 	#define HAL_MAILBOX_CREATE_MAX    MPPA256_MAILBOX_CREATE_MAX    /**< MPPA256_MAILBOX_CREATE_MAX    */
 	#define HAL_MAILBOX_OPEN_MAX      MPPA256_MAILBOX_OPEN_MAX      /**< MPPA256_MAILBOX_OPEN_MAX      */
+	#define HAL_MAILBOX_HEADER_SIZE   MPPA256_MAILBOX_HEADER_SIZE   /**< MPPA256_MAILBOX_MSG_SIZE      */
+	#define HAL_MAILBOX_DATA_SIZE     MPPA256_MAILBOX_DATA_SIZE     /**< MPPA256_MAILBOX_MSG_SIZE      */
+	#define HAL_MAILBOX_MSG_SIZE      MPPA256_MAILBOX_MSG_SIZE      /**< MPPA256_MAILBOX_MSG_SIZE      */
 	/**@}*/
 
 	/**

--- a/include/arch/target/kalray/mppa256/portal.h
+++ b/include/arch/target/kalray/mppa256/portal.h
@@ -26,7 +26,7 @@
 #define TARGET_KALRAY_MPPA256_PORTAL_H_
 
 /*============================================================================*
- *                            Mailbox Interface                               *
+ *                            Portal Interface                                *
  *============================================================================*/
 
 	/* Processor API. */
@@ -52,9 +52,13 @@
 	/**@}*/
 
 	/**
-	 * @brief Maximum size of transfer data.
+	 * @name Sizes (in bytes) of a portal message.
 	 */
-	#define MPPA256_PORTAL_MAX_SIZE (8*KB)
+	/**@{*/
+	#define MPPA256_PORTAL_RESERVED_SIZE (3 * 4)                                                   /**< Header size (3 * sizeof(int)). */
+	#define MPPA256_PORTAL_DATA_SIZE     (8*KB)                                                    /**< Maximum data size.             */
+	#define MPPA256_PORTAL_MAX_SIZE      (MPPA256_PORTAL_RESERVED_SIZE + MPPA256_PORTAL_DATA_SIZE) /**< Maximum size.                  */
+	/**@}*/
 
 	/**
 	 * @brief Creates a portal.
@@ -166,11 +170,13 @@
 	 * @name Provided Constants
 	 */
 	/**@{*/
-	#define HAL_PORTAL_CREATE_MAX    MPPA256_PORTAL_CREATE_MAX    /**< @see MPPA256_PORTAL_CREATE_MAX */
-	#define HAL_PORTAL_CREATE_OFFSET MPPA256_PORTAL_CREATE_OFFSET /**< MPPA256_PORTAL_CREATE_OFFSET   */
-	#define HAL_PORTAL_OPEN_MAX      MPPA256_PORTAL_OPEN_MAX      /**< @see MPPA256_PORTAL_OPEN_MAX   */
-	#define HAL_PORTAL_OPEN_OFFSET   MPPA256_PORTAL_OPEN_OFFSET   /**< MPPA256_PORTAL_OPEN_OFFSET     */
-	#define HAL_PORTAL_MAX_SIZE      MPPA256_PORTAL_MAX_SIZE      /**< @see MPPA256_PORTAL_MAX_SIZE   */
+	#define HAL_PORTAL_CREATE_MAX    MPPA256_PORTAL_CREATE_MAX    /**< @see MPPA256_PORTAL_CREATE_MAX    */
+	#define HAL_PORTAL_CREATE_OFFSET MPPA256_PORTAL_CREATE_OFFSET /**< @see MPPA256_PORTAL_CREATE_OFFSET */
+	#define HAL_PORTAL_OPEN_MAX      MPPA256_PORTAL_OPEN_MAX      /**< @see MPPA256_PORTAL_OPEN_MAX      */
+	#define HAL_PORTAL_OPEN_OFFSET   MPPA256_PORTAL_OPEN_OFFSET   /**< @see MPPA256_PORTAL_OPEN_OFFSET   */
+	#define HAL_PORTAL_RESERVED_SIZE MPPA256_PORTAL_RESERVED_SIZE /**< @see MPPA256_PORTAL_RESERVED_SIZE */
+	#define HAL_PORTAL_DATA_SIZE     MPPA256_PORTAL_DATA_SIZE     /**< @see MPPA256_PORTAL_DATA_SIZE     */
+	#define HAL_PORTAL_MAX_SIZE      MPPA256_PORTAL_MAX_SIZE      /**< @see MPPA256_PORTAL_MAX_SIZE      */
 	/**@}*/
 
 	/**

--- a/include/arch/target/unix64/unix64/mailbox.h
+++ b/include/arch/target/unix64/unix64/mailbox.h
@@ -59,7 +59,9 @@
 	 * @name Sizes (in bytes) of a mailbox message.
 	 */
 	/**@{*/
-	#define UNIX64_MAILBOX_MSG_SIZE 128 /**< Data size. */
+	#define UNIX64_MAILBOX_RESERVED_SIZE (3 * 4)                                                   /**< Header size (3 * sizeof(int)). */
+	#define UNIX64_MAILBOX_DATA_SIZE     (120)                                                     /**< Data size.                     */
+	#define UNIX64_MAILBOX_MSG_SIZE      (UNIX64_MAILBOX_RESERVED_SIZE + UNIX64_MAILBOX_DATA_SIZE) /**< Message size.                  */
 	/**@}*/
 
 #ifdef __NANVIX_HAL
@@ -165,11 +167,13 @@
 	 * @name Provided Constants
 	 */
 	/**@{*/
-	#define HAL_MAILBOX_MSG_SIZE      UNIX64_MAILBOX_MSG_SIZE      /**< UNIX64_MAILBOX_MSG_SIZE      */
-	#define HAL_MAILBOX_CREATE_OFFSET UNIX64_MAILBOX_CREATE_OFFSET /**< UNIX64_MAILBOX_CREATE_OFFSET */
-	#define HAL_MAILBOX_OPEN_OFFSET   UNIX64_MAILBOX_OPEN_OFFSET   /**< UNIX64_MAILBOX_OPEN_OFFSET   */
-	#define HAL_MAILBOX_CREATE_MAX    UNIX64_MAILBOX_CREATE_MAX    /**< UNIX64_MAILBOX_CREATE_MAX    */
-	#define HAL_MAILBOX_OPEN_MAX      UNIX64_MAILBOX_OPEN_MAX      /**< UNIX64_MAILBOX_OPEN_MAX      */
+	#define HAL_MAILBOX_CREATE_OFFSET UNIX64_MAILBOX_CREATE_OFFSET /**< @see UNIX64_MAILBOX_CREATE_OFFSET */
+	#define HAL_MAILBOX_OPEN_OFFSET   UNIX64_MAILBOX_OPEN_OFFSET   /**< @see UNIX64_MAILBOX_OPEN_OFFSET   */
+	#define HAL_MAILBOX_CREATE_MAX    UNIX64_MAILBOX_CREATE_MAX    /**< @see UNIX64_MAILBOX_CREATE_MAX    */
+	#define HAL_MAILBOX_OPEN_MAX      UNIX64_MAILBOX_OPEN_MAX      /**< @see UNIX64_MAILBOX_OPEN_MAX      */
+	#define HAL_MAILBOX_RESERVED_SIZE UNIX64_MAILBOX_RESERVED_SIZE /**< @see UNIX64_MAILBOX_RESERVED_SIZE */
+	#define HAL_MAILBOX_DATA_SIZE     UNIX64_MAILBOX_DATA_SIZE     /**< @see UNIX64_MAILBOX_DATA_SIZE     */
+	#define HAL_MAILBOX_MSG_SIZE      UNIX64_MAILBOX_MSG_SIZE      /**< @see UNIX64_MAILBOX_MSG_SIZE      */
 	/**@}*/
 
 #ifdef __NANVIX_HAL

--- a/include/arch/target/unix64/unix64/portal.h
+++ b/include/arch/target/unix64/unix64/portal.h
@@ -56,9 +56,13 @@
 	/**@}*/
 
 	/**
-	 * @brief Maximum size of transfer data.
+	 * @name Sizes (in bytes) of a portal message.
 	 */
-	#define UNIX64_PORTAL_MAX_SIZE (8*KB)
+	/**@{*/
+	#define UNIX64_PORTAL_RESERVED_SIZE (3 * 4)                                                 /**< Header size (3 * sizeof(int)). */
+	#define UNIX64_PORTAL_DATA_SIZE     (8*KB)                                                  /**< Maximum data size.             */
+	#define UNIX64_PORTAL_MAX_SIZE      (UNIX64_PORTAL_RESERVED_SIZE + UNIX64_PORTAL_DATA_SIZE) /**< Maximum size.                  */
+	/**@}*/
 
 #ifdef __NANVIX_HAL
 
@@ -182,11 +186,13 @@
 	 * @name Provided Constants
 	 */
 	/**@{*/
-	#define HAL_PORTAL_CREATE_MAX    UNIX64_PORTAL_CREATE_MAX    /**< UNIX64_PORTAL_CREATE_MAX    */
-	#define HAL_PORTAL_CREATE_OFFSET UNIX64_PORTAL_CREATE_OFFSET /**< UNIX64_PORTAL_CREATE_OFFSET */
-	#define HAL_PORTAL_OPEN_MAX      UNIX64_PORTAL_OPEN_MAX      /**< UNIX64_PORTAL_OPEN_MAX      */
-	#define HAL_PORTAL_OPEN_OFFSET   UNIX64_PORTAL_OPEN_OFFSET   /**< UNIX64_PORTAL_OPEN_OFFSET   */
-	#define HAL_PORTAL_MAX_SIZE      UNIX64_PORTAL_MAX_SIZE      /**< UNIX64_PORTAL_MAX_SIZE      */
+	#define HAL_PORTAL_CREATE_MAX    UNIX64_PORTAL_CREATE_MAX    /**< @see UNIX64_PORTAL_CREATE_MAX    */
+	#define HAL_PORTAL_CREATE_OFFSET UNIX64_PORTAL_CREATE_OFFSET /**< @see UNIX64_PORTAL_CREATE_OFFSET */
+	#define HAL_PORTAL_OPEN_MAX      UNIX64_PORTAL_OPEN_MAX      /**< @see UNIX64_PORTAL_OPEN_MAX      */
+	#define HAL_PORTAL_OPEN_OFFSET   UNIX64_PORTAL_OPEN_OFFSET   /**< @see UNIX64_PORTAL_OPEN_OFFSET   */
+	#define HAL_PORTAL_RESERVED_SIZE UNIX64_PORTAL_RESERVED_SIZE /**< @see UNIX64_PORTAL_RESERVED_SIZE */
+	#define HAL_PORTAL_DATA_SIZE     UNIX64_PORTAL_DATA_SIZE     /**< @see UNIX64_PORTAL_DATA_SIZE     */
+	#define HAL_PORTAL_MAX_SIZE      UNIX64_PORTAL_MAX_SIZE      /**< @see UNIX64_PORTAL_MAX_SIZE      */
 	/**@}*/
 
 	/**

--- a/include/nanvix/hal/target/mailbox.h
+++ b/include/nanvix/hal/target/mailbox.h
@@ -43,9 +43,6 @@
 	#if (__TARGET_HAS_MAILBOX)
 
 		/* Constants */
-		#ifndef HAL_MAILBOX_MSG_SIZE
-		#error "HAL_MAILBOX_MSG_SIZE not defined"
-		#endif
 		#ifndef HAL_MAILBOX_CREATE_OFFSET
 		#error "HAL_MAILBOX_CREATE_OFFSET not defined"
 		#endif
@@ -57,6 +54,15 @@
 		#endif
 		#ifndef HAL_MAILBOX_OPEN_MAX
 		#error "HAL_MAILBOX_OPEN_MAX not defined"
+		#endif
+		#ifndef HAL_MAILBOX_MSG_SIZE
+		#error "HAL_MAILBOX_MSG_SIZE not defined"
+		#endif
+		#ifndef HAL_MAILBOX_RESERVED_SIZE
+		#error "HAL_MAILBOX_RESERVED_SIZE not defined"
+		#endif
+		#ifndef HAL_MAILBOX_DATA_SIZE
+		#error "HAL_PORTAL_DATA_SIZE not defined"
 		#endif
 
 		/* Functions */

--- a/include/nanvix/hal/target/portal.h
+++ b/include/nanvix/hal/target/portal.h
@@ -55,6 +55,12 @@
 		#ifndef HAL_PORTAL_OPEN_OFFSET
 		#error "HAL_PORTAL_OPEN_OFFSET not defined"
 		#endif
+		#ifndef HAL_PORTAL_RESERVED_SIZE
+		#error "HAL_PORTAL_RESERVED_SIZE not defined"
+		#endif
+		#ifndef HAL_PORTAL_DATA_SIZE
+		#error "HAL_PORTAL_DATA_SIZE not defined"
+		#endif
 		#ifndef HAL_PORTAL_MAX_SIZE
 		#error "HAL_PORTAL_MAX_SIZE not defined"
 		#endif

--- a/include/nanvix/hal/target/sync.h
+++ b/include/nanvix/hal/target/sync.h
@@ -43,23 +43,23 @@
 	#if (__TARGET_HAS_SYNC)
 
 		/* Constants */
-		#ifndef SYNC_ONE_TO_ALL
-		#error "SYNC_ONE_TO_ALL not defined"
-		#endif
-		#ifndef SYNC_ALL_TO_ONE
-		#error "SYNC_ALL_TO_ONE not defined"
-		#endif
 		#ifndef SYNC_CREATE_MAX
 		#error "SYNC_CREATE_MAX not defined"
 		#endif
-		#ifndef SYNC_OPEN_OFFSET
-		#error "SYNC_OPEN_OFFSET not defined"
+		#ifndef SYNC_CREATE_OFFSET
+		#error "SYNC_CREATE_OFFSET not defined"
 		#endif
 		#ifndef SYNC_OPEN_MAX
 		#error "SYNC_OPEN_MAX not defined"
 		#endif
 		#ifndef SYNC_OPEN_OFFSET
 		#error "SYNC_OPEN_OFFSET not defined"
+		#endif
+		#ifndef SYNC_ONE_TO_ALL
+		#error "SYNC_ONE_TO_ALL not defined"
+		#endif
+		#ifndef SYNC_ALL_TO_ONE
+		#error "SYNC_ALL_TO_ONE not defined"
 		#endif
 
 		/* Functions */

--- a/src/hal/target/portal.c
+++ b/src/hal/target/portal.c
@@ -255,7 +255,7 @@ PUBLIC ssize_t portal_awrite(int portalid, const void *buffer, uint64_t size)
 		return (-EINVAL);
 
 	/* Bad size. */
-	if (size == 0)
+	if (size == 0 || size > HAL_PORTAL_MAX_SIZE)
 		return (-EINVAL);
 
 	return (__portal_awrite(portalid, buffer, size));
@@ -289,7 +289,7 @@ PUBLIC ssize_t portal_aread(int portalid, void *buffer, uint64_t size)
 		return (-EINVAL);
 
 	/* Bad size. */
-	if (size == 0)
+	if (size == 0 || size > HAL_PORTAL_MAX_SIZE)
 		return (-EINVAL);
 
 	return (__portal_aread(portalid, buffer, size));


### PR DESCRIPTION
In this PR, I solved two problems:
- Introduces constants to define each part of a mailbox/portal message, i.e., header (reserved) and data sizes. The size of the data in the portal message is still 8 KB, as this eliminates the need to break data with sizes multiple of two, much used by the internal systems of Nanvix.
- Lack of verification of the maximum size of messages sent by the portal.

## Related issues
[[hal] Check for Read/Write Size in Portal Operations #557](https://github.com/nanvix/hal/issues/557)