### PR TITLE
[hlib] Block Long Prints

### DIFF
--- a/include/nanvix/hlib.h
+++ b/include/nanvix/hlib.h
@@ -166,11 +166,6 @@
 /**@{*/
 
 	/**
-	 * @see __vsprintf().
-	 */
-	#define kvsprintf(str,fmt,args) __vsprintf(str,fmt,args)
-
-	/**
 	 * @see __sprintf().
 	 */
 	#define ksprintf(str,fmt,...) __sprintf(str,fmt,__VA_ARGS__)

--- a/include/nanvix/hlib.h
+++ b/include/nanvix/hlib.h
@@ -175,6 +175,10 @@
 	 */
 	#define ksprintf(str,fmt,...) __sprintf(str,fmt,__VA_ARGS__)
 
+	/**
+	 * @see __vsnprintf().
+	 */
+	#define kvsnprintf(str,size,fmt,args) __vsnprintf(str,size,fmt,args)
 /**@}*/
 
 /*============================================================================*

--- a/src/hal/hlib/kpanic.c
+++ b/src/hal/hlib/kpanic.c
@@ -37,15 +37,15 @@ PUBLIC NORETURN void kpanic(const char *fmt, ...)
 {
 	size_t len;                    /* String length.           */
 	va_list args;                  /* Variable arguments list. */
-	char buffer[KBUFFER_SIZE + 1]; /* Temporary buffer.        */
+	char buffer[KBUFFER_SIZE + 2]; /* Temporary buffer.        */
 
 	kstrncpy(buffer, "PANIC: ", 7);
 
 	/* Convert to raw string. */
 	va_start(args, fmt);
-	len = kvsprintf(buffer + 7, fmt, args) + 7;
-	buffer[len++] = '\n';
-	buffer[len++] = '\0';
+	len = kvsnprintf(buffer + 7, KBUFFER_SIZE - 7 + 1, fmt, args) + 7;
+	buffer[++len] = '\n';
+	buffer[++len] = '\0';
 	va_end(args);
 
 	kputs(buffer);

--- a/src/hal/hlib/kprintf.c
+++ b/src/hal/hlib/kprintf.c
@@ -35,14 +35,19 @@ PUBLIC void kprintf(const char *fmt, ...)
 {
 	size_t len;                    /* String length.           */
 	va_list args;                  /* Variable arguments list. */
-	char buffer[KBUFFER_SIZE + 1]; /* Temporary buffer.        */
+	char buffer[KBUFFER_SIZE + 2]; /* Temporary buffer (+2 for \n\0). */
 
 	/* Convert to raw string. */
 	va_start(args, fmt);
-	len = kvsprintf(buffer, fmt, args);
-	buffer[len++] = '\n';
-	buffer[len++] = '\0';
+
+	/* Give it 1 extra byte because the size includes '\0'. */
+	len = kvsnprintf(buffer, KBUFFER_SIZE + 1, fmt, args);
+	/* Substitute the ending with \n\0. */
+	buffer[++len] = '\n';
+	buffer[++len] = '\0';
+
 	va_end(args);
 
 	kputs(buffer);
 }
+


### PR DESCRIPTION
# Description
Changes kprintf to use kvsnprintf instead of ksvprintf. By doing this, we can limit the size of characters the formatting function will place inside the buffer and block outputs that would overflow the buffer. If an output were to overflow the buffer, it would be truncated.

This closes #364 

### Dependencies
This depends on the addition of the __vsnprintf function on the barelib. Without it, build errors will occur.