### PR TITLE
[cores][unix64] Linux Cores Num

### DIFF
--- a/include/arch/cluster/linux64-cluster/cores.h
+++ b/include/arch/cluster/linux64-cluster/cores.h
@@ -41,7 +41,7 @@
 	/**
 	 * @brief Number of cores in the cluster.
 	 */
-    #define LINUX64_CLUSTER_NUM_CORES 4
+    #define LINUX64_CLUSTER_NUM_CORES 5
 
 	/**
 	 * @brief ID of the master core.


### PR DESCRIPTION
# Description #
In this PR, we increase the number of cores in Unix64 from 4 to 5, to permit the Nanvix System to include a Name Service Daemon in each Compute Cluster without incurring in cores starvation.