### PR TITLE
[test] Unit Tests Get Stuck in Unix

### DIFF
--- a/src/test/main.c
+++ b/src/test/main.c
@@ -160,20 +160,31 @@ PUBLIC NORETURN void kmain(int argc, const char *argv[])
 
 	int nodenum = processor_node_get_num();
 
+#ifdef __unix64__
+	if (nodenum == NODENUM_MASTER)
+#else
 	/* Run local unit tests. */
 	if ((nodenum == NODENUM_MASTER) || (nodenum == NODENUM_SLAVE))
+#endif
 	{
 		test_core_al();
 		test_cluster_al();
 		test_processor_al();
 
+#ifndef __unix64__
 		/* Run comm. service unit tests. */
 		if (nodenum == NODENUM_MASTER)
+#endif
 			test_target_al();
-
+#ifndef __unix64__
 		/* Run Inter-Cluster tests. */
 		test_stress_al();
+#endif
 	}
+#ifdef __unix64__
+	if ((nodenum == NODENUM_MASTER) || (nodenum == NODENUM_SLAVE))
+		test_stress_al();
+#endif
 
 #endif
 


### PR DESCRIPTION
In this PR, we change back the main of tests to the old version only on Unix, i.e., only master cluster runs all tests available. We need to make this because if both clusters run all tests, they cannot synchronize on communication tests for some sake.

# Releated Issues

Mention #633 