### PR TITLE
[k1b-core] Drop the Dependency on BSP Interrupt Dispatcher

### DIFF
--- a/include/arch/core/k1b/int.h
+++ b/include/arch/core/k1b/int.h
@@ -50,22 +50,22 @@
 	 * @name Hardware Interrupts for Kalray MPPA-256 Target
 	 */
 	/**@{*/
-	#define K1B_INT_TIMER0     0 /**< Timer 0              */
-	#define K1B_INT_TIMER1     1 /**< Timer 1              */
-	#define K1B_INT_TIMER      2 /**< Watchdog Timer       */
-	#define K1B_INT_CNOC       3 /**< Control NoC          */
-	#define K1B_INT_DNOC       4 /**< Data NoC             */
-	#define K1B_INT_DMA        5 /**< DMA                  */
-	#define K1B_INT_NOC_ERR    6 /**< NoC Error            */
-	#define K1B_INT_VIRT       7 /**< Virtual Line         */
-	#define K1B_INT_TIMER_ERR  8 /**< Watchdog Timer Error */
-	#define K1B_INT_DEBUG      9 /**< Debug                */
+	#define K1B_INT_TIMER0     K1B_IRQ_0 /**< Timer 0              */
+	#define K1B_INT_TIMER1     K1B_IRQ_1 /**< Timer 1              */
+	#define K1B_INT_TIMER      K1B_IRQ_2 /**< Watchdog Timer       */
+	#define K1B_INT_CNOC       K1B_IRQ_3 /**< Control NoC          */
+	#define K1B_INT_DNOC       K1B_IRQ_4 /**< Data NoC             */
+	#define K1B_INT_DMA        K1B_IRQ_5 /**< DMA                  */
+	#define K1B_INT_NOC_ERR    K1B_IRQ_6 /**< NoC Error            */
+	#define K1B_INT_VIRT       K1B_IRQ_7 /**< Virtual Line         */
+	#define K1B_INT_TIMER_ERR  K1B_IRQ_8 /**< Watchdog Timer Error */
+	#define K1B_INT_DEBUG      K1B_IRQ_9 /**< Debug                */
 	#ifdef __k1io__
-	#define K1B_INT_GIC1      10 /**< GIC 1                */
-	#define K1B_INT_GIC2      11 /**< GIC 2                */
-	#define K1B_INT_GIC3      12 /**< GIC2                 */
+	#define K1B_INT_GIC1      K1B_IRQ_10 /**< GIC 1                */
+	#define K1B_INT_GIC2      K1B_IRQ_11 /**< GIC 2                */
+	#define K1B_INT_GIC3      K1B_IRQ_12 /**< GIC2                 */
 	#endif
-	#define K1B_INT_IPI      256 /**< Dummy IPI interrupt  */
+	#define K1B_INT_IPI              256 /**< Dummy IPI interrupt  */
 	/**@}*/
 
 #ifndef _ASM_FILE_

--- a/include/arch/core/k1b/int.h
+++ b/include/arch/core/k1b/int.h
@@ -90,6 +90,10 @@
 	 */
 	EXTERN int k1b_int_unmask(int intnum);
 
+	/**
+	 * @brief Low-level interrupt dispatcher.
+	 */
+	EXTERN void _k1b_do_int(void);
 
 	/**
 	 * @brief Enables interrupts.

--- a/src/hal/arch/core/k1b/hooks.S
+++ b/src/hal/arch/core/k1b/hooks.S
@@ -59,6 +59,16 @@
 	;;
 .endm
 
+/*
+ * Gets exception/interrupt cause (28: exception cause in PS register)
+ */
+.macro _get_suspension_cause from to tmp
+	lw  \tmp = MOS_VC_REG_PS[\from]
+	;;
+	srl \to = \tmp, 28
+	;;
+.endm
+
 /*===========================================================================*
  * _do_kcall()                                                             *
  *===========================================================================*/
@@ -203,9 +213,7 @@ _k1b_do_excp:
 	 */
 	add  $sp, $sp, -K1B_EXCP_SIZE
 	;;
-	lw  $r5 = MOS_VC_REG_PS[$r2]
-	;;
-	srl $r4 = $r5, 28                 /* Exception code. */
+	_get_suspension_cause $r2 $r4 $r5  /* Exception code. */
 	;;
 	sw  K1B_EXCP_NR[$sp], $r4
 	;;
@@ -337,9 +345,7 @@ _k1b_do_int:
 	/*
 	 * Save interrupt number into r0.
 	 */
-	lw  $r5 = MOS_VC_REG_PS[$r2]
-	;;
-	srl $r0 = $r5, 28                 /* Interrupt code. */
+	_get_suspension_cause $r2 $r0 $r5  /* Interrupt code. */
 	;;
 
 	/*

--- a/src/hal/arch/core/k1b/hooks.S
+++ b/src/hal/arch/core/k1b/hooks.S
@@ -36,6 +36,7 @@
 
 .global _k1b_do_kcall
 .global _k1b_do_excp
+.global _k1b_do_int
 
 .section .text
 
@@ -240,6 +241,115 @@ _k1b_do_excp:
 	 * from current stack.
 	 */
 	add $sp, $sp, K1B_EXCP_SIZE
+	;;
+
+	_scoreboard_get $r2 $r3
+	;;
+
+	/* Restore saved program counter. */
+	lw  $r4 = K1B_CONTEXT_SPC[$sp]
+	;;
+	sw  MOS_VC_REG_SPC[$r2], $r4
+	;;
+
+	/* Restore shadow stack pointer. */
+	lw  $r4 = K1B_CONTEXT_SSP[$sp]
+	;;
+	sw  MOS_VC_REG_SSP[$r2], $r4
+	;;
+
+	/*
+	 * Restore saved execution context.
+	 */
+	k1b_context_restore
+	;;
+
+	/* Restore exception context. */
+	scall MOS_VC_RFE
+	;;
+	ret
+	;;
+
+/*===========================================================================*
+ * _do_int()                                                                 *
+ *===========================================================================*/
+
+/*
+ * Interrupt hook.
+ */
+.align 8
+_k1b_do_int:
+
+	/*
+	 * Save execution context
+	 * in the current stack.
+	 */
+	k1b_context_save
+	;;
+
+	/*
+	 * Save a reference to execution context
+	 * into r1. The high-level exception handler
+	 * dispatcher will need it.
+	 */
+	copy $r1 = $sp
+	;;
+
+	_scoreboard_get $r2 $r3
+	;;
+
+	/* Processing Status. */
+	lw  $r4 = MOS_VC_REG_PS[$r2]
+	;;
+	sw  K1B_CONTEXT_PS[$r1], $r4
+	;;
+
+	/* Saved Processing Status */
+	lw  $r4 = MOS_VC_REG_SPS[$r2]
+	;;
+	sw  K1B_CONTEXT_SPS[$r1], $r4
+	;;
+
+	/* Saved Program Counter. */
+	lw  $r4 = MOS_VC_REG_SPC[$r2]
+	;;
+	sw  K1B_CONTEXT_SPC[$r1], $r4
+	;;
+
+	/* Shadow Stack Pointer. */
+	lw  $r4 = MOS_VC_REG_SSP[$r2]
+	;;
+	sw  K1B_CONTEXT_SSP[$r1], $r4
+	;;
+
+	/* Shadow Shadow Stack Pointer. */
+	lw  $r4 = MOS_VC_REG_SSSP[$r2]
+	;;
+	sw  K1B_CONTEXT_SSSP[$r1], $r4
+	;;
+
+	/* Shadow Shadow Shadow Stack Pointer. */
+	lw  $r4 = MOS_VC_REG_SSSSP[$r2]
+	;;
+	sw  K1B_CONTEXT_SSSSP[$r1], $r4
+	;;
+
+	/*
+	 * Save interrupt number into r0.
+	 */
+	lw  $r5 = MOS_VC_REG_PS[$r2]
+	;;
+	srl $r0 = $r5, 28                 /* Interrupt code. */
+	;;
+
+	/*
+	 * Call exception dispatcher.
+	 */
+	redzone_alloc
+	;;
+	call __k1b_do_int
+	;;
+	redzone_free
 	;;
 
 	_scoreboard_get $r2 $r3

--- a/src/hal/arch/core/k1b/ivt.c
+++ b/src/hal/arch/core/k1b/ivt.c
@@ -37,62 +37,22 @@
 /**
  * @brief High-level interrupt dispatcher.
  */
-PRIVATE k1b_int_handler_fn _k1b_do_int = NULL;
-
-/**
- * @brief Interrupt vectors.
- */
-PRIVATE struct {
-	int intnum; /**< Interrupt Number          */
-	int hwint;  /**< Hardware Interrupt Number */
-} hwints[K1B_IVT_LENGTH] = {
-	{ BSP_IT_TIMER_0, K1B_INT_TIMER0    }, /* Timer 0              */
-	{ BSP_IT_TIMER_1, K1B_INT_TIMER1    }, /* Timer 1              */
-	{ BSP_IT_WDOG,    K1B_INT_TIMER     }, /* Watchdog Timer       */
-	{ BSP_IT_CN,      K1B_INT_CNOC      }, /* Control NoC          */
-	{ BSP_IT_RX,      K1B_INT_DNOC      }, /* Data NoC             */
-	{ BSP_IT_UC,      K1B_INT_DMA       }, /* DMA                  */
-	{ BSP_IT_NE,      K1B_INT_NOC_ERR   }, /* NoC Error            */
-	{ BSP_IT_WDOG_U,  K1B_INT_TIMER_ERR }, /* Watchdog Timer Error */
-	{ BSP_IT_PE_0,    K1B_INT_VIRT      }, /* Remote Core 0        */
-	{ BSP_IT_PE_1,    K1B_INT_VIRT      }, /* Remote Core 1        */
-	{ BSP_IT_PE_2,    K1B_INT_VIRT      }, /* Remote Core 2        */
-	{ BSP_IT_PE_3,    K1B_INT_VIRT      }, /* Remote Core 3        */
-	{ BSP_IT_PE_4,    K1B_INT_VIRT      }, /* Remote Core 4        */
-	{ BSP_IT_PE_5,    K1B_INT_VIRT      }, /* Remote Core 5        */
-	{ BSP_IT_PE_6,    K1B_INT_VIRT      }, /* Remote Core 6        */
-	{ BSP_IT_PE_7,    K1B_INT_VIRT      }, /* Remote Core 7        */
-	{ BSP_IT_PE_8,    K1B_INT_VIRT      }, /* Remote Core 8        */
-	{ BSP_IT_PE_9,    K1B_INT_VIRT      }, /* Remote Core 9        */
-	{ BSP_IT_PE_10,   K1B_INT_VIRT      }, /* Remote Core 10       */
-	{ BSP_IT_PE_11,   K1B_INT_VIRT      }, /* Remote Core 11       */
-	{ BSP_IT_PE_12,   K1B_INT_VIRT      }, /* Remote Core 12       */
-	{ BSP_IT_PE_13,   K1B_INT_VIRT      }, /* Remote Core 14       */
-	{ BSP_IT_PE_14,   K1B_INT_VIRT      }, /* Remote Core 14       */
-	{ BSP_IT_PE_15,   K1B_INT_VIRT      }, /* Remote Core 15       */
-};
+PRIVATE k1b_int_handler_fn _do_interrupt = NULL;
 
 /**
  * @brief Low-level interrupt dispatcher.
  *
- * @param intnum Interrupt number.
- * @param ctx    Saved interrupted context.
+ * @param hwint Interrupt number.
+ * @param ctx   Saved interrupted context.
  *
  * @author Pedro Henrique Penna
  */
-PRIVATE void __k1b_do_int(int intnum, __k1_vcontext_t *ctx)
+PUBLIC void __k1b_do_int(int hwint, struct context * ctx)
 {
 	UNUSED(ctx);
 
-	for (int i = 0; i < K1B_IVT_LENGTH; i++)
-	{
-		if (hwints[i].intnum == intnum)
-		{
-			if (LIKELY(_k1b_do_int != NULL))
-				_k1b_do_int(hwints[i].hwint);
-			return;
-		}
-	}
+	if (LIKELY(_do_interrupt != NULL))
+		_do_interrupt(hwint);
 }
 
 /**
@@ -113,14 +73,16 @@ PRIVATE void k1b_ivt_setup(
 	k1b_int_handler_fn hwint_handler,
 	k1b_swint_handler_fn swint_handler,
 	void (*excp_handler)(void),
-	void *stack)
+	void (*it_handler)(void),
+	void *stack
+)
 {
 	kprintf("[hal] exception stack at %x", stack);
 
 	/* Register dispatchers. */
-	_k1b_do_int = hwint_handler;
-	for (int i = 0; i < K1B_IVT_LENGTH; i++)
-		bsp_register_it(__k1b_do_int, hwints[i].intnum);
+	_do_interrupt = hwint_handler;
+	mOS_register_it_handler(it_handler);
+
 	mOS_register_scall_handler(swint_handler);
 	mOS_register_trap_handler(excp_handler);
 	k1b_dcache_inval();
@@ -137,12 +99,14 @@ PRIVATE void k1b_ivt_setup(
  *
  * @author Pedro Henrique Penna
  */
-PUBLIC void ivt_setup(void *stack)
+PUBLIC void ivt_setup(void * stack)
 {
 	k1b_ivt_setup(
 		do_interrupt,
 		_k1b_do_kcall,
 		_k1b_do_excp,
+		_k1b_do_int,
 		stack
 	);
 }
+


### PR DESCRIPTION
In this PR, I implement our own interrupt dispatcher and configure that directly on mOS scoreboard. This made it possible to remove BSP dependency.

I also map interrupt code to correspond to the IRQ code, which is the identifier used by the hardware to identify the interrupts.