### PR TITLE
[target] Support for ONLY_MAILBOX Mode

### DIFF
--- a/include/arch/target/kalray/mppa256/portal.h
+++ b/include/arch/target/kalray/mppa256/portal.h
@@ -60,6 +60,8 @@
 	#define MPPA256_PORTAL_MAX_SIZE      (MPPA256_PORTAL_RESERVED_SIZE + MPPA256_PORTAL_DATA_SIZE) /**< Maximum size.                  */
 	/**@}*/
 
+#if !__NANVIX_IKC_USES_ONLY_MAILBOX
+
 	/**
 	 * @brief Setup portal module.
 	 */
@@ -152,6 +154,8 @@
 	 */
 	EXTERN int mppa256_portal_wait(int portalid);
 
+#endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX */
+
 /*============================================================================*
  *                              Exported Interface                            *
  *============================================================================*/
@@ -183,6 +187,8 @@
 	#define HAL_PORTAL_DATA_SIZE     MPPA256_PORTAL_DATA_SIZE     /**< @see MPPA256_PORTAL_DATA_SIZE     */
 	#define HAL_PORTAL_MAX_SIZE      MPPA256_PORTAL_MAX_SIZE      /**< @see MPPA256_PORTAL_MAX_SIZE      */
 	/**@}*/
+
+#if !__NANVIX_IKC_USES_ONLY_MAILBOX
 
 	/**
 	 * @see mppa256_portal_setup()
@@ -237,5 +243,7 @@
 	 */
 	#define __portal_wait(portalid) \
 		mppa256_portal_wait(portalid)
+
+#endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX */
 
 #endif /* TARGET_KALRAY_MPPA256_PORTAL_H_ */

--- a/include/arch/target/kalray/mppa256/sync.h
+++ b/include/arch/target/kalray/mppa256/sync.h
@@ -66,6 +66,8 @@
 	#define MPPA256_SYNC_OPEN_OFFSET   MPPA256_SYNC_CREATE_MAX /**< Initial File Descriptor ID for Opens.   */
 	/**@}*/
 
+#if !__NANVIX_IKC_USES_ONLY_MAILBOX
+
 	/**
 	 * @brief Setup sync module.
 	 */
@@ -129,6 +131,8 @@
 	 */
 	EXTERN int mppa256_sync_signal(int syncid);
 
+#endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX */
+
 /*============================================================================*
  *                              Exported Interface                            *
  *============================================================================*/
@@ -165,6 +169,8 @@
 	#define SYNC_OPEN_MAX      MPPA256_SYNC_OPEN_MAX      /**< MPPA256_SYNC_OPEN_MAX      */
 	#define SYNC_OPEN_OFFSET   MPPA256_SYNC_OPEN_OFFSET   /**< MPPA256_SYNC_OPEN_OFFSET   */
 	/**@}*/
+
+#if !__NANVIX_IKC_USES_ONLY_MAILBOX
 
 	/**
 	 * @see mppa256_sync_setup()
@@ -207,5 +213,7 @@
 	 */
 	#define __sync_signal(syncid) \
 		mppa256_sync_signal(syncid)
+
+#endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX */
 
 #endif /* TARGET_KALRAY_MPPA256_SYNC_H_ */

--- a/include/arch/target/unix64/unix64/sync.h
+++ b/include/arch/target/unix64/unix64/sync.h
@@ -67,6 +67,8 @@
 	 */
 	#define UNIX64_SYNC_MAX (UNIX64_SYNC_CREATE_MAX + UNIX64_SYNC_OPEN_MAX)
 
+#if !__NANVIX_IKC_USES_ONLY_MAILBOX
+
 #ifdef __NANVIX_HAL
 
 	/**
@@ -150,6 +152,8 @@
 	 */
 	EXTERN int unix64_sync_signal(int syncid);
 
+#endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX */
+
 /**@}*/
 
 /*============================================================================*
@@ -181,6 +185,8 @@
 	#define SYNC_OPEN_MAX      UNIX64_SYNC_OPEN_MAX      /**< UNIX64_SYNC_OPEN_MAX      */
 	#define SYNC_OPEN_OFFSET   UNIX64_SYNC_OPEN_OFFSET   /**< UNIX64_SYNC_OPEN_OFFSET   */
 	/**@}*/
+
+#if !__NANVIX_IKC_USES_ONLY_MAILBOX
 
 	/**
 	 * @see unix64_sync_setup()
@@ -223,6 +229,8 @@
 	 */
 	#define __sync_signal(syncid) \
 		unix64_sync_signal(syncid)
+
+#endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX */
 
 /**@}*/
 

--- a/makefile
+++ b/makefile
@@ -96,6 +96,9 @@ export CFLAGS += -Wno-unused-function
 export CFLAGS += -I $(INCDIR)
 export CFLAGS += -D__NANVIX_HAL
 
+# Enable sync and portal implementation that uses mailboxes
+export CFLAGS += -D__NANVIX_IKC_USES_ONLY_MAILBOX=0
+
 # Additional C Flags
 include $(BUILDDIR)/makefile.cflags
 

--- a/src/hal/arch/target/mppa256/portal.c
+++ b/src/hal/arch/target/mppa256/portal.c
@@ -31,6 +31,8 @@
 #include <nanvix/hlib.h>
 #include <posix/errno.h>
 
+#if !__NANVIX_IKC_USES_ONLY_MAILBOX
+
 /*============================================================================*
  * Definitions                                                                *
  *============================================================================*/
@@ -1108,3 +1110,6 @@ PUBLIC void mppa256_portal_shutdown(void)
 			kpanic("[hal][portal] Cannot close data channel.");
 	}
 }
+
+#endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX */
+

--- a/src/hal/arch/target/mppa256/sync.c
+++ b/src/hal/arch/target/mppa256/sync.c
@@ -31,6 +31,8 @@
 #include <nanvix/hlib.h>
 #include <posix/errno.h>
 
+#if !__NANVIX_IKC_USES_ONLY_MAILBOX
+
 /*============================================================================*
  * Definitions                                                                *
  *============================================================================*/
@@ -1087,3 +1089,6 @@ PRIVATE int mppa256_sync_select_tx_interface(const int *nodenums, int nnodes, in
 }
 
 #endif /* MPPA256_USING_MULTIPLE_DMA_INTERFACES */
+
+#endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX */
+

--- a/src/hal/arch/target/unix64/boot.c
+++ b/src/hal/arch/target/unix64/boot.c
@@ -97,9 +97,11 @@ PUBLIC NORETURN void unix64_poweroff(void)
 	if (cluster_get_num() == PROCESSOR_CLUSTERNUM_MASTER)
 		kprintf("[hal][target] powering off...");
 
-	unix64_sync_shutdown();
 	unix64_mailbox_shutdown();
+#if !__NANVIX_IKC_USES_ONLY_MAILBOX
+	unix64_sync_shutdown();
 	unix64_portal_shutdown();
+#endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX  */
 
 	processor_poweroff();
 }

--- a/src/hal/arch/target/unix64/portal.c
+++ b/src/hal/arch/target/unix64/portal.c
@@ -38,6 +38,8 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#if !__NANVIX_IKC_USES_ONLY_MAILBOX
+
 /**
  * @brief Length of portal name.
  */
@@ -946,3 +948,6 @@ PUBLIC void unix64_portal_shutdown(void)
 		}
 	}
 }
+
+#endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX */
+

--- a/src/hal/arch/target/unix64/sync.c
+++ b/src/hal/arch/target/unix64/sync.c
@@ -38,6 +38,8 @@
 #include <posix/errno.h>
 #include <stdio.h>
 
+#if !__NANVIX_IKC_USES_ONLY_MAILBOX
+
 /**
  * @brief Length of sync name.
  */
@@ -861,3 +863,6 @@ PUBLIC void unix64_sync_shutdown(void)
 		KASSERT(mq_close(mqueues[i].fd) == 0);
 	}
 }
+
+#endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX */
+

--- a/src/hal/arch/target/unix64/target.c
+++ b/src/hal/arch/target/unix64/target.c
@@ -36,6 +36,8 @@ PUBLIC void unix64_setup(void)
 {
 	kprintf("[hal][target] initializing target...");
 
+#if !__NANVIX_IKC_USES_ONLY_MAILBOX
 	unix64_portal_setup();
+#endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX  */
 	linux64_processor_setup();
 }

--- a/src/hal/target/portal.c
+++ b/src/hal/target/portal.c
@@ -31,7 +31,7 @@
  * portal_rx_is_valid()                                                       *
  *============================================================================*/
 
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 /**
  * @brief Asserts whether or not a receiver portal is valid.
@@ -62,7 +62,7 @@ PRIVATE int portal_rx_is_valid(int portalid)
  * portal_tx_is_valid()                                                       *
  *============================================================================*/
 
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 /**
  * @brief Asserts whether or not a sender portal is valid.
@@ -98,7 +98,7 @@ PRIVATE int portal_tx_is_valid(int portalid)
  */
 PUBLIC int portal_create(int nodenum)
 {
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* Is local valid? */
 	if (!node_is_valid(nodenum))
@@ -126,7 +126,7 @@ PUBLIC int portal_create(int nodenum)
  */
 PUBLIC int portal_open(int localnum, int remotenum)
 {
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* Invalid local NoC node. */
 	if (!node_is_valid(localnum))
@@ -163,7 +163,7 @@ PUBLIC int portal_open(int localnum, int remotenum)
  */
 PUBLIC int portal_allow(int portalid, int nodenum)
 {
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* Is nodenum valid? */
 	if (!node_is_valid(nodenum))
@@ -196,7 +196,7 @@ PUBLIC int portal_allow(int portalid, int nodenum)
  */
 PUBLIC int portal_unlink(int portalid)
 {
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* Invalid portal. */
 	if (!portal_rx_is_valid(portalid))
@@ -220,7 +220,7 @@ PUBLIC int portal_unlink(int portalid)
  */
 PUBLIC int portal_close(int portalid)
 {
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* Invalid portal. */
 	if (!portal_tx_is_valid(portalid))
@@ -244,7 +244,7 @@ PUBLIC int portal_close(int portalid)
  */
 PUBLIC ssize_t portal_awrite(int portalid, const void *buffer, uint64_t size)
 {
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* Invalid NoC node ID. */
 	if (!portal_tx_is_valid(portalid))
@@ -278,7 +278,7 @@ PUBLIC ssize_t portal_awrite(int portalid, const void *buffer, uint64_t size)
  */
 PUBLIC ssize_t portal_aread(int portalid, void *buffer, uint64_t size)
 {
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* Invalid NoC node ID. */
 	if (!portal_rx_is_valid(portalid))
@@ -312,7 +312,7 @@ PUBLIC ssize_t portal_aread(int portalid, void *buffer, uint64_t size)
  */
 PUBLIC int portal_wait(int portalid)
 {
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* Invalid mailbox. */
 	if (!(portal_rx_is_valid(portalid) || portal_tx_is_valid(portalid)))
@@ -336,7 +336,7 @@ PUBLIC int portal_wait(int portalid)
  */
 PUBLIC void portal_setup(void)
 {
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 	__portal_setup();
 #endif /* __TARGET_HAS_PORTAL */
 }

--- a/src/hal/target/sync.c
+++ b/src/hal/target/sync.c
@@ -31,7 +31,7 @@
  * sync_rx_is_valid()                                                         *
  *============================================================================*/
 
-#if (__TARGET_HAS_SYNC)
+#if (__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 /**
  * @brief Asserts whether or not a receiver portal is valid.
@@ -62,7 +62,7 @@ PRIVATE int sync_rx_is_valid(int syncid)
  * sync_tx_is_valid()                                                         *
  *============================================================================*/
 
-#if (__TARGET_HAS_SYNC)
+#if (__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 /**
  * @brief Asserts whether or not a sender portal is valid.
@@ -93,7 +93,7 @@ PRIVATE int sync_tx_is_valid(int syncid)
  * sync_nodelist_is_valid()                                                   *
  *============================================================================*/
 
-#if (__TARGET_HAS_SYNC)
+#if (__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 /**
  * @brief Node list validation.
@@ -149,7 +149,7 @@ PRIVATE int sync_nodelist_is_valid(const int * nodes, int nnodes, int is_the_one
  */
 PUBLIC int sync_create(const int * nodes, int nnodes, int type)
 {
-#if (__TARGET_HAS_SYNC)
+#if (__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 	int is_the_one;
 
 	/*  Invalid nodes list. */
@@ -190,7 +190,7 @@ PUBLIC int sync_create(const int * nodes, int nnodes, int type)
  */
 PUBLIC int sync_open(const int * nodes, int nnodes, int type)
 {
-#if (__TARGET_HAS_SYNC)
+#if (__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 	int is_the_one;
 
 	/*  Invalid nodes list. */
@@ -231,7 +231,7 @@ PUBLIC int sync_open(const int * nodes, int nnodes, int type)
  */
 PUBLIC int sync_unlink(int syncid)
 {
-#if (__TARGET_HAS_SYNC)
+#if (__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* Invalid portal. */
 	if (!sync_rx_is_valid(syncid))
@@ -255,7 +255,7 @@ PUBLIC int sync_unlink(int syncid)
  */
 PUBLIC int sync_close(int syncid)
 {
-#if (__TARGET_HAS_SYNC)
+#if (__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* Invalid portal. */
 	if (!sync_tx_is_valid(syncid))
@@ -279,7 +279,7 @@ PUBLIC int sync_close(int syncid)
  */
 PUBLIC ssize_t sync_signal(int syncid)
 {
-#if (__TARGET_HAS_SYNC)
+#if (__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* Invalid NoC node ID. */
 	if (!sync_tx_is_valid(syncid))
@@ -303,7 +303,7 @@ PUBLIC ssize_t sync_signal(int syncid)
  */
 PUBLIC int sync_wait(int syncid)
 {
-#if (__TARGET_HAS_SYNC)
+#if (__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* Invalid mailbox. */
 	if (!sync_rx_is_valid(syncid))
@@ -327,7 +327,7 @@ PUBLIC int sync_wait(int syncid)
  */
 PUBLIC void sync_setup(void)
 {
-#if (__TARGET_HAS_SYNC)
+#if (__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 	__sync_setup();
 #endif /* __TARGET_HAS_SYNC */
 }

--- a/src/test/stress/api.c
+++ b/src/test/stress/api.c
@@ -29,7 +29,7 @@
 #include "../test.h"
 #include "stress.h"
 
-#if (__TARGET_HAS_SYNC && __TARGET_HAS_MAILBOX && __TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_SYNC && __TARGET_HAS_MAILBOX && __TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 /**
  * @brief Stress core fence.
@@ -93,4 +93,4 @@ PUBLIC void test_stress_al(void)
 
 }
 
-#endif /* __TARGET_HAS_SYNC && __TARGET_HAS_MAILBOX && __TARGET_HAS_PORTAL */
+#endif /* __TARGET_HAS_SYNC && __TARGET_HAS_MAILBOX && __TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX */

--- a/src/test/target/portal.c
+++ b/src/test/target/portal.c
@@ -28,7 +28,7 @@
 #include <posix/errno.h>
 #include "../test.h"
 
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 /**
  * @brief Size of exchange data.
@@ -293,13 +293,13 @@ PRIVATE void test_portal_double_allow(void)
 	KASSERT(portal_unlink(portalid) == 0);
 }
 
-#endif /* __TARGET_HAS_PORTAL */
+#endif /* __TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX */
 
 /*============================================================================*
  * Test Driver                                                                *
  *============================================================================*/
 
-#if __TARGET_HAS_PORTAL
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 /**
  * @brief API unit tests.
@@ -333,7 +333,7 @@ PRIVATE struct test portal_tests_fault[] = {
 	{ NULL,                        NULL            },
 };
 
-#endif /* __TARGET_HAS_PORTAL */
+#endif /* __TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX */
 
 /**
  * The test_portal() function launches testing units on the portal
@@ -343,7 +343,7 @@ PRIVATE struct test portal_tests_fault[] = {
  */
 PUBLIC void test_portal(void)
 {
-#if (__TARGET_HAS_PORTAL)
+#if (__TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 	/* API Tests */
 	kprintf(HLINE);
@@ -361,5 +361,5 @@ PUBLIC void test_portal(void)
 		kprintf("[test][fault][portal] %s [passed]", portal_tests_fault[i].name);
 	}
 
-#endif /* __TARGET_HAS_PORTAL */
+#endif /* __TARGET_HAS_PORTAL && !__NANVIX_IKC_USES_ONLY_MAILBOX */
 }

--- a/src/test/target/sync.c
+++ b/src/test/target/sync.c
@@ -28,7 +28,7 @@
 #include <posix/errno.h>
 #include "../test.h"
 
-#if (__TARGET_HAS_SYNC)
+#if (__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 
 /*============================================================================*
  * API Tests                                                                  *
@@ -432,6 +432,8 @@ PRIVATE struct test sync_tests_fault[] = {
 	{ NULL,                      NULL            },
 };
 
+#endif /* __TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX */
+
 /**
  * The test_sync() function launches testing units on the sync
  * interface of the HAL.
@@ -440,6 +442,7 @@ PRIVATE struct test sync_tests_fault[] = {
  */
 PUBLIC void test_sync(void)
 {
+#if (__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX)
 	/* API Tests */
 	kprintf(HLINE);
 	for (int i = 0; sync_tests_api[i].test_fn != NULL; i++)
@@ -455,6 +458,6 @@ PUBLIC void test_sync(void)
 		sync_tests_fault[i].test_fn();
 		kprintf("[test][fault][sync] %s [passed]", sync_tests_fault[i].name);
 	}
+#endif /* !__TARGET_HAS_SYNC && !__NANVIX_IKC_USES_ONLY_MAILBOX */
 }
 
-#endif /* !__TARGET_HAS_SYNC */


### PR DESCRIPTION
In this PR, I add __NANVIX_IKC_USES_ONLY_MAILBOX flag that disables sync/portal implementation.