### PR TITLE
[core] Introduce Context Switching Mechanism

### DIFF
--- a/include/arch/core/i486.h
+++ b/include/arch/core/i486.h
@@ -59,13 +59,14 @@
 	 * @name Core Features
 	 */
 	/**@{*/
-	#define CORE_HAS_PERF         0 /**< Has Performance Monitors?   */
-	#define CORE_HAS_ATOMICS      1 /**< Has Atomic Instructions?    */
-	#define CORE_HAS_PMIO         1 /**< Has Programmed I/O?         */
-	#define CORE_HAS_TLB_HW       1 /**< Has Hardware-Managed TLB?   */
-	#define CORE_HAS_CACHE_HW     1 /**< Has Hardware-Managed Cache? */
-	#define CORE_HAS_HUGE_PAGES   0 /**< Are Huge Pages Supported?   */
-	#define CORE_IS_LITTLE_ENDIAN 1 /**< Is Little Endian?           */
+	#define CORE_HAS_PERF                0 /**< Has Performance Monitors?          */
+	#define CORE_HAS_ATOMICS             1 /**< Has Atomic Instructions?           */
+	#define CORE_HAS_PMIO                1 /**< Has Programmed I/O?                */
+	#define CORE_HAS_TLB_HW              1 /**< Has Hardware-Managed TLB?          */
+	#define CORE_HAS_CACHE_HW            1 /**< Has Hardware-Managed Cache?        */
+	#define CORE_HAS_HUGE_PAGES          0 /**< Are Huge Pages Supported?          */
+	#define CORE_IS_LITTLE_ENDIAN        1 /**< Is Little Endian?                  */
+	#define CORE_SUPPORTS_MULTITHREADING 0 /**< Has support for context switching? */
 	/**@}*/
 
 /**@endcond*/

--- a/include/arch/core/k1b.h
+++ b/include/arch/core/k1b.h
@@ -69,7 +69,7 @@
 	#define CORE_HAS_CACHE_HW            0 /**< Has Hardware-Managed Cache?        */
 	#define CORE_HAS_HUGE_PAGES          0 /**< Are Huge Pages Supported?          */
 	#define CORE_IS_LITTLE_ENDIAN        1 /**< Is Little Endian?                  */
-	#define CORE_SUPPORTS_MULTITHREADING 0 /**< Has support for context switching? */
+	#define CORE_SUPPORTS_MULTITHREADING 1 /**< Has support for context switching? */
 	/**@}*/
 
 /**@endcond*/

--- a/include/arch/core/k1b.h
+++ b/include/arch/core/k1b.h
@@ -62,13 +62,14 @@
 	 * @name Core Features
 	 */
 	/**@{*/
-	#define CORE_HAS_PERF         1 /**< Has Performance Monitors?   */
-	#define CORE_HAS_ATOMICS      1 /**< Has Atomic Instructions?    */
-	#define CORE_HAS_PMIO         1 /**< Has Programmed I/O?         */
-	#define CORE_HAS_TLB_HW       0 /**< Has Hardware-Managed TLB?   */
-	#define CORE_HAS_CACHE_HW     0 /**< Has Hardware-Managed Cache? */
-	#define CORE_HAS_HUGE_PAGES   0 /**< Are Huge Pages Supported?   */
-	#define CORE_IS_LITTLE_ENDIAN 1 /**< Is Little Endian?           */
+	#define CORE_HAS_PERF                1 /**< Has Performance Monitors?          */
+	#define CORE_HAS_ATOMICS             1 /**< Has Atomic Instructions?           */
+	#define CORE_HAS_PMIO                1 /**< Has Programmed I/O?                */
+	#define CORE_HAS_TLB_HW              0 /**< Has Hardware-Managed TLB?          */
+	#define CORE_HAS_CACHE_HW            0 /**< Has Hardware-Managed Cache?        */
+	#define CORE_HAS_HUGE_PAGES          0 /**< Are Huge Pages Supported?          */
+	#define CORE_IS_LITTLE_ENDIAN        1 /**< Is Little Endian?                  */
+	#define CORE_SUPPORTS_MULTITHREADING 0 /**< Has support for context switching? */
 	/**@}*/
 
 /**@endcond*/

--- a/include/arch/core/k1b/asm.h
+++ b/include/arch/core/k1b/asm.h
@@ -41,7 +41,7 @@
 	 */
 	/**@{*/
 	#define sp r12 /**< Stack Pointer Pointer               */
-	#define bp r13 /**< Thread Local Store Pointer Register */
+	#define bp r13 /**< Base Stack Pointer Register         */
 	#define pi pcr /**< Processing Identification Register  */
 	/**@}*/
 

--- a/include/arch/core/k1b/ctx.h
+++ b/include/arch/core/k1b/ctx.h
@@ -205,6 +205,21 @@
 	);
 
 	/**
+	 * @brief Switch between contexts.
+	 *
+	 * @details The previous context will be store into kernel stack
+	 * and the pointer to it will be store into @previous parameter.
+	 * And the next context will be restore from the @next parameter.
+	 *
+	 * @param previous Pointer to store the pointer of the previous context.
+	 * @param next     Pointer to get the pointer to the next context.
+	 */
+	EXTERN void k1b_context_switch_to(
+		struct context ** previous,
+		struct context ** next
+	);
+
+	/**
 	 * @brief Gets the value of the stack pointer register.
 	 *
 	 * @param ctx Target context.
@@ -290,6 +305,7 @@
 	#define __context_set_pc_fn    /**< context_set_pc()    */
 	#define __context_dump_fn      /**< context_dump()      */
 	#define __context_create_fn    /**< context_create()    */
+	#define __context_switch_to_fn /**< context_switch_to() */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -339,6 +355,12 @@
 	 */
 	#define __context_create(start, ustack, kstack) \
 		k1b_context_create(start, ustack, kstack)
+
+	/**
+	 * @see k1b_context_switch_to()
+	 */
+	#define __context_switch_to(previous, next) \
+		k1b_context_switch_to(previous, next)
 
 #endif /* _ASM_FILE_ */
 

--- a/include/arch/core/k1b/mOS.h
+++ b/include/arch/core/k1b/mOS.h
@@ -39,6 +39,7 @@
 
 	#include <HAL/hal/board/boot_args.h>
 	#include <HAL/hal/core/diagnostic.h>
+	#include <HAL/hal/core/legacy.h>
 	#include <HAL/hal/cluster/dsu.h>
 	#include "HAL/hal/cluster/cnoc.h"
 	#include "HAL/hal/cluster/dnoc.h"

--- a/include/arch/core/linux64.h
+++ b/include/arch/core/linux64.h
@@ -71,13 +71,14 @@
 	 * @name Provided Features
 	 */
 	/**@{*/
-	#define CORE_HAS_PERF         1 /**< Has Performance Monitors?   */
-	#define CORE_HAS_ATOMICS      1 /**< Has Atomic Instructions?    */
-	#define CORE_HAS_PMIO         0 /**< Has Programmed I/O?         */
-	#define CORE_HAS_TLB_HW       1 /**< Has Hardware-Managed TLB?   */
-	#define CORE_HAS_CACHE_HW     1 /**< Has Hardware-Managed Cache? */
-	#define CORE_HAS_HUGE_PAGES   0 /**< Are Huge Pages Supported?   */
-	#define CORE_IS_LITTLE_ENDIAN 0 /**< Is Little Endian?           */
+	#define CORE_HAS_PERF                1 /**< Has Performance Monitors?          */
+	#define CORE_HAS_ATOMICS             1 /**< Has Atomic Instructions?           */
+	#define CORE_HAS_PMIO                0 /**< Has Programmed I/O?                */
+	#define CORE_HAS_TLB_HW              1 /**< Has Hardware-Managed TLB?          */
+	#define CORE_HAS_CACHE_HW            1 /**< Has Hardware-Managed Cache?        */
+	#define CORE_HAS_HUGE_PAGES          0 /**< Are Huge Pages Supported?          */
+	#define CORE_IS_LITTLE_ENDIAN        0 /**< Is Little Endian?                  */
+	#define CORE_SUPPORTS_MULTITHREADING 0 /**< Has support for context switching? */
 	/**@}*/
 
 	/**

--- a/include/arch/core/mor1kx.h
+++ b/include/arch/core/mor1kx.h
@@ -60,13 +60,14 @@
 	 * @name Core Features
 	 */
 	/**@{*/
-	#define CORE_HAS_PERF         1 /**< Has Performance Monitors?   */
-	#define CORE_HAS_ATOMICS      1 /**< Has Atomic Instructions?    */
-	#define CORE_HAS_PMIO         0 /**< Has Programmed I/O?         */
-	#define CORE_HAS_TLB_HW       0 /**< Has Hardware-Managed TLB?   */
-	#define CORE_HAS_CACHE_HW     1 /**< Has Hardware-Managed Cache? */
-	#define CORE_HAS_HUGE_PAGES   1 /**< Are Huge Pages Supported?   */
-	#define CORE_IS_LITTLE_ENDIAN 0 /**< Is Little Endian?           */
+	#define CORE_HAS_PERF                1 /**< Has Performance Monitors?          */
+	#define CORE_HAS_ATOMICS             1 /**< Has Atomic Instructions?           */
+	#define CORE_HAS_PMIO                0 /**< Has Programmed I/O?                */
+	#define CORE_HAS_TLB_HW              0 /**< Has Hardware-Managed TLB?          */
+	#define CORE_HAS_CACHE_HW            1 /**< Has Hardware-Managed Cache?        */
+	#define CORE_HAS_HUGE_PAGES          1 /**< Are Huge Pages Supported?          */
+	#define CORE_IS_LITTLE_ENDIAN        0 /**< Is Little Endian?                  */
+	#define CORE_SUPPORTS_MULTITHREADING 0 /**< Has support for context switching? */
 	/**@}*/
 
 /**@endcond*/

--- a/include/arch/core/or1k.h
+++ b/include/arch/core/or1k.h
@@ -58,13 +58,14 @@
 	 * @name Core Features
 	 */
 	/**@{*/
-	#define CORE_HAS_PERF         0 /**< Has Performance Monitors?   */
-	#define CORE_HAS_ATOMICS      1 /**< Has Atomic Instructions?    */
-	#define CORE_HAS_PMIO         0 /**< Has Programmed I/O?         */
-	#define CORE_HAS_TLB_HW       0 /**< Has Hardware-Managed TLB?   */
-	#define CORE_HAS_CACHE_HW     1 /**< Has Hardware-Managed Cache? */
-	#define CORE_HAS_HUGE_PAGES   1 /**< Are Huge Pages Supported?   */
-	#define CORE_IS_LITTLE_ENDIAN 0 /**< Is Little Endian?           */
+	#define CORE_HAS_PERF                0 /**< Has Performance Monitors?          */
+	#define CORE_HAS_ATOMICS             1 /**< Has Atomic Instructions?           */
+	#define CORE_HAS_PMIO                0 /**< Has Programmed I/O?                */
+	#define CORE_HAS_TLB_HW              0 /**< Has Hardware-Managed TLB?          */
+	#define CORE_HAS_CACHE_HW            1 /**< Has Hardware-Managed Cache?        */
+	#define CORE_HAS_HUGE_PAGES          1 /**< Are Huge Pages Supported?          */
+	#define CORE_IS_LITTLE_ENDIAN        0 /**< Is Little Endian?                  */
+	#define CORE_SUPPORTS_MULTITHREADING 0 /**< Has support for context switching? */
 	/**@}*/
 
 /**@endcond*/

--- a/include/arch/core/rv32gc.h
+++ b/include/arch/core/rv32gc.h
@@ -64,13 +64,14 @@
 	 * @name Core Features
 	 */
 	/**@{*/
-	#define CORE_HAS_PERF         0 /**< Has Performance Monitors?   */
-	#define CORE_HAS_ATOMICS      1 /**< Has Atomic Instructions?    */
-	#define CORE_HAS_PMIO         0 /**< Has Programmed I/O?         */
-	#define CORE_HAS_TLB_HW       1 /**< Has Hardware-Managed TLB?   */
-	#define CORE_HAS_CACHE_HW     0 /**< Has Hardware-Managed Cache? */
-	#define CORE_HAS_HUGE_PAGES   1 /**< Are Huge Pages Supported?   */
-	#define CORE_IS_LITTLE_ENDIAN 1 /**< Is Little Endian?           */
+	#define CORE_HAS_PERF                0 /**< Has Performance Monitors?          */
+	#define CORE_HAS_ATOMICS             1 /**< Has Atomic Instructions?           */
+	#define CORE_HAS_PMIO                0 /**< Has Programmed I/O?                */
+	#define CORE_HAS_TLB_HW              1 /**< Has Hardware-Managed TLB?          */
+	#define CORE_HAS_CACHE_HW            0 /**< Has Hardware-Managed Cache?        */
+	#define CORE_HAS_HUGE_PAGES          1 /**< Are Huge Pages Supported?          */
+	#define CORE_IS_LITTLE_ENDIAN        1 /**< Is Little Endian?                  */
+	#define CORE_SUPPORTS_MULTITHREADING 0 /**< Has support for context switching? */
 	/**@}*/
 
 /**@endcond*/

--- a/include/nanvix/hal/core/context.h
+++ b/include/nanvix/hal/core/context.h
@@ -69,6 +69,9 @@
 		#ifndef __context_create_fn
 		#error "context_create() not defined?"
 		#endif
+		#ifndef __context_switch_to_fn
+		#error "context_switch_to() not defined?"
+		#endif
 	#endif
 
 #endif
@@ -160,6 +163,24 @@
 		void (* start)(void),
 		struct stack * ustack,
 		struct stack * kstack
+	);
+
+	/**
+	 * @brief Switch between contexts.
+	 *
+	 * @details The previous context will be store into kernel stack
+	 * and the pointer to it will be store into @previous parameter.
+	 * And the next context will be restore from the @next parameter.
+	 *
+	 * @param previous Pointer to store the pointer of the previous context.
+	 * @param next     Pointer to get the pointer to the next context.
+	 *
+	 * @returns Zero if the context was switched and restored, non-zero if
+	 * the arguments are invalid.
+	 */
+	EXTERN int context_switch_to(
+		struct context ** previous,
+		struct context ** next
 	);
 
 /**@}*/

--- a/include/nanvix/hal/core/context.h
+++ b/include/nanvix/hal/core/context.h
@@ -43,6 +43,11 @@
 	#ifndef __context_struct
 	#error "struct context not defined?"
 	#endif
+	#if CORE_SUPPORTS_MULTITHREADING
+		#ifndef __stack_struct
+		#error "struct stack not defined?"
+		#endif
+	#endif
 
 	/* Functions */
 	#ifndef __context_get_sp_fn
@@ -59,6 +64,11 @@
 	#endif
 	#ifndef __context_dump_fn
 	#error "context_dump() not defined?"
+	#endif
+	#if CORE_SUPPORTS_MULTITHREADING
+		#ifndef __context_create_fn
+		#error "context_create() not defined?"
+		#endif
 	#endif
 
 #endif
@@ -81,6 +91,17 @@
 	 * @brief Execution context.
 	 */
 	struct context;
+
+	/**
+	 * @brief Execution Stack.
+	 */
+	#if CORE_SUPPORTS_MULTITHREADING
+		struct stack;
+	#else
+		struct stack {
+			word_t dummy;
+		};
+	#endif
 
 	/**
 	 * @brief Gets the value of the stack pointer register.
@@ -124,6 +145,22 @@
 	 * @param ctx Saved execution context.
 	 */
 	EXTERN void context_dump(const struct context *ctx);
+
+	/**
+	 * @brief Create a context.
+	 *
+	 * @param start  Start routine.
+	 * @param ustack User stack pointer.
+	 * @param kstack Kernel stack pointer.
+	 *
+	 * @returns Valid pointer if the context struct was created
+	 * into the kernel stack correctly, NULL pointer otherwise.
+	 */
+	EXTERN struct context * context_create(
+		void (* start)(void),
+		struct stack * ustack,
+		struct stack * kstack
+	);
 
 /**@}*/
 

--- a/src/hal/arch/core/k1b/hooks.S
+++ b/src/hal/arch/core/k1b/hooks.S
@@ -37,6 +37,7 @@
 .global _k1b_do_kcall
 .global _k1b_do_excp
 .global _k1b_do_int
+.global k1b_context_switch_to
 
 .section .text
 
@@ -460,8 +461,167 @@ _k1b_do_int:
 	_k1b_context_restore
 	;;
 
-	/* Restore exception context. */
+	/* Restore interrupt context. */
 	scall MOS_VC_RFE
 	;;
 	ret
 	;;
+
+/*===========================================================================*
+ * k1b_context_switch_to()                                                   *
+ *===========================================================================*/
+
+/**
+ * @brief Switch between contexts.
+ *
+ * @details The previous context will be store into kernel stack
+ * and the pointer to it will be store into @previous parameter.
+ * And the next context will be restore from the @next parameter.
+ *
+ * @param previous Pointer to store the pointer of the previous context.
+ * @param next     Pointer to get the pointer to the next context.
+ */
+.align 8
+k1b_context_switch_to:
+
+	/**
+	 * Save previous context 
+	 **/
+
+		/*
+		 * Save execution context
+		 * in the current stack.
+		 */
+		_k1b_context_save
+		;;
+
+		_scoreboard_get $r2 $r3
+		;;
+
+		/* Save Processing Status. */
+		lw $r4 = MOS_VC_REG_PS[$r2]
+		;;
+		sw K1B_CONTEXT_SPS[$sp], $r4
+		;;
+
+		/* Save Shadow Processing Status */
+		lw $r4 = MOS_VC_REG_SPS[$r2]
+		;;
+		sw K1B_CONTEXT_SSPS[$sp], $r4
+		;;
+
+		/* Save Shadow Shadow Processing Status */
+		lw $r4 = MOS_VC_REG_SSPS[$r2]
+		;;
+		sw K1B_CONTEXT_SSSPS[$sp], $r4
+		;;
+
+		/* Change where the context will be restored. */
+		make $r4 = k1b_context_switch_to.return
+		;;
+		sw K1B_CONTEXT_SPC[$sp], $r4
+		;;
+
+		/* Save Shadown Program Counter. */
+		lw $r4 = MOS_VC_REG_SPC[$r2]
+		;;
+		sw K1B_CONTEXT_SSPC[$sp], $r4
+		;;
+
+		/* Save Shadown Shadown Program Counter. */
+		lw $r4 = MOS_VC_REG_SSPC[$r2]
+		;;
+		sw K1B_CONTEXT_SSSPC[$sp], $r4
+		;;
+
+		/* Save Shadow Stack Pointer. */
+		add $r4, $sp, K1B_CONTEXT_SIZE
+		;;
+		sw K1B_CONTEXT_SSP[$sp], $r4
+		;;
+
+		/* Save Shadow Shadow Stack Pointer. */
+		lw $r4 = MOS_VC_REG_SSP[$r2]
+		;;
+		sw K1B_CONTEXT_SSSP[$sp], $r4
+		;;
+
+		/* Save Shadow Shadow Shadow Stack Pointer. */
+		lw $r4 = MOS_VC_REG_SSSP[$r2]
+		;;
+		sw K1B_CONTEXT_SSSSP[$sp], $r4
+		;;
+
+		/* Save Kernel Stack Pointer. */
+		lw $r4 = MOS_VC_REG_KERNEL_SP[$r2]
+		;;
+		sw K1B_CONTEXT_KSP[$sp], $r4
+		;;
+
+	/**
+	 * Store previous context pointer and switch stacks 
+	 **/
+
+		/**
+		 * Load saved parameters
+		 * r0 = struct context ** previous
+		 * r1 = const struct context ** next
+		 **/
+		ld $p0 = K1B_CONTEXT_R0[$sp] /**< r0 + r1  */
+		;;
+
+		/* Store pointer to previous context. */
+		sw 0[$r0], $sp
+		;;
+
+		/* Switch stack. */
+		lw $sp = 0[$r1]
+		;;
+
+		/* Clear next context pointer pointer. */
+		make $r4 = 0
+		;;
+		sw 0[$r1], $r4
+		;;
+
+	/**
+	 * Restore next context 
+	 **/
+
+		/* Restore saved execution mos context. */
+		_k1b_mos_context_restore $sp $r2 $r4
+		;;
+
+		/* Restore saved execution context. */
+		_k1b_context_restore
+		;;
+
+		/* Invalidate the cache. */
+		wpurge
+		;;
+		fence
+		;;
+		dinval
+		;;
+
+		/* Restore exception context. */
+		scall MOS_VC_RFE
+		;;
+
+	/**
+	 * Return of preempted context. 
+	 **/
+
+	k1b_context_switch_to.return:
+
+		/* Invalidate the cache. */
+		wpurge
+		;;
+		fence
+		;;
+		dinval
+		;;
+
+		/* Return normal execution. */
+		ret
+		;;

--- a/src/hal/core/context.c
+++ b/src/hal/core/context.c
@@ -61,3 +61,44 @@ PUBLIC struct context * context_create(
 #endif
 }
 
+/*============================================================================*
+ * context_switch_to()                                                        *
+ *============================================================================*/
+
+/**
+ * @brief Switch between contexts.
+ *
+ * @details The previous context will be store into kernel stack
+ * and the pointer to it will be store into @previous parameter.
+ * And the next context will be restore from the @next parameter.
+ *
+ * @param previous Pointer to store the pointer of the previous context.
+ * @param next     Pointer to get the pointer to the next context.
+ *
+ * @returns Zero if the context was switched and restored, non-zero if
+ * the arguments are invalid.
+ *
+ * @author João Vicente Souto
+ */
+PUBLIC int context_switch_to(struct context ** previous, struct context ** next)
+{
+	/* Is the previous pointer invalid? */
+	if (previous == NULL)
+		return (-EINVAL);
+
+	/* Is the next pointer invalid? */
+	if (next == NULL || (*next) == NULL)
+		return (-EINVAL);
+
+#if CORE_SUPPORTS_MULTITHREADING
+
+	/* Restore contex. */
+	__context_switch_to(previous, next);
+
+	return (0);
+
+#else
+	return (-ENOSYS);
+#endif
+}
+

--- a/src/hal/core/context.c
+++ b/src/hal/core/context.c
@@ -1,0 +1,63 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* Must come first. */
+#define __NEED_HAL_CORE
+
+#include <nanvix/hal/core.h>
+#include <nanvix/const.h>
+#include <nanvix/hlib.h>
+#include <posix/errno.h>
+
+/*============================================================================*
+ * context_create()                                                           *
+ *============================================================================*/
+
+/**
+ * @brief Create a context.
+ *
+ * @param start  Start routine.
+ * @param ustack User stack pointer.
+ * @param kstack Kernel stack pointer.
+ *
+ * @returns Context struct create into the kernel stack.
+ *
+ * @author João Vicente Souto
+ */
+PUBLIC struct context * context_create(
+	void (* start)(void),
+	struct stack * ustack,
+	struct stack * kstack
+)
+{
+	if ((start == NULL) || (ustack == NULL) || (kstack == NULL))
+		return (NULL);
+
+#if CORE_SUPPORTS_MULTITHREADING
+	return (__context_create(start, ustack, kstack));
+#else
+	return (NULL);
+#endif
+}
+

--- a/src/test/core/core.c
+++ b/src/test/core/core.c
@@ -62,11 +62,9 @@ PRIVATE void test_core_get_id(void)
 	KASSERT(coreid == COREID_MASTER);
 }
 
-
 /*----------------------------------------------------------------------------*
  * Core Poweroff                                                              *
  *----------------------------------------------------------------------------*/
-
 
 /**
  * @brief API Test: Poweroff the core
@@ -80,6 +78,39 @@ PRIVATE void test_core_poweroff(void)
 	core_poweroff();
 }
 
+#if CORE_SUPPORTS_MULTITHREADING
+
+/*----------------------------------------------------------------------------*
+ * Context create                                                             *
+ *----------------------------------------------------------------------------*/
+
+PRIVATE struct stack ustack;
+PRIVATE struct stack kstack;
+
+PRIVATE void dummy_start(void)
+{
+	kprintf("[test][core] Dummy function start.");
+}
+
+/**
+ * @brief API Test: Poweroff the core
+ */
+PRIVATE void test_context_create(void)
+{
+	struct context * ctx;
+
+	KASSERT((ctx = context_create(dummy_start, &ustack, &kstack)) != NULL);
+
+	KASSERT(context_get_pc(ctx) == (word_t) dummy_start);
+	KASSERT(WITHIN(
+		context_get_sp(ctx),
+		(word_t) (&ustack),
+		(word_t) (&ustack + 1)
+	));
+}
+
+#endif /* CORE_SUPPORTS_MULTITHREADING */
+
 /*============================================================================*
  * Test Driver                                                                *
  *============================================================================*/
@@ -88,9 +119,12 @@ PRIVATE void test_core_poweroff(void)
  * @brief API Tests.
  */
 PRIVATE struct test core_tests_api[] = {
-	{ test_core_get_id,   "get core id   " },
-	{ test_core_poweroff, "power off core" },
-	{ NULL,                NULL            },
+	{ test_core_get_id,    "get core id   " },
+	{ test_core_poweroff,  "power off core" },
+#if CORE_SUPPORTS_MULTITHREADING
+	{ test_context_create, "create context" },
+#endif
+	{ NULL,                NULL             },
 };
 
 /**


### PR DESCRIPTION
## Description

In this PR, I introduce the interface to create and exchange execution contexts. Besides the default interface, the incoming changes already bring the implementation for MPPA-256 architecture.

This feature is verified by two unit tests:
- Creation of a context
- Context switching and restoration using three levels of contexts.

## Related issue

Mention #620 