### PR TITLE
[test] Non-Destructive Exception Test

### DIFF
--- a/include/arch/core/i486/ctx.h
+++ b/include/arch/core/i486/ctx.h
@@ -89,7 +89,7 @@
         i486_word_t gs, fs, es, ds;                    /**< Segment Registers         */
         i486_word_t edi, esi, ebp, edx, ecx, ebx, eax; /**< General Purpose Registers */
         i486_word_t eip, cs, eflags, useresp, ss;      /**< Special Registers         */
-	} PACK;
+	} PACK ALIGN(I486_WORD_SIZE);
 
 /**@endcond*/
 

--- a/include/arch/core/k1b/ctx.h
+++ b/include/arch/core/k1b/ctx.h
@@ -158,7 +158,7 @@
 			k1b_word_t ps;                                     /**< Processing Status Register         */
 			k1b_word_t sps;                                    /**< Shadow Processing Status Register  */
 			k1b_byte_t RESERVED[4];                            /**< Required padding.                  */
-		} PACK;
+		} PACK ALIGN(K1B_WORD_SIZE);
 
 	/**@endcond*/
 

--- a/include/arch/core/linux64/ctx.h
+++ b/include/arch/core/linux64/ctx.h
@@ -57,7 +57,7 @@
 	struct context
 	{
 		linux64_dword_t id;
-	} PACK;
+	} PACK ALIGN(LINUX64_DWORD_SIZE);
 
 /**@endcond*/
 

--- a/include/arch/core/or1k/ctx.h
+++ b/include/arch/core/or1k/ctx.h
@@ -105,7 +105,7 @@
 			or1k_word_t eear;                                   /**< Shadow Effective Address Register  */
 			or1k_word_t  esr;                                   /**< Shadow Status Register             */
 			or1k_byte_t RESERVED[4];                            /**< Required padding                   */
-		} PACK;
+		} PACK ALIGN(OR1K_WORD_SIZE);
 
 	/**@endcond*/
 

--- a/include/arch/core/rv32gc/ctx.h
+++ b/include/arch/core/rv32gc/ctx.h
@@ -29,9 +29,6 @@
 		#error "do not include this file"
 	#endif
 
-	/* Must come first. */
-	#define __NEED_CORE_TYPES
-
 /**
  * @addtogroup rv32gc-core-context Context
  * @ingroup rv32gc-core
@@ -40,7 +37,7 @@
  */
 /**@{*/
 
-	#include <arch/core/rv32gc/types.h>
+	#include <arch/core/rv32gc/core.h>
 	#include <nanvix/hlib.h>
 
 	/**
@@ -110,7 +107,7 @@
 			rv32gc_word_t s7, s8, s9, s10, s11;   /**< Saved Registers 7 to 11                  */
 			rv32gc_word_t t3, t4, t5, t6;         /**< Temporary Registers 3 to 6               */
 			rv32gc_word_t pc;                     /**< Program Counter                          */
-		} PACK;
+		} PACK ALIGN(RV32GC_WORD_SIZE);
 
 	/**@endcond*/
 

--- a/src/test/core/exception.c
+++ b/src/test/core/exception.c
@@ -28,39 +28,168 @@
 #include <posix/errno.h>
 #include "../test.h"
 
-/**
- * @brief Run destructive tests?
- */
-#define TEST_EXCEPTION_DESTRUCTIVE 0
+#if defined(__unix64__)
 
-#if defined(__rv32gc__)
+	/**
+	 * @brief Non-destrutive test not supported on Unix64
+	 */
+	#define TEST_EXCEPTION_DESTRUCTIVE 0
+
+	/**
+	 * @brief Number of exception triggered on unit test.
+	 */
+	#define TEST_TRIGGERED_EXCEPTION_NUM EXCEPTION_INVALID_OPCODE
+
+	/**
+	 * @brief Invalid opcode exception handler
+	 */
+	PRIVATE void triggered_exception_handler(
+		const struct exception *excp,
+		const struct context *ctx
+	)
+	{
+		UNUSED(excp);
+		UNUSED(ctx);
+
+		kpanic("[test][core][exception] This test is destructive only.");
+	}
+
+	/**
+	 * @brief Triggers an invalid instruction exception.
+	 */
+	PRIVATE inline void trigger_exception(void)
+	{
+		raise(TEST_TRIGGERED_EXCEPTION_NUM);
+	}
+
+#elif defined(__rv32gc__) || defined(__or1k__)
+
+	/**
+	 * @brief Non-destrutive test not supported on RiscV 32
+	 */
+	#define TEST_EXCEPTION_DESTRUCTIVE 0
+
+	/**
+	 * @brief Number of exception triggered on unit test.
+	 */
+	#define TEST_TRIGGERED_EXCEPTION_NUM EXCEPTION_INVALID_OPCODE
+
+	/**
+	 * @brief Skips invalid instruction.
+	 */
+	PRIVATE void triggered_exception_handler(
+		const struct exception *excp,
+		const struct context *ctx
+	)
+	{
+		word_t next_pc;
+		struct context * _ctx;
+
+		KASSERT(excp->num == TEST_TRIGGERED_EXCEPTION_NUM);
+
+		_ctx = (struct context *) ctx;
+
+		next_pc = context_get_pc(_ctx) + WORD_SIZE;
+
+		context_set_pc(_ctx, next_pc);
+	}
 
 	/**
 	 * @brief Triggers an invalid instruction exception.
 	 *
-	 * The trigger_exception() function triggers an invalid
-	 * instruction exception in the rv32gc core. It does so by writing
-	 * a random value into the mhartid special function register.
-	 * Hopefully, if the core is compliant to the standards this is
-	 * not allowed.
-	 *
-	 * @author Pedro Henrique Penna
 	 */
 	PRIVATE inline void trigger_exception(void)
 	{
+#if defined(__rv32gc__)
+
+		/**
+		 * The trigger_exception() function triggers an invalid
+		 * instruction exception in the rv32gc core. It does so by writing
+		 * a random value into the mhartid special function register.
+		 * Hopefully, if the core is compliant to the standards this is
+		 * not allowed.
+		 *
+		 * @author Pedro Henrique Penna
+		 */
 		asm volatile (
 			"csrw mhartid, %0;"
 			:
 			: "r" (0xdeadc0de)
 		);
-	}
+
+#elif defined(__or1k__)
+
+		/**
+		 * The trigger_exception() function triggers an invalid
+		 * instruction exception in the or1k core. It call a custom
+		 * instruction that is not implemented. Hopefully, this 
+		 * instruction is not really implemented.
+		 *
+		 * @author João Vicente Souto 
+		 */
+		asm volatile (
+			"l.cust4;"
+		);
 
 #else
+		kpanic("Missing arch!");
+#endif
+	}
+
+#else /* Others archs. */
 
 	/**
-	 * @brief Triggers a page fault exception.
+	 * @brief Number of exception triggered on unit test.
+	 */
+	#ifdef EXCEPTION_DTLB_FAULT
+		#define TEST_TRIGGERED_EXCEPTION_NUM EXCEPTION_DTLB_FAULT
+	#else
+		#define TEST_TRIGGERED_EXCEPTION_NUM EXCEPTION_PAGE_FAULT
+	#endif
+
+	/**
+	 * @brief Bad address to trigger a DTLB fault execption.
+	 */
+	#define BAD_ADDRESS 0x4badbeef /* I like beefs. */
+
+	/**
+	 * @brief Global variable used by DTLB fault exepction handler.
+	 */
+	PRIVATE unsigned char exception_variable;
+
+	/**
+	 * @brief DTLB fault exception handler
+	 */
+	PRIVATE void triggered_exception_handler(
+		const struct exception *excp,
+		const struct context *ctx
+	)
+	{
+		word_t * reg;
+		word_t * end;
+
+		KASSERT(excp->num == TEST_TRIGGERED_EXCEPTION_NUM);
+
+		reg = (word_t *) (ctx);
+		end = (word_t *) (ctx + 1);
+
+		do
+		{
+			if (*reg == BAD_ADDRESS)
+			{
+				*reg = (word_t) &exception_variable;
+				break;
+			}
+		} while ((++reg) != end);
+
+		if (reg == end)
+			kpanic("[test][core][exception] No register contains the invalid address.");
+	}
+
+	/**
+	 * @brief Triggers a DTLB fault exception.
 	 *
-	 * The trigger_exception() function forces a page fault exception
+	 * The trigger_exception() function forces a DTLB fault exception
 	 * by writing some data into a random memory location. Hopefully,
 	 * the target memory location is not mapped.
 	 *
@@ -68,8 +197,14 @@
 	 */
 	PRIVATE inline void trigger_exception(void)
 	{
-		unsigned char *p = (unsigned char *) 0x4badbeef; /* I like beefs. */
+		unsigned char *p = (unsigned char *) BAD_ADDRESS;
+		exception_variable = 0;
+
+		/* Triggers the DTLB fault. */
 		*p = 0xfe;
+
+		/* Correct handled. */
+		KASSERT(exception_variable == 0xfe);
 	}
 
 #endif
@@ -112,11 +247,17 @@ PRIVATE void test_exception_set_unset_handler(void)
  */
 PRIVATE void test_trigger_exception(void)
 {
+#if defined(__rv32gc__) || defined(__unix64__)
 	/* Don't run destructive tests. */
 	if (!TEST_EXCEPTION_DESTRUCTIVE)
 		return;
+#endif
+
+	KASSERT(exception_register(TEST_TRIGGERED_EXCEPTION_NUM, triggered_exception_handler) == 0);
 
 	trigger_exception();
+
+	KASSERT(exception_unregister(TEST_TRIGGERED_EXCEPTION_NUM) == 0);
 }
 
 /*============================================================================*


### PR DESCRIPTION
## Description

In this PR, I define non-destructive exception tests for most architectures. The current version has the following behaviors:
- `unix64`: Does not support non-destructive tests because of the way that we simulate that.
- `rv32gc`:  illegal instruction dealt with by increasing the program counter of the context. **But it is not currently supported because the issue #611**
- `or1k`: illegal instruction dealt with by increasing the program counter of the context.
- `Other architectures`: Access to an invalid address handled by changing the address to a local static variable (DTLB exception).

This enhancement highlight the not alignment of context structures (issue #612) that is fixed by this PR.

## Related issues

- Cites #611
- Closes #612
