### PR TITLE
[core] Feature: Tracking execution modes (core status)

### DIFF
--- a/include/arch/core/i486/int.h
+++ b/include/arch/core/i486/int.h
@@ -163,7 +163,7 @@
 	/**
 	 * @see i486_int_enable()
 	 */
-	static inline void interrupts_enable(void)
+	static inline void __interrupts_enable(void)
 	{
 		i486_int_enable();
 	}
@@ -171,7 +171,7 @@
 	/**
 	 * @see i486_int_disable()
 	 */
-	static inline void interrupts_disable(void)
+	static inline void __interrupts_disable(void)
 	{
 		i486_int_disable();
 	}
@@ -187,7 +187,7 @@
 	/**
 	 * @see i486_lpic_lvl_set().
 	 */
-	static inline int interrupts_set_level(int newlevel)
+	static inline int __interrupts_set_level(int newlevel)
 	{
 		return (i486_lpic_lvl_set(newlevel));
 	}

--- a/include/arch/core/k1b/int.h
+++ b/include/arch/core/k1b/int.h
@@ -186,7 +186,7 @@
 	/**
 	 * @see k1b_hwint_enable().
 	 */
-	static inline void interrupts_enable(void)
+	static inline void __interrupts_enable(void)
 	{
 		k1b_int_enable();
 	}
@@ -194,7 +194,7 @@
 	/**
 	 * @see k1b_hwint_disable().
 	 */
-	static inline void interrupts_disable(void)
+	static inline void __interrupts_disable(void)
 	{
 		k1b_int_disable();
 	}
@@ -210,7 +210,7 @@
 	/**
 	 * @see k1b_pic_lvl_set().
 	 */
-	static inline int interrupts_set_level(int newlevel)
+	static inline int __interrupts_set_level(int newlevel)
 	{
 		return (k1b_pic_lvl_set(newlevel));
 	}

--- a/include/arch/core/linux64/int.h
+++ b/include/arch/core/linux64/int.h
@@ -141,7 +141,7 @@
 	/**
 	 * @see linux64_core_int_disable().
 	 */
-	static inline void interrupts_disable(void)
+	static inline void __interrupts_disable(void)
 	{
 		linux64_interrupts_disable();
 	}
@@ -149,7 +149,7 @@
 	/**
 	 * @see linux64_interrupts_enable().
 	 */
-	static inline void interrupts_enable(void)
+	static inline void __interrupts_enable(void)
 	{
 		linux64_interrupts_enable();
 	}
@@ -165,7 +165,7 @@
 	/**
 	 * @see linux64_interrupts_set_level().
 	 */
-	static inline int interrupts_set_level(int newlevel)
+	static inline int __interrupts_set_level(int newlevel)
 	{
 		return (linux64_interrupts_set_level(newlevel));
 	}

--- a/include/arch/core/or1k/int.h
+++ b/include/arch/core/or1k/int.h
@@ -164,7 +164,7 @@
 	/**
 	 * @see or1k_int_enable().
 	 */
-	static inline void interrupts_enable(void)
+	static inline void __interrupts_enable(void)
 	{
 		or1k_int_enable();
 	}
@@ -172,7 +172,7 @@
 	/**
 	 * @see or1k_int_disable().
 	 */
-	static inline void interrupts_disable(void)
+	static inline void __interrupts_disable(void)
 	{
 		or1k_int_disable();
 	}
@@ -188,7 +188,7 @@
 	/**
 	 * @see or1k_pic_lvl_set().
 	 */
-	static inline int interrupts_set_level(int newlevel)
+	static inline int __interrupts_set_level(int newlevel)
 	{
 		return (or1k_pic_lvl_set(newlevel));
 	}

--- a/include/arch/core/rv32gc/int.h
+++ b/include/arch/core/rv32gc/int.h
@@ -166,7 +166,7 @@
 	/**
 	 * @see rv32gc_int_enable().
 	 */
-	static inline void interrupts_enable(void)
+	static inline void __interrupts_enable(void)
 	{
 		rv32gc_int_enable();
 	}
@@ -174,7 +174,7 @@
 	/**
 	 * @see rv32gc_int_disable().
 	 */
-	static inline void interrupts_disable(void)
+	static inline void __interrupts_disable(void)
 	{
 		rv32gc_int_disable();
 	}
@@ -190,7 +190,7 @@
 	/**
 	 * @brief TODO Implement this function. 
 	 */
-	static inline int interrupts_set_level(int newlevel)
+	static inline int __interrupts_set_level(int newlevel)
 	{
 		UNUSED(newlevel);
 

--- a/include/nanvix/hal/core.h
+++ b/include/nanvix/hal/core.h
@@ -42,6 +42,7 @@
 	#include <nanvix/hal/core/tlb.h>
 	#include <nanvix/hal/core/trap.h>
 	#include <nanvix/hal/core/upcall.h>
+	#include <nanvix/hal/core/status.h>
 	#include <nanvix/const.h>
 
 /*============================================================================*

--- a/include/nanvix/hal/core/status.h
+++ b/include/nanvix/hal/core/status.h
@@ -1,0 +1,80 @@
+/*
+ * MIT License
+ *
+ * Copyright(c) 2011-2020 The Maintainers of Nanvix
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NANVIX_HAL_CORE_STATUS_H_
+#define NANVIX_HAL_CORE_STATUS_H_
+
+	/* Core Interface Implementation */
+	#include <nanvix/hal/core/_core.h>
+
+/*============================================================================*
+ * Status Interface                                                           *
+ *============================================================================*/
+
+/**
+ * @addtogroup kernel-hal-core-status Status
+ * @ingroup kernel-hal-core
+ *
+ * @brief Status
+ */
+/**@{*/
+
+	/**
+	 * @name Core status modes.
+	 */
+	/**@{*/
+	#define CORE_STATUS_MODE_NORMAL    0                             /**< Core is on normal execution. */
+	#define CORE_STATUS_MODE_INTERRUPT 1                             /**< Core is in an interrupt.     */
+	#define CORE_STATUS_MODE_EXCEPTION 2                             /**< Core is in an exception.     */
+	#define CORE_STATUS_MODE_TRAP      3                             /**< Core is in a trap.           */
+	#define CORE_STATUS_MODE_MASKED    4                             /**< Core interrupts were masked. */
+	#define CORE_STATUS_MODE_LIMIT     (CORE_STATUS_MODE_MASKED + 1) /**< Limiting number.             */
+	/**@}*/
+
+	/**
+	 * @brief Core Status.
+	 *
+	 * @details This structure holds general status informations about the
+	 * underlying core that is updated by kernels code. In this sense, we can
+	 * easy consult the execution status of the core in an
+	 * architecture-independent way.
+	 */
+	struct core_status
+	{
+		int mode; /**< @see Core status modes. */
+	} ALIGN(CACHE_LINE_SIZE);
+
+	/**
+	 * @brief Set execution mode.
+	 */
+	EXTERN int core_status_set_mode(int mode);
+
+	/**
+	 * @brief Get execution mode.
+	 */
+	EXTERN int core_status_get_mode(void);
+
+/**@}*/
+
+#endif /* NANVIX_HAL_CORE_STATUS_H_ */

--- a/include/nanvix/hal/core/trap.h
+++ b/include/nanvix/hal/core/trap.h
@@ -168,6 +168,18 @@
 		word_t arg4,
 		word_t kcall_nr);
 
+	/**
+	 * @brief Generic exception handler.
+	 */
+	EXTERN int __do_kcall(
+		word_t arg0,
+		word_t arg1,
+		word_t arg2,
+		word_t arg3,
+		word_t arg4,
+		word_t kcall_nr
+	);
+
 /**@}*/
 
 #endif /* NANVIX_HAL_CORE_TRAP_H_ */

--- a/src/hal/arch/core/i486/hooks.S
+++ b/src/hal/arch/core/i486/hooks.S
@@ -203,7 +203,7 @@ i486_kcall:
 		pushl %eax
 
 		/* Handle system call. */
-		call do_kcall
+		call __do_kcall
 
 		/* Wipe out system call parameters. */
 		addl $6*I486_WORD_SIZE, %esp

--- a/src/hal/arch/core/k1b/hooks.S
+++ b/src/hal/arch/core/k1b/hooks.S
@@ -274,7 +274,7 @@ _k1b_do_kcall:
 		 */
 		_redzone_alloc
 		;;
-		call do_kcall
+		call __do_kcall
 		;;
 		_redzone_free
 		;;

--- a/src/hal/arch/core/or1k/hooks.S
+++ b/src/hal/arch/core/or1k/hooks.S
@@ -271,7 +271,7 @@ _kcall:
 		/*
 		 * Call kcall handler.
 		 */
-		l.jal do_kcall
+		l.jal __do_kcall
 		l.nop
 
 		/* Copy return value to the user stack. */

--- a/src/hal/arch/core/rv32gc/hooks.S
+++ b/src/hal/arch/core/rv32gc/hooks.S
@@ -134,7 +134,7 @@ rv32gc_do_strap:
 		lw a4, RV32GC_CONTEXT_A5(fp) /* Argument 4         */
 
 		/* Call high-level dispatcher. */
-		call do_kcall
+		call __do_kcall
 
 		/* Copy return value to the user stack. */
 		sw a0, RV32GC_CONTEXT_A0(fp)

--- a/src/hal/core/exception.c
+++ b/src/hal/core/exception.c
@@ -23,6 +23,7 @@
  */
 
 #include <nanvix/hal/core/exception.h>
+#include <nanvix/hal/core/status.h>
 #include <nanvix/const.h>
 #include <nanvix/hlib.h>
 #include <posix/errno.h>
@@ -66,13 +67,21 @@ PRIVATE NORETURN void default_handler(
 PUBLIC void do_exception(const struct exception *excp, const struct context *ctx)
 {
 	int excpnum;
+	int modenum;
 	exception_handler_t handler;
 
-	/* Nothing to do. */
-	excpnum = exception_get_num(excp);
-	handler = exceptions[excpnum].handler;
+	/* Set exception execution mode. */
+	modenum = core_status_set_mode(CORE_STATUS_MODE_EXCEPTION);
 
-	handler(excp, ctx);
+		/* Nothing to do. */
+		excpnum = exception_get_num(excp);
+		handler = exceptions[excpnum].handler;
+
+		/* Call handler. */
+		handler(excp, ctx);
+
+	/* Reset exception execution mode. */
+	core_status_set_mode(modenum);
 }
 
 /*===========================================================================*

--- a/src/hal/core/status.c
+++ b/src/hal/core/status.c
@@ -22,59 +22,51 @@
  * SOFTWARE.
  */
 
-#ifndef __unix64__
-
 /* Must come first. */
-#define __NEED_HAL_CORE
+#define __NEED_HAL_CLUSTER
 
-#include <nanvix/hal/core.h>
+#include <nanvix/hal/cluster.h>
 #include <nanvix/const.h>
 #include <nanvix/hlib.h>
 
+/**
+ * @brief Status per core.
+ *
+ * @see include/hal/core/status.h
+ */
+PRIVATE struct core_status cores_status[CORES_NUM];
+
 /*============================================================================*
- * core_halt()                                                                *
+ * core_status_set_mode()                                                     *
  *============================================================================*/
 
 /**
- * The core_halt() function halt the underlying core.
- * After halting a core, instruction execution cannot be
- * resumed on it.
- *
- * @author João Vicente Souto
+ * @brief Set execution mode.
  */
-PUBLIC NORETURN void core_halt(void)
+PUBLIC int core_status_set_mode(int mode)
 {
-	kprintf("[hal][core] halting...");
+	int coreid;
+	int oldmode;
 
-	/* Disable all interrupts. */
-	interrupts_disable();
+	/* Valid mode. */
+	KASSERT(WITHIN(mode, CORE_STATUS_MODE_NORMAL, CORE_STATUS_MODE_LIMIT));
 
-	/* Stay here forever. */
-	UNREACHABLE();
+	coreid = core_get_id();
+
+	oldmode = cores_status[coreid].mode;
+	cores_status[coreid].mode = mode;
+
+	return (oldmode);
 }
 
 /*============================================================================*
- * core_setup()                                                               *
+ * core_status_get_mode()                                                     *
  *============================================================================*/
 
 /**
- * The core_setup() function initializes all architectural structures
- * of the underlying core. It initializes the Memory Management Unit
- * (MMU), Interrupt Vector Table (IVT) as well as performance
- * monitoring registers.
- *
- * @author Pedro Henrique Penna
+ * @brief Get execution mode.
  */
-PUBLIC void core_setup(void *stack)
+PUBLIC int core_status_get_mode(void)
 {
-	kprintf("[hal][core] booting up core...");
-
-	core_status_set_mode(CORE_STATUS_MODE_INTERRUPT);
-	mmu_setup();
-	perf_setup();
-	ivt_setup(stack);
+	return (cores_status[core_get_id()].mode);
 }
-
-#else
-typedef int make_iso_compilers_happy;
-#endif

--- a/src/hal/core/trap.c
+++ b/src/hal/core/trap.c
@@ -22,26 +22,40 @@
  * SOFTWARE.
  */
 
-#include <nanvix/hal/core/trap.h>
+/* Must come first. */
+#define __NEED_HAL_CORE
+
+#include <nanvix/hal/core.h>
+#include <nanvix/const.h>
+#include <nanvix/hlib.h>
+
+/*===========================================================================*
+ * __do_kcall()                                                              *
+ *===========================================================================*/
 
 /**
- * @todo TODO: provide a defailed description for this function.
+ * @brief Generic exception handler.
  */
-PUBLIC linux64_word_t linux64_core_do_kcall(
+PUBLIC int __do_kcall(
 	word_t arg0,
 	word_t arg1,
 	word_t arg2,
 	word_t arg3,
 	word_t arg4,
-	word_t kcall_nr)
+	word_t kcall_nr
+)
 {
-	return (__do_kcall(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-			arg4,
-			kcall_nr
-		)
-	);
+	int ret;
+	int modenum;
+
+	/* Set trap execution mode. */
+	modenum = core_status_set_mode(CORE_STATUS_MODE_TRAP);
+
+		/* Call kernel call. */
+		ret = do_kcall(arg0, arg1, arg2, arg3, arg4, kcall_nr);
+
+	/* Reset trap execution mode. */
+	core_status_set_mode(modenum);
+
+	return (ret);
 }


### PR DESCRIPTION
In this PR, I introduce a managed software structure to track the mode in which the nuclei are running. This feature was introduced because the Section_Guard abstraction in the MPPA masked the interruptions even are inside an interrupt handler. That is, the interrupt control is different from the level of interruptions in the MPPA so required this structure to abstract how we check in which way we are.