### PR TITLE
[target][mppa256] Bugfix: Setting values on the incorrect array on mailbox_open

### DIFF
--- a/src/hal/arch/target/mppa256/mailbox.c
+++ b/src/hal/arch/target/mppa256/mailbox.c
@@ -520,7 +520,7 @@ PRIVATE int do_mppa256_mailbox_open(int nodenum)
 	}
 
 	/* Configures associated resource. */
-	mbxtab.rxs[mbxid].ret             = (-EAGAIN);
+	mbxtab.txs[mbxid].ret             = (-EAGAIN);
 	mbxtab.txs[mbxid].commit          = 0;
 	mbxtab.txs[mbxid].ack             = 1;
 	mbxtab.txs[mbxid].source_ctag     = ctag;


### PR DESCRIPTION
We are setting value on RX's array instead of TX's on mailbox_open of the MPPA-256.