### PR TITLE
[mppa256] Remove Nested Interrupts and Interference Between NoC Handlers

### DIFF
--- a/include/arch/processor/bostan/noc.h
+++ b/include/arch/processor/bostan/noc.h
@@ -208,6 +208,33 @@
 	}
 
 	/**
+	 * @brief Mask NoC interrupts.
+	 */
+	static inline void bostan_noc_it_mask(void)
+	{
+		interrupt_mask(K1B_INT_CNOC);
+		interrupt_mask(K1B_INT_DNOC);
+	}
+
+	/**
+	 * @brief Unnask NoC interrupts.
+	 */
+	static inline void bostan_noc_it_unmask(void)
+	{
+		interrupt_unmask(K1B_INT_DNOC);
+		interrupt_unmask(K1B_INT_CNOC);
+	}
+
+	/**
+	 * @brief Verify lost interrupts.
+	 */
+	static inline void bostan_noc_it_verify(void)
+	{
+		bostan_cnoc_it_verify();
+		bostan_dnoc_it_verify();
+	}
+
+	/**
 	 * @brief Asserts whether a NoC node is attached to an IO cluster.
 	 *
 	 * @param nodenum Logic ID of the target NoC node.

--- a/include/arch/processor/bostan/noc/ctag.h
+++ b/include/arch/processor/bostan/noc/ctag.h
@@ -89,7 +89,7 @@
 	#define BOSTAN_MAILBOX_CNOC_TX_BASE 0 /**< C-NoC Transfer Tag reserved for Mailbox. */
 	#define BOSTAN_PORTAL_CNOC_TX_BASE  1 /**< C-NoC Transfer Tag reserved for Portal.  */
 	#define BOSTAN_SYNC_CNOC_TX_BASE    2 /**< C-NoC Transfer Tag reserved for Sync.    */
-	#define BOSTAN_CNOC_TX_UNUSED       3 /**< C-NoC Transfer Tag reserved unused.      */
+	#define BOSTAN_CNOC_TX_UNUSED       3 /**< Unused C-NoC Transfer Tag.               */
 	/**@}*/
 
 	/**

--- a/src/hal/arch/processor/bostan/ctag.c
+++ b/src/hal/arch/processor/bostan/ctag.c
@@ -296,7 +296,7 @@ PRIVATE void bostan_cnoc_it_handler(int ev_src)
 	volatile dword_t * field_status;
 	bostan_processor_noc_handler_fn handler;
 
-	if (ev_src > 0)
+	if (ev_src < 0)
 		interrupt_mask(K1B_INT_CNOC);
 
 	dcache_invalidate();
@@ -339,7 +339,8 @@ PRIVATE void bostan_cnoc_it_handler(int ev_src)
 							(void *) &bostan_cnoc_rx_handlers[interface][tag]
 						);
 
-						handler(interface, tag);
+						if (handler)
+							handler(interface, tag);
 					}
 				}
 			}
@@ -349,7 +350,7 @@ PRIVATE void bostan_cnoc_it_handler(int ev_src)
 		}
 	} while (possible_lost_it);
 
-	if (ev_src > 0)
+	if (ev_src < 0)
 		interrupt_unmask(K1B_INT_CNOC);
 }
 

--- a/src/hal/arch/processor/bostan/dtag.c
+++ b/src/hal/arch/processor/bostan/dtag.c
@@ -434,7 +434,7 @@ PRIVATE void bostan_dnoc_it_handler(int ev_src)
 	volatile dword_t * field_status;
 	bostan_processor_noc_handler_fn handler;
 
-	if (ev_src > 0)
+	if (ev_src < 0)
 		interrupt_mask(K1B_INT_DNOC);
 
 	dcache_invalidate();
@@ -479,7 +479,7 @@ PRIVATE void bostan_dnoc_it_handler(int ev_src)
 		}
 	}
 
-	if (ev_src > 0)
+	if (ev_src < 0)
 		interrupt_unmask(K1B_INT_DNOC);
 }
 
@@ -492,8 +492,7 @@ PRIVATE void bostan_dnoc_it_handler(int ev_src)
  */
 PUBLIC void bostan_dnoc_it_verify(void)
 {
-	if (bostan_dnoc_it_received())
-		bostan_dnoc_it_handler(-1);
+	bostan_dnoc_it_handler(-1);
 }
 
 /*============================================================================*

--- a/src/hal/arch/target/mppa256/mailbox.c
+++ b/src/hal/arch/target/mppa256/mailbox.c
@@ -724,7 +724,7 @@ PRIVATE ssize_t do_mppa256_mailbox_awrite(int mbxid, const void * buffer, uint64
 		resource_set_busy(&mbxtab.txs[mbxid].resource);
 	mppa256_mailbox_unlock();
 
-	interrupt_mask(K1B_INT_CNOC);
+	bostan_noc_it_mask();
 
 		/* Programs the next write. */
 		kmemcpy(&mbxtab.txs[mbxid].message.buffer, buffer, MPPA256_MAILBOX_MSG_SIZE);
@@ -747,10 +747,10 @@ PRIVATE ssize_t do_mppa256_mailbox_awrite(int mbxid, const void * buffer, uint64
 			}
 		}
 
-		/* Double check. */
-		bostan_cnoc_it_verify();
+	bostan_noc_it_unmask();
 
-	interrupt_unmask(K1B_INT_CNOC);
+	/* Losing interrupts? */
+	bostan_noc_it_verify();
 
 	if (ret < 0)
 	{
@@ -920,7 +920,7 @@ PRIVATE ssize_t do_mppa256_mailbox_aread(int mbxid, void * buffer, uint64_t size
 		resource_set_busy(&mbxtab.rxs[mbxid].resource);
 	mppa256_mailbox_unlock();
 
-	interrupt_mask(K1B_INT_DNOC);
+	bostan_noc_it_mask();
 
 		/* Check on underlying messages. */
 		mppa256_mailbox_count_messages(&mbxtab.rxs[mbxid]);
@@ -934,10 +934,10 @@ PRIVATE ssize_t do_mppa256_mailbox_aread(int mbxid, void * buffer, uint64_t size
 		else
 			ret = (-ENOMSG);
 
-		/* Double check. */
-		bostan_dnoc_it_verify();
+	bostan_noc_it_unmask();
 
-	interrupt_unmask(K1B_INT_DNOC);
+	/* Losing interrupts? */
+	bostan_noc_it_verify();
 
 	if (ret < 0)
 	{

--- a/src/hal/arch/target/mppa256/sync.c
+++ b/src/hal/arch/target/mppa256/sync.c
@@ -648,7 +648,7 @@ again:
 	 */
 	mppa256_sync_unlock();
 
-	interrupt_mask(K1B_INT_CNOC);
+	bostan_noc_it_mask();
 
 		/* Broadcast. */
 		if (synctab.txs[syncid].hash.type == MPPA256_SYNC_ONE_TO_ALL)
@@ -674,10 +674,10 @@ again:
 			);
 		}
 
-		/* Losing interrupts? */
-		bostan_cnoc_it_verify();
+	bostan_noc_it_unmask();
 
-	interrupt_unmask(K1B_INT_CNOC);
+	/* Losing interrupts? */
+	bostan_noc_it_verify();
 
 	mppa256_sync_lock();
 		resource_set_notbusy(&synctab.txs[syncid].resource);
@@ -1091,4 +1091,3 @@ PRIVATE int mppa256_sync_select_tx_interface(const int *nodenums, int nnodes, in
 #endif /* MPPA256_USING_MULTIPLE_DMA_INTERFACES */
 
 #endif /* !__NANVIX_IKC_USES_ONLY_MAILBOX */
-


### PR DESCRIPTION
In this PR, I fix when we need to mask interrupts inside the NoC handlers, eliminating undesired nested interrupts.

Also, I standardized how we verify the loss of interrupts. This new way verifies both NoC interrupts (CNoC and DNoC) eliminating interference between NoC handlers and critical regions.

## Resolved Issue

[[target] Make Sync use Only one C-NoC TX](https://github.com/nanvix/hal/issues/606)