### PR TITLE
[cluster] Core Reset in Two Phases

### DIFF
--- a/build/qemu-riscv32/make/makefile
+++ b/build/qemu-riscv32/make/makefile
@@ -49,7 +49,7 @@ export LD := $(TOOLCHAIN_DIR)/riscv32-elf-ld
 export AR := $(TOOLCHAIN_DIR)/riscv32-elf-ar
 
 # Timeout Variable
-export TIMEOUT ?= 10
+export TIMEOUT ?= 30
 
 # Compiler Options
 export CFLAGS += -march=rv32imac -mabi=ilp32 -mcmodel=medany

--- a/include/nanvix/hal/cluster.h
+++ b/include/nanvix/hal/cluster.h
@@ -113,11 +113,12 @@
 	 * @name States of a Core
 	 */
 	/**@{*/
-	#define CORE_IDLE      0 /**< Idle        */
-	#define CORE_SLEEPING  1 /**< Sleeping    */
-	#define CORE_RUNNING   2 /**< Running     */
-	#define CORE_RESETTING 3 /**< Resetting   */
-	#define CORE_OFFLINE   4 /**< Powered Off */
+	#define CORE_IDLE      0 /**< Idle          */
+	#define CORE_SLEEPING  1 /**< Sleeping      */
+	#define CORE_RUNNING   2 /**< Running       */
+	#define CORE_ZOMBIE    3 /**< Pre-resetting */
+	#define CORE_RESETTING 4 /**< Resetting     */
+	#define CORE_OFFLINE   5 /**< Powered Off   */
 	/**@}*/
 
 	/**
@@ -234,6 +235,11 @@
 	 * @brief Resumes instruction execution in the underlying core.
 	 */
 	EXTERN void core_run(void);
+
+	/**
+	 * @brief Pre-reset the underlying core.
+	 */
+	EXTERN int core_release(void);
 
 	/**
 	 * @brief Reset the underlying core.

--- a/src/test/cluster/cores.c
+++ b/src/test/cluster/cores.c
@@ -204,6 +204,7 @@ PRIVATE void slave(void)
 
 	fence_join(&slave_fence);
 
+	KASSERT(core_release() == 0);
 	core_reset();
 }
 
@@ -234,7 +235,10 @@ PRIVATE void slave_reset(void)
 
 	/* If first invocation, lets reset. */
 	if (slave_nstarts == 1)
+	{
+		KASSERT(core_release() == 0);
 		core_reset();
+	}
 
 #if (TEST_CORES_VERBOSE)
 	kprintf("[test][cluster][cores] core %d stopping", core_get_id());
@@ -342,6 +346,7 @@ PRIVATE void leader(void)
 
 	fence_join(&leader_fence);
 
+	KASSERT(core_release() == 0);
 	core_reset();
 }
 
@@ -664,6 +669,7 @@ PRIVATE void test_cluster_core_fault_start_inval(void)
  */
 PRIVATE void test_cluster_core_fault_reset_master(void)
 {
+	KASSERT(core_release() == -EINVAL);
 	KASSERT(core_reset() == -EINVAL);
 }
 
@@ -863,6 +869,7 @@ PRIVATE void consumer(void)
 
 	fence_join(&slave_fence);
 
+	KASSERT(core_release() == 0);
 	core_reset();
 }
 


### PR DESCRIPTION
In this PR, I introduce a pre-reset phase of the core to allow the upper layers to indicate when a core is close to being reset.

For this, I added a new state called `CORE_ZOMBIE`. When trying to call `core_start()` on a core that is in this state, a busy-wait is performed until the core enters the `CORE_RESETTING` state.

**Obs: `core_release` call is prerequisite of the `core_reset` call.**

## Related issue

- Closes https://github.com/nanvix/hal/issues/586