### PR TITLE
[k1b-cluster][k1b-core] Bugfix: Fixes on new contexts, assembly and events

### DIFF
--- a/src/hal/arch/cluster/k1b-cluster/ipi.c
+++ b/src/hal/arch/cluster/k1b-cluster/ipi.c
@@ -45,10 +45,8 @@ PUBLIC void k1b_cluster_ipi_send(int coreid)
 {
 	KASSERT(WITHIN(coreid, 0, CORES_NUM));
 
-	/* Notify an event before IPI. */
-	__event_notify(coreid);
-
 	bsp_inter_pe_interrupt_raise((1 << coreid), K1B_BSP_IPI_LINE);
+	__event_notify(coreid);
 }
 
 /**

--- a/src/hal/arch/core/k1b/ctx.c
+++ b/src/hal/arch/core/k1b/ctx.c
@@ -104,7 +104,7 @@ PUBLIC struct context * k1b_context_create(
 	ps.ext  = 0; /**< Exception not taken.               */
 	ps.isw  = 1; /**< Use kernel stack on interrupts.    */
 	ps.esw  = 1; /**< Use kernel stack on traps.         */
-	ps.ie   = 1; /**< Enable interrupt.                  */
+	ps.ie   = 0; /**< Enable interrupt.                  */
 	ps.hle  = 1; /**< Enable hardware loop.              */
 	ps.ice  = 1; /**< Enable instruction cache.          */
 	ps.use  = 1; /**< Enable uncached streaming.         */

--- a/src/hal/arch/core/k1b/hooks.S
+++ b/src/hal/arch/core/k1b/hooks.S
@@ -199,7 +199,7 @@
 	;;
 
 	/* Restore program counter. */
-	lw $r4 = K1B_CONTEXT_SPC[\from]
+	lw \tmp = K1B_CONTEXT_SPC[\from]
 	;;
 	sw MOS_VC_REG_SPC[\to], \tmp
 	;;
@@ -220,15 +220,6 @@
 	lw \tmp = K1B_CONTEXT_SPS[\from]
 	;;
 	sw MOS_VC_REG_SPS[\to], \tmp
-	;;
-
-	/**
-	 * Restore Processing Status
-	 * @todo Is it Necessary? It is will be overwritten.
-	 **/
-	lw \tmp = K1B_CONTEXT_PS[\from]
-	;;
-	sw MOS_VC_REG_PS[\to], \tmp
 	;;
 
 .endm


### PR DESCRIPTION
In this PR, I fix the following bugs:
- New context must start with the interrupt disabled
- Use parameters register instead of hard-coded register
- Move the IPI sending to before the event notify so that the core can execute the interrupt before clearing the event and continues its execution.
- Because on the microkernel we have thread migration, I change the lock from core granularity to be global. Moreover, we reevaluate what is the underlying core always that an event is completed.

## Dependencies

The following PR must be accepted before the review of this PR:
- Mentions #638