### PR TITLE
[rv32gc] backporting gcc from 1.10 to 1.9.1 to support pulp sdk

### DIFF
--- a/include/arch/core/rv32gc/mregs.h
+++ b/include/arch/core/rv32gc/mregs.h
@@ -186,7 +186,7 @@
 		__extension__({             \
 		 rv32gc_word_t __tmp;        \
 		  __asm__ __volatile__ (    \
-			"csrr %0, " #regname    \
+			"csrrs %0, " #regname ", x0"\
 			: "=r"(__tmp));         \
 		    __tmp;                  \
 		})
@@ -237,7 +237,7 @@
 		rv32gc_word_t misa;
 
 		__asm__ __volatile__(
-			"csrr %0, misa"
+			"csrrs %0, misa, x0"
 			: "=r" (misa)
 		);
 
@@ -254,7 +254,7 @@
 		rv32gc_word_t mhartid;
 
 		__asm__ __volatile__(
-			"csrr %0, mhartid"
+			"csrrs %0, mhartid, x0"
 			: "=r" (mhartid)
 		);
 
@@ -271,7 +271,7 @@
 		rv32gc_word_t mstatus;
 
 		__asm__ __volatile__(
-			"csrr %0, mstatus"
+			"csrrs %0, mstatus, x0"
 			: "=r" (mstatus)
 		);
 
@@ -286,7 +286,7 @@
 	static inline void rv32gc_mstatus_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw mstatus, %0;"
+			"csrrw x0, mstatus, %0;"
 			:
 			: "r" (val)
 		);
@@ -302,7 +302,7 @@
 		rv32gc_word_t mie;
 
 		__asm__ __volatile__(
-			"csrr %0, mie"
+			"csrrs %0, mie, x0"
 			: "=r" (mie)
 		);
 
@@ -317,7 +317,7 @@
 	static inline void rv32gc_mie_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw mie, %0;"
+			"csrrw x0, mie, %0;"
 			:
 			: "r" (val)
 		);
@@ -333,7 +333,7 @@
 		rv32gc_word_t mip;
 
 		__asm__ __volatile__(
-			"csrr %0, mip"
+			"csrrs %0, mip, x0"
 			: "=r" (mip)
 		);
 
@@ -348,7 +348,7 @@
 	static inline void rv32gc_mip_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw mip, %0;"
+			"csrrw x0, mip, %0"
 			:
 			: "r" (val)
 		);
@@ -364,7 +364,7 @@
 		rv32gc_word_t mideleg;
 
 		__asm__ __volatile__(
-			"csrr %0, mideleg"
+			"csrrs %0, mideleg, x0"
 			: "=r" (mideleg)
 		);
 
@@ -379,7 +379,7 @@
 	static inline void rv32gc_mideleg_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw mideleg, %0;"
+			"csrrw x0, mideleg, %0"
 			:
 			: "r" (val)
 		);
@@ -395,7 +395,7 @@
 		rv32gc_word_t mtvec;
 
 		__asm__ __volatile__(
-			"csrr %0, mtvec"
+			"csrrs %0, mtvec, x0"
 			: "=r" (mtvec)
 		);
 
@@ -410,7 +410,7 @@
 	static inline void rv32gc_mtvec_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw mtvec, %0;"
+			"csrrw x0, mtvec, %0"
 			:
 			: "r" (val)
 		);
@@ -426,7 +426,7 @@
 		rv32gc_word_t mepc;
 
 		__asm__ __volatile__(
-			"csrr %0, mepc"
+			"csrrs %0, mepc, x0"
 			: "=r" (mepc)
 		);
 
@@ -441,7 +441,7 @@
 	static inline void rv32gc_mepc_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw mepc, %0;"
+			"csrrw x0, mepc, %0"
 			:
 			: "r" (val)
 		);
@@ -457,7 +457,7 @@
 		rv32gc_word_t mcause;
 
 		__asm__ __volatile__(
-			"csrr %0, mcause"
+			"csrrs %0, mcause, x0"
 			: "=r" (mcause)
 		);
 
@@ -474,7 +474,7 @@
 		rv32gc_word_t mtval;
 
 		__asm__ __volatile__(
-			"csrr %0, mtval"
+			"csrrs %0, mbadaddr, x0"
 			: "=r" (mtval)
 		);
 
@@ -491,7 +491,7 @@
 		rv32gc_word_t medeleg;
 
 		__asm__ __volatile__(
-			"csrr %0, medeleg"
+			"csrrs %0, medeleg, x0"
 			: "=r" (medeleg)
 		);
 
@@ -506,7 +506,7 @@
 	static inline void rv32gc_medeleg_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw medeleg, %0;"
+			"csrrw x0, medeleg, %0"
 			:
 			: "r" (val)
 		);

--- a/include/arch/core/rv32gc/sregs.h
+++ b/include/arch/core/rv32gc/sregs.h
@@ -162,7 +162,7 @@
 		rv32gc_word_t sstatus;
 
 		__asm__ __volatile__(
-			"csrr %0, sstatus"
+			"csrrs %0, sstatus, x0"
 			: "=r" (sstatus)
 		);
 
@@ -177,7 +177,7 @@
 	static inline void rv32gc_sstatus_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw sstatus, %0;"
+			"csrrw x0, sstatus, %0"
 			:
 			: "r" (val)
 		);
@@ -193,7 +193,7 @@
 		rv32gc_word_t sie;
 
 		__asm__ __volatile__(
-			"csrr %0, sie"
+			"csrrs %0, sie, x0"
 			: "=r" (sie)
 		);
 
@@ -208,7 +208,7 @@
 	static inline void rv32gc_sie_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw sie, %0;"
+			"csrrw x0, sie, %0"
 			:
 			: "r" (val)
 		);
@@ -224,7 +224,7 @@
 		rv32gc_word_t sip;
 
 		__asm__ __volatile__(
-			"csrr %0, sip"
+			"csrrs %0, sip, x0"
 			: "=r" (sip)
 		);
 
@@ -239,7 +239,7 @@
 	static inline void rv32gc_sip_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw sip, %0;"
+			"csrrw x0, sip, %0"
 			:
 			: "r" (val)
 		);
@@ -255,7 +255,7 @@
 		rv32gc_word_t stvec;
 
 		__asm__ __volatile__(
-			"csrr %0, stvec"
+			"csrrs %0, stvec, x0"
 			: "=r" (stvec)
 		);
 
@@ -270,7 +270,7 @@
 	static inline void rv32gc_stvec_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw stvec, %0"
+			"csrrw x0, stvec, %0"
 			:
 			: "r" (val)
 		);
@@ -286,7 +286,7 @@
 		rv32gc_word_t sepc;
 
 		__asm__ __volatile__(
-			"csrr %0, sepc"
+			"csrrs %0, sepc, x0"
 			: "=r" (sepc)
 		);
 
@@ -301,7 +301,7 @@
 	static inline void rv32gc_sepc_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw sepc, %0;"
+			"csrrw x0, sepc, %0"
 			:
 			: "r" (val)
 		);
@@ -317,7 +317,7 @@
 		rv32gc_word_t scause;
 
 		__asm__ __volatile__(
-			"csrr %0, scause"
+			"csrrs %0, scause, x0"
 			: "=r" (scause)
 		);
 
@@ -334,7 +334,7 @@
 		rv32gc_word_t stval;
 
 		__asm__ __volatile__(
-			"csrr %0, stval"
+			"csrrs %0, sbadaddr, x0"
 			: "=r" (stval)
 		);
 
@@ -351,7 +351,7 @@
 		rv32gc_word_t satp;
 
 		__asm__ __volatile__(
-			"csrr %0, satp"
+			"csrrs %0, sptbr, x0"
 			: "=r" (satp)
 		);
 
@@ -366,7 +366,7 @@
 	static inline void rv32gc_satp_write(rv32gc_word_t val)
 	{
 		__asm__ __volatile__(
-			"csrw satp, %0;"
+			"csrrw x0, sptbr, %0"
 			:
 			: "r" (val)
 		);

--- a/src/hal/arch/core/rv32gc/hooks.S
+++ b/src/hal/arch/core/rv32gc/hooks.S
@@ -67,10 +67,10 @@ rv32gc_do_strap:
 	 * Get reference to
 	 * context structure.
 	 */
-	csrr s1, sscratch
+	csrrs s1, sscratch, x0
 
 	/* Parse trap. */
-	csrr  s2, scause
+	csrrs  s2, scause, x0
 	li    t0, RV32GC_SCAUSE_INT
 	and   t0, s2, t0
 	bnez  t0, rv32gc_do_strap.sint
@@ -94,9 +94,9 @@ rv32gc_do_strap:
 		 */
 		andi  t0, s2, RV32GC_SCAUSE_CAUSE
 		sw    t0, RV32GC_EXCP_NR(sp)
-		csrr  t0, stval
+		csrrs t0, sbadaddr, x0
 		sw    t0, RV32GC_EXCP_ADDR(sp)
-		csrr  t0, sepc
+		csrrs t0, sepc, x0
 		sw    t0, RV32GC_EXCP_INSTR(sp)
 
 		/*
@@ -166,7 +166,7 @@ rv32gc_do_strap:
 	rv32gc_do_strap.ret:
 
 		/* Retore all registers. */
-		csrr sp, sscratch
+		csrrs sp, sscratch, x0
 		rv32gc_context_restore
 
 		/* Return from event. */


### PR DESCRIPTION
I backported all instructions from gcc 1.10 to 1.9.1. That way it's possible to compile and run using the pulp sdk.