### PR TITLE
[core] Add a Getter to Interrupt Level and Use It on Section Guards

### DIFF
--- a/include/arch/core/i486/int.h
+++ b/include/arch/core/i486/int.h
@@ -148,13 +148,14 @@
 	 * @name Exported Functions
 	 */
 	/**@{*/
-	#define __interrupts_disable_fn /**< @ref interrupts_disable() */
-	#define __interrupts_enable_fn  /**< @ref interrupts_enable()  */
-	#define __interrupts_level_fn   /**< @ref interrupts_level()   */
-	#define __interrupt_next_fn     /**< @ref interrupt_next()     */
-	#define __interrupt_mask_fn     /**< @ref interrupt_mask()     */
-	#define __interrupt_unmask_fn   /**< @ref interrupt_unmask()   */
-	#define __interrupt_ack_fn      /**< @ref interrupt_ack()      */
+	#define __interrupts_disable_fn   /**< @ref interrupts_disable()   */
+	#define __interrupts_enable_fn    /**< @ref interrupts_enable()    */
+	#define __interrupts_get_level_fn /**< @ref interrupts_get_level() */
+	#define __interrupts_set_level_fn /**< @ref interrupts_set_level() */
+	#define __interrupt_next_fn       /**< @ref interrupt_next()       */
+	#define __interrupt_mask_fn       /**< @ref interrupt_mask()       */
+	#define __interrupt_unmask_fn     /**< @ref interrupt_unmask()     */
+	#define __interrupt_ack_fn        /**< @ref interrupt_ack()        */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -176,9 +177,17 @@
 	}
 
 	/**
+	 * @see i486_lpic_lvl_get().
+	 */
+	static inline int interrupts_get_level(void)
+	{
+		return (i486_lpic_lvl_get());
+	}
+
+	/**
 	 * @see i486_lpic_lvl_set().
 	 */
-	static inline int interrupts_level(int newlevel)
+	static inline int interrupts_set_level(int newlevel)
 	{
 		return (i486_lpic_lvl_set(newlevel));
 	}

--- a/include/arch/core/i486/lpic.h
+++ b/include/arch/core/i486/lpic.h
@@ -139,6 +139,13 @@
 	EXTERN int i486_lpic_unmask(int irq);
 
 	/**
+	 * @brief Gets the interrupt level of the calling core.
+	 *
+	 * @returns The current interrupt level.
+	 */
+	EXTERN int i486_lpic_lvl_get(void);
+
+	/**
 	 * @brief Sets the interrupt level of the calling core.
 	 *
 	 * @param newlevel New interrupt level.

--- a/include/arch/core/k1b/int.h
+++ b/include/arch/core/k1b/int.h
@@ -171,13 +171,14 @@
 	 * @name Exported Functions
 	 */
 	/**@{*/
-	#define __interrupts_disable_fn /**< @ref interrupts_disable() */
-	#define __interrupts_enable_fn  /**< @ref interrupts_enable()  */
-	#define __interrupts_level_fn   /**< @ref interrupts_level()   */
-	#define __interrupt_next_fn     /**< @ref interrupt_next()     */
-	#define __interrupt_mask_fn     /**< @ref interrupt_mask()     */
-	#define __interrupt_unmask_fn   /**< @ref interrupt_unmask()   */
-	#define __interrupt_ack_fn      /**< @ref interrupt_ack()      */
+	#define __interrupts_disable_fn   /**< @ref interrupts_disable()   */
+	#define __interrupts_enable_fn    /**< @ref interrupts_enable()    */
+	#define __interrupts_get_level_fn /**< @ref interrupts_get_level() */
+	#define __interrupts_set_level_fn /**< @ref interrupts_set_level() */
+	#define __interrupt_next_fn       /**< @ref interrupt_next()       */
+	#define __interrupt_mask_fn       /**< @ref interrupt_mask()       */
+	#define __interrupt_unmask_fn     /**< @ref interrupt_unmask()     */
+	#define __interrupt_ack_fn        /**< @ref interrupt_ack()        */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -199,9 +200,17 @@
 	}
 
 	/**
+	 * @see k1b_pic_lvl_get().
+	 */
+	static inline int interrupts_get_level(void)
+	{
+		return (k1b_pic_lvl_get());
+	}
+
+	/**
 	 * @see k1b_pic_lvl_set().
 	 */
-	static inline int interrupts_level(int newlevel)
+	static inline int interrupts_set_level(int newlevel)
 	{
 		return (k1b_pic_lvl_set(newlevel));
 	}

--- a/include/arch/core/k1b/lpic.h
+++ b/include/arch/core/k1b/lpic.h
@@ -122,6 +122,13 @@
 #ifndef _ASM_FILE_
 
 	/**
+	 * @brief Gets the interrupt level of the underlying core.
+	 *
+	 * @returns The current interrupt level.
+	 */
+	EXTERN int k1b_pic_lvl_get(void);
+
+	/**
 	 * @brief Sets the interrupt level of the underlying core.
 	 *
 	 * @param newlevel New interrupt level.

--- a/include/arch/core/linux64/int.h
+++ b/include/arch/core/linux64/int.h
@@ -54,13 +54,21 @@
 	EXTERN void linux64_interrupts_enable(void);
 
 	/**
+	 * @brief Gets the interrupt level of the underlying core.
+	 *
+	 * @returns The current interrupt level.
+	 */
+	EXTERN int linux64_interrupts_get_level(void);
+
+
+	/**
 	 * @brief Sets the interrupt level of the underlying core.
 	 *
 	 * @param newlevel New interrupt level.
 	 *
 	 * @returns The old interrupt level.
 	 */
-	EXTERN int linux64_interrupts_level(int newlevel);
+	EXTERN int linux64_interrupts_set_level(int newlevel);
 
 	/**
 	 * @brief Unmask a interrupt.
@@ -120,13 +128,14 @@
 	 * @name Exported Functions
 	 */
 	/**@{*/
-	#define __interrupts_disable_fn /**< @ref interrupts_disable() */
-	#define __interrupts_enable_fn  /**< @ref interrupts_enable()  */
-	#define __interrupts_level_fn   /**< @ref interrupts_level()   */
-	#define __interrupt_next_fn     /**< @ref interrupt_next()     */
-	#define __interrupt_mask_fn     /**< @ref interrupt_mask()     */
-	#define __interrupt_unmask_fn   /**< @ref interrupt_unmask()   */
-	#define __interrupt_ack_fn      /**< @ref interrupt_ack()      */
+	#define __interrupts_disable_fn   /**< @ref interrupts_disable()   */
+	#define __interrupts_enable_fn    /**< @ref interrupts_enable()    */
+	#define __interrupts_get_level_fn /**< @ref interrupts_get_level() */
+	#define __interrupts_set_level_fn /**< @ref interrupts_set_level() */
+	#define __interrupt_next_fn       /**< @ref interrupt_next()       */
+	#define __interrupt_mask_fn       /**< @ref interrupt_mask()       */
+	#define __interrupt_unmask_fn     /**< @ref interrupt_unmask()     */
+	#define __interrupt_ack_fn        /**< @ref interrupt_ack()        */
 	/**@}*/
 
 	/**
@@ -146,11 +155,19 @@
 	}
 
 	/**
-	 * @see linux64_interrupts_level().
+	 * @see linux64_interrupts_get_level().
 	 */
-	static inline int interrupts_level(int newlevel)
+	static inline int interrupts_get_level(void)
 	{
-		return (linux64_interrupts_level(newlevel));
+		return (linux64_interrupts_get_level());
+	}
+
+	/**
+	 * @see linux64_interrupts_set_level().
+	 */
+	static inline int interrupts_set_level(int newlevel)
+	{
+		return (linux64_interrupts_set_level(newlevel));
 	}
 
 	/**

--- a/include/arch/core/or1k/int.h
+++ b/include/arch/core/or1k/int.h
@@ -149,13 +149,14 @@
 	 * @name Exported Functions
 	 */
 	/**@{*/
-	#define __interrupts_disable_fn /**< @ref interrupts_disable() */
-	#define __interrupts_enable_fn  /**< @ref interrupts_enable()  */
-	#define __interrupts_level_fn   /**< @ref interrupts_level()   */
-	#define __interrupt_next_fn     /**< @ref interrupt_next()     */
-	#define __interrupt_mask_fn     /**< @ref interrupt_mask()     */
-	#define __interrupt_unmask_fn   /**< @ref interrupt_unmask()   */
-	#define __interrupt_ack_fn      /**< @ref interrupt_ack()      */
+	#define __interrupts_disable_fn   /**< @ref interrupts_disable()   */
+	#define __interrupts_enable_fn    /**< @ref interrupts_enable()    */
+	#define __interrupts_get_level_fn /**< @ref interrupts_get_level() */
+	#define __interrupts_set_level_fn /**< @ref interrupts_set_level() */
+	#define __interrupt_next_fn       /**< @ref interrupt_next()       */
+	#define __interrupt_mask_fn       /**< @ref interrupt_mask()       */
+	#define __interrupt_unmask_fn     /**< @ref interrupt_unmask()     */
+	#define __interrupt_ack_fn        /**< @ref interrupt_ack()        */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -177,9 +178,17 @@
 	}
 
 	/**
+	 * @see or1k_pic_lvl_get().
+	 */
+	static inline int interrupts_get_level(void)
+	{
+		return (or1k_pic_lvl_get());
+	}
+
+	/**
 	 * @see or1k_pic_lvl_set().
 	 */
-	static inline int interrupts_level(int newlevel)
+	static inline int interrupts_set_level(int newlevel)
 	{
 		return (or1k_pic_lvl_set(newlevel));
 	}

--- a/include/arch/core/or1k/lpic.h
+++ b/include/arch/core/or1k/lpic.h
@@ -133,6 +133,13 @@
 	EXTERN int or1k_pic_next(void);
 
 	/**
+	 * @brief Gets the interrupt level of the calling core.
+	 *
+	 * @returns The current interrupt level.
+	 */
+	EXTERN int or1k_pic_lvl_get(void);
+
+	/**
 	 * @brief Sets the interrupt level of the calling core.
 	 *
 	 * @param newlevel New interrupt level.

--- a/include/arch/core/rv32gc/int.h
+++ b/include/arch/core/rv32gc/int.h
@@ -151,13 +151,14 @@
 	 * @name Exported Functions
 	 */
 	/**@{*/
-	#define __interrupts_disable_fn /**< @ref interrupts_disable() */
-	#define __interrupts_enable_fn  /**< @ref interrupts_enable()  */
-	#define __interrupts_level_fn   /**< @ref interrupts_level()   */
-	#define __interrupt_next_fn     /**< @ref interrupt_next()     */
-	#define __interrupt_mask_fn     /**< @ref interrupt_mask()     */
-	#define __interrupt_unmask_fn   /**< @ref interrupt_unmask()   */
-	#define __interrupt_ack_fn      /**< @ref interrupt_ack()      */
+	#define __interrupts_disable_fn   /**< @ref interrupts_disable()   */
+	#define __interrupts_enable_fn    /**< @ref interrupts_enable()    */
+	#define __interrupts_get_level_fn /**< @ref interrupts_get_level() */
+	#define __interrupts_set_level_fn /**< @ref interrupts_set_level() */
+	#define __interrupt_next_fn       /**< @ref interrupt_next()       */
+	#define __interrupt_mask_fn       /**< @ref interrupt_mask()       */
+	#define __interrupt_unmask_fn     /**< @ref interrupt_unmask()     */
+	#define __interrupt_ack_fn        /**< @ref interrupt_ack()        */
 	/**@}*/
 
 #ifndef _ASM_FILE_
@@ -181,7 +182,15 @@
 	/**
 	 * @brief TODO Implement this function. 
 	 */
-	static inline int interrupts_level(int newlevel)
+	static inline int interrupts_get_level(void)
+	{
+		return (0);
+	}
+
+	/**
+	 * @brief TODO Implement this function. 
+	 */
+	static inline int interrupts_set_level(int newlevel)
 	{
 		UNUSED(newlevel);
 

--- a/include/nanvix/hal/core/interrupt.h
+++ b/include/nanvix/hal/core/interrupt.h
@@ -68,8 +68,11 @@
 	#ifndef __interrupts_enable_fn
 	#error "interrupts_enable() not defined?"
 	#endif
-	#ifndef __interrupts_level_fn
-	#error "interrupts_level() not defined?"
+	#ifndef __interrupts_get_level_fn
+	#error "interrupts_get_level() not defined?"
+	#endif
+	#ifndef __interrupts_set_level_fn
+	#error "interrupts_set_level() not defined?"
 	#endif
 	#ifndef __interrupt_mask_fn
 	#error "interrupt_mask() not defined?"
@@ -149,10 +152,15 @@
 	EXTERN void interrupts_enable(void);
 
 	/**
+	 * @brief Gets current interrupt level.
+	 */
+	EXTERN int interrupts_get_level(void);
+
+	/**
 	 * @brief Change interrupt level, i.e., change the minimum interrupt
 	 * priority that can be accepted.
 	 */
-	EXTERN int interrupts_level(int newlevel);
+	EXTERN int interrupts_set_level(int newlevel);
 
 	/**
 	 * @brief Registers an interrupt handler.

--- a/src/hal/arch/core/i486/lpic.c
+++ b/src/hal/arch/core/i486/lpic.c
@@ -135,8 +135,17 @@ PUBLIC int i486_lpic_unmask(int irq)
 }
 
 /*============================================================================*
- * i486_lpic_lvl_set()                                                        *
+ * i486_lpic_lvl_get()                                                        *
  *============================================================================*/
+
+/**
+ * The i486_lpic_get() function gets the interrupt level of the calling
+ * core to @p newlevel. The old interrupt level is returned.
+ */
+PUBLIC int i486_lpic_lvl_get(void)
+{
+	return (currlevel);
+}
 
 /**
  * The i486_lpic_set() function sets the interrupt level of the calling

--- a/src/hal/arch/core/k1b/lpic.c
+++ b/src/hal/arch/core/k1b/lpic.c
@@ -29,8 +29,19 @@
 #include <arch/core/k1b/lpic.h>
 #include <arch/core/k1b/mOS.h>
 #include <nanvix/const.h>
+#include <nanvix/hlib.h>
 #include <posix/errno.h>
 #include <posix/stdint.h>
+
+/**
+ * @brief Gets the interrupt level of the underlying core.
+ *
+ * @returns The curent interrupt level.
+ */
+PUBLIC int k1b_pic_lvl_get(void)
+{
+	return (_scoreboard_start.SCB_VCORE.PER_CPU[core_get_id()].SFR_PS.il);
+}
 
 /**
  * @brief Sets the interrupt level of the underlying core.
@@ -48,14 +59,13 @@ PUBLIC int k1b_pic_lvl_set(int newlevel)
 		return (-EINVAL);
 
 	/* Gets old interrupt level. */
-	oldlevel = _scoreboard_start.SCB_VCORE.PER_CPU[core_get_id()].SFR_PS.il;
+	oldlevel = k1b_pic_lvl_get();
 
 	/* Sets new interrupt level. */
 	mOS_set_it_level(newlevel);
 
 	return (oldlevel);
 }
-
 /**
  * The k1b_pic_mask() function masks the interrupt line in which
  * the interrupt @p irq is hooked up in the underlying k1b

--- a/src/hal/arch/core/linux64-core/int.c
+++ b/src/hal/arch/core/linux64-core/int.c
@@ -88,9 +88,17 @@ PUBLIC void linux64_interrupts_disable(void)
 }
 
 /**
+ * @brief Gets interrupt level.
+ */
+PUBLIC int linux64_interrupts_get_level(void)
+{
+	return (current_it_level);
+}
+
+/**
  * @brief Change interrupt level.
  */
-PUBLIC int linux64_interrupts_level(int newlevel)
+PUBLIC int linux64_interrupts_set_level(int newlevel)
 {
 	int oldlevel;
 

--- a/src/hal/arch/core/or1k/lpic.c
+++ b/src/hal/arch/core/or1k/lpic.c
@@ -57,6 +57,16 @@ PRIVATE int currlevel = OR1K_IRQLVL_0;
  *
  * @author Davidson Francis
  */
+PUBLIC int or1k_pic_lvl_get(void)
+{
+	return (currlevel);
+}
+
+/**
+ * @todo TODO provide a detailed description for this function.
+ *
+ * @author Davidson Francis
+ */
 PUBLIC int or1k_pic_lvl_set(int newlevel)
 {
 	uint32_t mask;

--- a/src/hal/cluster/cluster.c
+++ b/src/hal/cluster/cluster.c
@@ -117,7 +117,7 @@ PUBLIC void core_idle(void)
 
 	spinlock_unlock(&cores[coreid].lock);
 
-	interrupts_level(INTERRUPT_LEVEL_LOW);
+	interrupts_set_level(INTERRUPT_LEVEL_LOW);
 	interrupt_unmask(INTERRUPT_IPI);
 
 	while (true)
@@ -416,7 +416,7 @@ PUBLIC int core_reset(void)
 		return (-EINVAL);
 
 	interrupt_mask(INTERRUPT_IPI);
-	interrupts_level(INTERRUPT_LEVEL_NONE);
+	interrupts_set_level(INTERRUPT_LEVEL_NONE);
 
 	spinlock_lock(&cores[coreid].lock);
 	dcache_invalidate();


### PR DESCRIPTION
In this PR, I add the `interrupts_get_level` function to all the platforms and use it to enhance the behavior of the section guard. Specifically, the section guard now only changes the interrupt level if the core is on a lower priority level.

## Related Issues

Closes #636