### PR TITLE
[noc] Sync Barrier Variable Uses Less Bits Than the Number of Nodes

### DIFF
--- a/src/hal/arch/target/mppa256/sync.c
+++ b/src/hal/arch/target/mppa256/sync.c
@@ -62,8 +62,8 @@ struct hash
 	uint64_t source    :  5;
 	uint64_t type      :  1;
 	uint64_t master    :  5;
-	uint64_t nodeslist : 20;
-	uint64_t unused    : 33;
+	uint64_t nodeslist : 24;
+	uint64_t unused    : 29;
 };
 
 #define HASH_INITIALIZER ((struct hash){-1, 0, -1, 0, 0})


### PR DESCRIPTION
In this PR, I increase the number of bits used to store the nodes list and the barrier in the sync of the MPPA-256.

## Resolved issue

[Sync barrier variable using fewer bits than the number of nodes #601](https://github.com/nanvix/hal/issues/601)